### PR TITLE
Refine renaming codex account after switching selected account

### DIFF
--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -149,7 +149,11 @@ export function AccountCard({
             ) : (
               <h3
                 className="font-semibold text-gray-900 truncate cursor-pointer hover:text-gray-600"
-                onClick={() => !masked && setIsEditing(true)}
+                onClick={() => {
+                  if (masked) return;
+                  setEditName(account.name);
+                  setIsEditing(true);
+                }}
                 title={masked ? undefined : "Click to rename"}
               >
                 <BlurredText blur={masked}>{account.name}</BlurredText>


### PR DESCRIPTION
Have the name of the account in sync after switching to different codex account and trying to rename the selected account.

Right now, if you have a Codex account active then try to switch to different account and try renaming the new active account, the name of previous active name shows up.