### PR TITLE
Fix account add reliability (cargo bootstrap, OAuth port/cancel handling, Import button state)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "sh ./scripts/tauri.sh"
   },
   "dependencies": {
     "@tauri-apps/api": "^2",

--- a/scripts/tauri.sh
+++ b/scripts/tauri.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+if ! command -v cargo >/dev/null 2>&1; then
+  if [ -f "$HOME/.cargo/env" ]; then
+    # rustup adds PATH updates here for POSIX shells.
+    . "$HOME/.cargo/env"
+  fi
+fi
+
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "Error: cargo not found. Install Rust via rustup: https://rustup.rs" >&2
+  exit 1
+fi
+
+exec tauri "$@"

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -27,6 +27,7 @@ export function AddAccountModal({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
+  const isPrimaryDisabled = loading || (activeTab === "oauth" && oauthPending);
 
   const resetForm = () => {
     setName("");
@@ -134,6 +135,13 @@ export function AddAccountModal({
             <button
               key={tab}
               onClick={() => {
+                if (tab === "import" && oauthPending) {
+                  void onCancelOAuth().catch((err) => {
+                    console.error("Failed to cancel login:", err);
+                  });
+                  setOauthPending(false);
+                  setLoading(false);
+                }
                 setActiveTab(tab);
                 setError(null);
               }}
@@ -224,7 +232,7 @@ export function AddAccountModal({
           </button>
           <button
             onClick={activeTab === "oauth" ? handleOAuthLogin : handleImportFile}
-            disabled={loading || oauthPending}
+            disabled={isPrimaryDisabled}
             className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 text-white transition-colors disabled:opacity-50"
           >
             {loading


### PR DESCRIPTION
## Summary
This PR fixes multiple issues in the account add flow and local dev startup.

## What was broken
1. `pnpm tauri dev` could fail with:
   `failed to run 'cargo metadata' ... No such file or directory (os error 2)`
   when `cargo` was not available in PATH.
2. OAuth login could fail with:
   `Failed to start OAuth server: Address already in use (os error 48)`
   due to fixed callback port conflicts and pending/canceled flows not being fully released.
3. In the Add Account modal, the **Import** button could remain disabled because OAuth pending state leaked into Import tab behavior.

## Changes
- Added a Tauri wrapper script that sources Rust env if needed:
  - `scripts/tauri.sh`
  - `package.json` script `tauri` now runs `sh ./scripts/tauri.sh`
- Hardened OAuth server startup:
  - Try default callback port `1455` first
  - Fallback to an ephemeral free port if `1455` is busy
- Added explicit cancellation signaling for OAuth server flow:
  - Track a cancel flag for pending OAuth
  - Cancel previous pending flow before starting a new one
  - `cancel_login` now actively signals cancellation
- Fixed Import button disabling logic in modal:
  - `oauthPending` only disables primary action in OAuth tab
  - Switching from OAuth tab to Import tab cancels pending OAuth and unblocks Import action

## Validation
- `pnpm exec tsc --noEmit`
- `cargo check`
- Manual checks:
  - Repeated OAuth start/cancel/restart no longer fails with address-in-use
  - Import tab action remains enabled when valid name/file are provided

## Notes
- No API contract change for frontend usage of OAuth URL/callback info.
- Behavior is now more resilient when multiple login attempts happen in sequence.
