### PR TITLE
Add browser dashboard runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ pnpm tauri build
 
 The built application will be in `src-tauri/target/release/bundle/`.
 
+### Run the Dashboard in a Browser
+
+You can also serve the built dashboard over HTTP instead of opening the Tauri shell.
+
+```bash
+# Build the frontend and start the web server on 0.0.0.0:3210
+pnpm lan
+```
+
+Optional environment variables:
+
+- `CODEX_SWITCHER_WEB_HOST` to override the bind host
+- `CODEX_SWITCHER_WEB_PORT` to override the port
+
+The browser dashboard serves the same UI and backend actions through `/api/invoke/*`, which makes it usable over LAN, Tailscale, or a remote host tunnel when you expose the chosen port safely.
+
 ## Disclaimer
 
 This tool is designed **exclusively for individuals who personally own multiple OpenAI/ChatGPT accounts**. It is intended to help users manage their own accounts more conveniently.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "sh ./scripts/tauri.sh"
+    "tauri": "sh ./scripts/tauri.sh",
+    "lan": "pnpm build && cargo run --manifest-path src-tauri/Cargo.toml --bin codex-web"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.10.0",

--- a/src-tauri/src/auth/switcher.rs
+++ b/src-tauri/src/auth/switcher.rs
@@ -83,8 +83,17 @@ pub fn import_from_auth_json(path: &str, account_name: String) -> Result<StoredA
     let content =
         fs::read_to_string(path).with_context(|| format!("Failed to read auth.json: {path}"))?;
 
-    let auth: AuthDotJson = serde_json::from_str(&content)
-        .with_context(|| format!("Failed to parse auth.json: {path}"))?;
+    import_from_auth_json_contents(&content, account_name)
+        .with_context(|| format!("Failed to parse auth.json: {path}"))
+}
+
+/// Import an account from auth.json file contents.
+pub fn import_from_auth_json_contents(
+    content: &str,
+    account_name: String,
+) -> Result<StoredAccount> {
+    let auth: AuthDotJson =
+        serde_json::from_str(&content).context("Failed to parse auth.json contents")?;
 
     // Determine auth mode and create account
     if let Some(api_key) = auth.openai_api_key {

--- a/src-tauri/src/bin/codex-web.rs
+++ b/src-tauri/src/bin/codex-web.rs
@@ -1,0 +1,16 @@
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("{error:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> anyhow::Result<()> {
+    let host = std::env::var("CODEX_SWITCHER_WEB_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    let port = std::env::var("CODEX_SWITCHER_WEB_PORT")
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(3210);
+
+    codex_switcher_lib::web::run_lan_server(&host, port)
+}

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -2,8 +2,8 @@
 
 use crate::auth::{
     add_account, create_chatgpt_account_from_refresh_token, get_active_account,
-    import_from_auth_json, load_accounts, remove_account, save_accounts, set_active_account,
-    switch_to_account, touch_account,
+    import_from_auth_json, import_from_auth_json_contents, load_accounts, remove_account,
+    save_accounts, set_active_account, switch_to_account, touch_account,
 };
 use crate::types::{AccountInfo, AccountsStore, AuthData, ImportAccountsSummary, StoredAccount};
 
@@ -101,6 +101,20 @@ pub async fn add_account_from_file(path: String, name: String) -> Result<Account
     let account = import_from_auth_json(&path, name).map_err(|e| e.to_string())?;
 
     // Add to storage
+    let stored = add_account(account).map_err(|e| e.to_string())?;
+
+    let store = load_accounts().map_err(|e| e.to_string())?;
+    let active_id = store.active_account_id.as_deref();
+
+    Ok(AccountInfo::from_stored(&stored, active_id))
+}
+
+/// Add an account from uploaded auth.json contents.
+pub async fn add_account_from_auth_json_text(
+    name: String,
+    contents: String,
+) -> Result<AccountInfo, String> {
+    let account = import_from_auth_json_contents(&contents, name).map_err(|e| e.to_string())?;
     let stored = add_account(account).map_err(|e| e.to_string())?;
 
     let store = load_accounts().map_err(|e| e.to_string())?;
@@ -213,6 +227,12 @@ pub async fn export_accounts_full_encrypted_file(path: String) -> Result<(), Str
     Ok(())
 }
 
+/// Export full account config as encrypted bytes for browser clients.
+pub async fn export_accounts_full_encrypted_bytes() -> Result<Vec<u8>, String> {
+    let store = load_accounts().map_err(|e| e.to_string())?;
+    encode_full_encrypted_store(&store, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())
+}
+
 /// Import full account config from an encrypted file, skipping existing accounts.
 #[tauri::command]
 pub async fn import_accounts_full_encrypted_file(
@@ -221,6 +241,20 @@ pub async fn import_accounts_full_encrypted_file(
     let encrypted = read_encrypted_file(&path).map_err(|e| e.to_string())?;
     let imported = decode_full_encrypted_store(&encrypted, FULL_PRESET_PASSPHRASE)
         .map_err(|e| e.to_string())?;
+    validate_imported_store(&imported).map_err(|e| e.to_string())?;
+
+    let current = load_accounts().map_err(|e| e.to_string())?;
+    let (merged, summary) = merge_accounts_store(current, imported);
+    save_accounts(&merged).map_err(|e| e.to_string())?;
+    Ok(summary)
+}
+
+/// Import full account config from encrypted bytes uploaded through the browser UI.
+pub async fn import_accounts_full_encrypted_bytes(
+    bytes: Vec<u8>,
+) -> Result<ImportAccountsSummary, String> {
+    let imported =
+        decode_full_encrypted_store(&bytes, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())?;
     validate_imported_store(&imported).map_err(|e| e.to_string())?;
 
     let current = load_accounts().map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod api;
 pub mod auth;
 pub mod commands;
 pub mod types;
+pub mod web;
 
 use commands::{
     add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -1,0 +1,319 @@
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::Context;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+use tokio::runtime::Runtime;
+
+use crate::commands::{
+    add_account_from_auth_json_text, add_account_from_file, cancel_login, check_codex_processes,
+    complete_login, delete_account, export_accounts_full_encrypted_bytes,
+    export_accounts_slim_text, get_active_account_info, get_masked_account_ids, get_usage,
+    import_accounts_full_encrypted_bytes, import_accounts_slim_text, list_accounts,
+    refresh_all_accounts_usage, rename_account, set_masked_account_ids, start_login,
+    switch_account, warmup_account, warmup_all_accounts,
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AccountIdArgs {
+    #[serde(alias = "account_id")]
+    account_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RenameAccountArgs {
+    #[serde(alias = "account_id")]
+    account_id: String,
+    #[serde(alias = "new_name")]
+    new_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LoginArgs {
+    #[serde(alias = "account_name")]
+    account_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ImportSlimArgs {
+    payload: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MaskedIdsArgs {
+    ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadAuthJsonArgs {
+    name: String,
+    contents: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UploadEncryptedArgs {
+    #[serde(alias = "contents_base64")]
+    contents_base64: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct FileImportArgs {
+    path: String,
+    name: String,
+}
+
+pub fn run_lan_server(host: &str, port: u16) -> anyhow::Result<()> {
+    let address = format!("{host}:{port}");
+    let server = Server::http(&address)
+        .map_err(|err| anyhow::anyhow!("Failed to bind HTTP server on {address}: {err}"))?;
+    let runtime = Runtime::new().context("Failed to start async runtime")?;
+    let dist_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("dist");
+
+    println!("Codex Switcher web server listening on http://{address}");
+    println!("Serving static files from {}", dist_dir.display());
+
+    for request in server.incoming_requests() {
+        if let Err(error) = handle_request(request, &runtime, &dist_dir) {
+            eprintln!("[web] request failed: {error:#}");
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_request(mut request: Request, runtime: &Runtime, dist_dir: &Path) -> anyhow::Result<()> {
+    let method = request.method().clone();
+    let url = request.url().to_string();
+
+    if method == Method::Get && url == "/api/health" {
+        respond_json(request, StatusCode(200), &json!({ "ok": true }))?;
+        return Ok(());
+    }
+
+    if method == Method::Post && url.starts_with("/api/invoke/") {
+        let command = url.trim_start_matches("/api/invoke/");
+        let payload = parse_request_json(&mut request)?;
+        let result = runtime.block_on(invoke_web_command(command, payload));
+        match result {
+            Ok(value) => respond_json(request, StatusCode(200), &value)?,
+            Err(error) => respond_json(request, StatusCode(400), &json!({ "error": error }))?,
+        }
+        return Ok(());
+    }
+
+    if method == Method::Get {
+        serve_static(request, dist_dir, &url)?;
+        return Ok(());
+    }
+
+    respond_text(
+        request,
+        StatusCode(405),
+        "Method Not Allowed",
+        "text/plain; charset=utf-8",
+    )?;
+    Ok(())
+}
+
+async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, String> {
+    match command {
+        "list_accounts" => to_json(list_accounts().await?),
+        "get_active_account_info" => to_json(get_active_account_info().await?),
+        "add_account_from_file" => {
+            let args: FileImportArgs = parse_args(payload)?;
+            to_json(add_account_from_file(args.path, args.name).await?)
+        }
+        "add_account_from_auth_json_text" => {
+            let args: UploadAuthJsonArgs = parse_args(payload)?;
+            to_json(add_account_from_auth_json_text(args.name, args.contents).await?)
+        }
+        "get_usage" => {
+            let args: AccountIdArgs = parse_args(payload)?;
+            to_json(get_usage(args.account_id).await?)
+        }
+        "refresh_all_accounts_usage" => to_json(refresh_all_accounts_usage().await?),
+        "warmup_account" => {
+            let args: AccountIdArgs = parse_args(payload)?;
+            to_json(warmup_account(args.account_id).await?)
+        }
+        "warmup_all_accounts" => to_json(warmup_all_accounts().await?),
+        "switch_account" => {
+            let args: AccountIdArgs = parse_args(payload)?;
+            to_json(switch_account(args.account_id).await?)
+        }
+        "delete_account" => {
+            let args: AccountIdArgs = parse_args(payload)?;
+            to_json(delete_account(args.account_id).await?)
+        }
+        "rename_account" => {
+            let args: RenameAccountArgs = parse_args(payload)?;
+            to_json(rename_account(args.account_id, args.new_name).await?)
+        }
+        "start_login" => {
+            let args: LoginArgs = parse_args(payload)?;
+            to_json(start_login(args.account_name).await?)
+        }
+        "complete_login" => to_json(complete_login().await?),
+        "cancel_login" => to_json(cancel_login().await?),
+        "export_accounts_slim_text" => to_json(export_accounts_slim_text().await?),
+        "import_accounts_slim_text" => {
+            let args: ImportSlimArgs = parse_args(payload)?;
+            to_json(import_accounts_slim_text(args.payload).await?)
+        }
+        "export_accounts_full_encrypted_bytes" => {
+            let encoded = STANDARD.encode(export_accounts_full_encrypted_bytes().await?);
+            to_json(encoded)
+        }
+        "import_accounts_full_encrypted_bytes" => {
+            let args: UploadEncryptedArgs = parse_args(payload)?;
+            let bytes = STANDARD
+                .decode(args.contents_base64)
+                .map_err(|error| format!("Failed to decode uploaded backup: {error}"))?;
+            to_json(import_accounts_full_encrypted_bytes(bytes).await?)
+        }
+        "get_masked_account_ids" => to_json(get_masked_account_ids().await?),
+        "set_masked_account_ids" => {
+            let args: MaskedIdsArgs = parse_args(payload)?;
+            to_json(set_masked_account_ids(args.ids).await?)
+        }
+        "check_codex_processes" => to_json(check_codex_processes().await?),
+        _ => Err(format!("Unsupported web command: {command}")),
+    }
+}
+
+fn parse_request_json(request: &mut Request) -> anyhow::Result<Value> {
+    let mut body = String::new();
+    request
+        .as_reader()
+        .read_to_string(&mut body)
+        .context("Failed to read request body")?;
+
+    if body.trim().is_empty() {
+        return Ok(json!({}));
+    }
+
+    serde_json::from_str(&body).context("Failed to parse request JSON")
+}
+
+fn parse_args<T>(value: Value) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    serde_json::from_value(value).map_err(|error| format!("Invalid command payload: {error}"))
+}
+
+fn to_json<T>(value: T) -> Result<Value, String>
+where
+    T: serde::Serialize,
+{
+    serde_json::to_value(value).map_err(|error| format!("Failed to serialize response: {error}"))
+}
+
+fn serve_static(request: Request, dist_dir: &Path, url: &str) -> anyhow::Result<()> {
+    let requested = if url == "/" {
+        PathBuf::from("index.html")
+    } else {
+        sanitize_path(url)?
+    };
+    let candidate = dist_dir.join(&requested);
+
+    if candidate.is_file() {
+        return serve_file(request, candidate);
+    }
+
+    if requested.extension().is_some() {
+        respond_text(
+            request,
+            StatusCode(404),
+            "Not Found",
+            "text/plain; charset=utf-8",
+        )?;
+        return Ok(());
+    }
+
+    serve_file(request, dist_dir.join("index.html"))
+}
+
+fn sanitize_path(url: &str) -> anyhow::Result<PathBuf> {
+    let path = url.split('?').next().unwrap_or("/");
+    let raw = path.trim_start_matches('/');
+    let candidate = Path::new(raw);
+
+    for component in candidate.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => anyhow::bail!("Invalid request path"),
+        }
+    }
+
+    Ok(candidate.to_path_buf())
+}
+
+fn serve_file(request: Request, path: PathBuf) -> anyhow::Result<()> {
+    let data = fs::read(&path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let mime = mime_type_for_path(&path);
+    let response = Response::from_data(data)
+        .with_header(header("Content-Type", mime)?)
+        .with_header(header("Cache-Control", "no-cache")?);
+    request.respond(response)?;
+    Ok(())
+}
+
+fn respond_json(request: Request, status: StatusCode, payload: &Value) -> anyhow::Result<()> {
+    let response = Response::from_string(serde_json::to_string(payload)?)
+        .with_status_code(status)
+        .with_header(header("Content-Type", "application/json; charset=utf-8")?);
+    request.respond(response)?;
+    Ok(())
+}
+
+fn respond_text(
+    request: Request,
+    status: StatusCode,
+    body: &str,
+    content_type: &str,
+) -> anyhow::Result<()> {
+    let response = Response::from_string(body.to_string())
+        .with_status_code(status)
+        .with_header(header("Content-Type", content_type)?);
+    request.respond(response)?;
+    Ok(())
+}
+
+fn header(name: &str, value: &str) -> anyhow::Result<Header> {
+    Header::from_bytes(name.as_bytes(), value.as_bytes()).map_err(|_| {
+        anyhow::anyhow!("Failed to create header {name}: invalid header value `{value}`")
+    })
+}
+
+fn mime_type_for_path(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "css" => "text/css; charset=utf-8",
+        "html" => "text/html; charset=utf-8",
+        "ico" => "image/x-icon",
+        "jpeg" | "jpg" => "image/jpeg",
+        "js" => "text/javascript; charset=utf-8",
+        "json" => "application/json; charset=utf-8",
+        "png" => "image/png",
+        "svg" => "image/svg+xml",
+        "txt" => "text/plain; charset=utf-8",
+        "webp" => "image/webp",
+        _ => "application/octet-stream",
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { invoke } from "@tauri-apps/api/core";
-import { open, save } from "@tauri-apps/plugin-dialog";
 import { useAccounts } from "./hooks/useAccounts";
 import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
 import type { CodexProcessInfo } from "./types";
+import {
+  exportFullBackupFile,
+  importFullBackupFile,
+  invokeBackend,
+} from "./lib/platform";
 import "./App.css";
 
 function App() {
@@ -11,6 +14,7 @@ function App() {
     accounts,
     loading,
     error,
+    loadAccounts,
     refreshUsage,
     refreshSingleUsage,
     warmupAccount,
@@ -21,8 +25,6 @@ function App() {
     importFromFile,
     exportAccountsSlimText,
     importAccountsSlimText,
-    exportAccountsFullEncryptedFile,
-    importAccountsFullEncryptedFile,
     startOAuthLogin,
     completeOAuthLogin,
     cancelOAuthLogin,
@@ -87,7 +89,7 @@ function App() {
 
   const checkProcesses = useCallback(async () => {
     try {
-      const info = await invoke<CodexProcessInfo>("check_codex_processes");
+      const info = await invokeBackend<CodexProcessInfo>("check_codex_processes");
       setProcessInfo(info);
     } catch (err) {
       console.error("Failed to check processes:", err);
@@ -287,20 +289,8 @@ function App() {
   const handleExportFullFile = async () => {
     try {
       setIsExportingFull(true);
-      const selected = await save({
-        title: "Export Full Encrypted Account Config",
-        defaultPath: "codex-switcher-full.cswf",
-        filters: [
-          {
-            name: "Codex Switcher Full Backup",
-            extensions: ["cswf"],
-          },
-        ],
-      });
-
-      if (!selected) return;
-
-      await exportAccountsFullEncryptedFile(selected);
+      const exported = await exportFullBackupFile();
+      if (!exported) return;
       showWarmupToast("Full encrypted file exported.");
     } catch (err) {
       console.error("Failed to export full encrypted file:", err);
@@ -313,21 +303,12 @@ function App() {
   const handleImportFullFile = async () => {
     try {
       setIsImportingFull(true);
-      const selected = await open({
-        multiple: false,
-        title: "Import Full Encrypted Account Config",
-        filters: [
-          {
-            name: "Codex Switcher Full Backup",
-            extensions: ["cswf"],
-          },
-        ],
-      });
-
-      if (!selected || Array.isArray(selected)) return;
-
-      const summary = await importAccountsFullEncryptedFile(selected);
-      setMaskedAccounts(new Set());
+      const summary = await importFullBackupFile();
+      if (!summary) return;
+      const accountList = await loadAccounts();
+      await refreshUsage(accountList);
+      const maskedIds = await loadMaskedAccountIds();
+      setMaskedAccounts(new Set(maskedIds));
       showWarmupToast(
         `Imported ${summary.imported_count}, skipped ${summary.skipped_count} (total ${summary.total_in_payload})`
       );

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -1,11 +1,16 @@
 import { useState } from "react";
-import { openUrl } from "@tauri-apps/plugin-opener";
-import { open } from "@tauri-apps/plugin-dialog";
+import {
+  describeFileSource,
+  isTauriRuntime,
+  openExternalUrl,
+  pickAuthJsonFile,
+  type FileSource,
+} from "../lib/platform";
 
 interface AddAccountModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onImportFile: (path: string, name: string) => Promise<void>;
+  onImportFile: (source: FileSource, name: string) => Promise<void>;
   onStartOAuth: (name: string) => Promise<{ auth_url: string }>;
   onCompleteOAuth: () => Promise<unknown>;
   onCancelOAuth: () => Promise<void>;
@@ -23,17 +28,18 @@ export function AddAccountModal({
 }: AddAccountModalProps) {
   const [activeTab, setActiveTab] = useState<Tab>("oauth");
   const [name, setName] = useState("");
-  const [filePath, setFilePath] = useState("");
+  const [fileSource, setFileSource] = useState<FileSource | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [oauthPending, setOauthPending] = useState(false);
   const [authUrl, setAuthUrl] = useState<string>("");
   const [copied, setCopied] = useState<boolean>(false);
   const isPrimaryDisabled = loading || (activeTab === "oauth" && oauthPending);
+  const tauriRuntime = isTauriRuntime();
 
   const resetForm = () => {
     setName("");
-    setFilePath("");
+    setFileSource(null);
     setError(null);
     setLoading(false);
     setOauthPending(false);
@@ -74,20 +80,8 @@ export function AddAccountModal({
 
   const handleSelectFile = async () => {
     try {
-      const selected = await open({
-        multiple: false,
-        filters: [
-          {
-            name: "JSON",
-            extensions: ["json"],
-          },
-        ],
-        title: "Select auth.json file",
-      });
-
-      if (selected) {
-        setFilePath(selected);
-      }
+      const selected = await pickAuthJsonFile();
+      if (selected) setFileSource(selected);
     } catch (err) {
       console.error("Failed to open file dialog:", err);
     }
@@ -98,7 +92,7 @@ export function AddAccountModal({
       setError("Please enter an account name");
       return;
     }
-    if (!filePath.trim()) {
+    if (!fileSource) {
       setError("Please select an auth.json file");
       return;
     }
@@ -106,7 +100,7 @@ export function AddAccountModal({
     try {
       setLoading(true);
       setError(null);
-      await onImportFile(filePath.trim(), name.trim());
+      await onImportFile(fileSource, name.trim());
       handleClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -191,9 +185,15 @@ export function AddAccountModal({
                     />
                     <button
                       onClick={() => {
-                        navigator.clipboard.writeText(authUrl);
-                        setCopied(true);
-                        setTimeout(() => setCopied(false), 2000);
+                        void navigator.clipboard
+                          .writeText(authUrl)
+                          .then(() => {
+                            setCopied(true);
+                            setTimeout(() => setCopied(false), 2000);
+                          })
+                          .catch(() => {
+                            setError("Clipboard unavailable. Copy the link manually.");
+                          });
                       }}
                       className={`px-3 py-1.5 border rounded text-xs font-medium transition-colors shrink-0 
                         ${copied
@@ -204,12 +204,20 @@ export function AddAccountModal({
                       {copied ? "Copied!" : "Copy"}
                     </button>
                     <button
-                      onClick={() => openUrl(authUrl)}
+                      onClick={() => {
+                        void openExternalUrl(authUrl);
+                      }}
                       className="px-3 py-1.5 bg-gray-900 border border-gray-900 rounded text-xs font-medium text-white hover:bg-gray-800 transition-colors shrink-0"
                     >
                       Open
                     </button>
                   </div>
+                  {!tauriRuntime && (
+                    <p className="text-xs text-amber-600">
+                      OAuth login must finish on the same host machine because the callback
+                      redirects to `localhost`.
+                    </p>
+                  )}
                 </div>
               ) : (
                 <p>
@@ -227,7 +235,7 @@ export function AddAccountModal({
               </label>
               <div className="flex gap-2">
                 <div className="flex-1 px-4 py-2.5 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-600 truncate">
-                  {filePath || "No file selected"}
+                  {describeFileSource(fileSource)}
                 </div>
                 <button
                   onClick={handleSelectFile}

--- a/src/components/UpdateChecker.tsx
+++ b/src/components/UpdateChecker.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
-import { check, type Update } from "@tauri-apps/plugin-updater";
-import { relaunch } from "@tauri-apps/plugin-process";
+import type { Update } from "@tauri-apps/plugin-updater";
+import { isTauriRuntime } from "../lib/platform";
 
 type UpdateStatus =
   | { kind: "idle" }
@@ -15,9 +15,12 @@ export function UpdateChecker() {
   const [dismissed, setDismissed] = useState(false);
 
   const checkForUpdate = useCallback(async () => {
+    if (!isTauriRuntime()) return;
+
     try {
       setStatus({ kind: "checking" });
       setDismissed(false);
+      const { check } = await import("@tauri-apps/plugin-updater");
       const update = await check();
       if (update) {
         setStatus({ kind: "available", update });
@@ -31,7 +34,8 @@ export function UpdateChecker() {
   }, []);
 
   useEffect(() => {
-    checkForUpdate();
+    if (!isTauriRuntime()) return;
+    void checkForUpdate();
   }, [checkForUpdate]);
 
   const handleDownloadAndInstall = async () => {
@@ -39,6 +43,7 @@ export function UpdateChecker() {
     const { update } = status;
 
     try {
+      if (!isTauriRuntime()) return;
       let downloaded = 0;
       let total: number | null = null;
 
@@ -68,11 +73,17 @@ export function UpdateChecker() {
 
   const handleRelaunch = async () => {
     try {
+      if (!isTauriRuntime()) return;
+      const { relaunch } = await import("@tauri-apps/plugin-process");
       await relaunch();
     } catch (err) {
       console.error("Relaunch failed:", err);
     }
   };
+
+  if (!isTauriRuntime()) {
+    return null;
+  }
 
   if (status.kind === "idle" || status.kind === "checking" || dismissed) {
     return null;

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import type {
   AccountInfo,
   UsageInfo,
@@ -7,6 +6,7 @@ import type {
   WarmupSummary,
   ImportAccountsSummary,
 } from "../types";
+import { invokeBackend, type FileSource } from "../lib/platform";
 
 export function useAccounts() {
   const [accounts, setAccounts] = useState<AccountWithUsage[]>([]);
@@ -62,7 +62,7 @@ export function useAccounts() {
     try {
       setLoading(true);
       setError(null);
-      const accountList = await invoke<AccountInfo[]>("list_accounts");
+      const accountList = await invokeBackend<AccountInfo[]>("list_accounts");
       
       if (preserveUsage) {
         // Preserve existing usage data when just updating account info
@@ -111,7 +111,7 @@ export function useAccounts() {
         accountIds,
         async (accountId) => {
           try {
-            const usage = await invoke<UsageInfo>("get_usage", { accountId });
+            const usage = await invokeBackend<UsageInfo>("get_usage", { accountId });
             setAccounts((prev) =>
               prev.map((account) =>
                 account.id === accountId
@@ -152,7 +152,7 @@ export function useAccounts() {
           a.id === accountId ? { ...a, usageLoading: true } : a
         )
       );
-      const usage = await invoke<UsageInfo>("get_usage", { accountId });
+      const usage = await invokeBackend<UsageInfo>("get_usage", { accountId });
       setAccounts((prev) =>
         prev.map((a) =>
           a.id === accountId ? { ...a, usage, usageLoading: false } : a
@@ -178,7 +178,7 @@ export function useAccounts() {
 
   const warmupAccount = useCallback(async (accountId: string) => {
     try {
-      await invoke("warmup_account", { accountId });
+      await invokeBackend("warmup_account", { accountId });
     } catch (err) {
       console.error("Failed to warm up account:", err);
       throw err;
@@ -187,7 +187,7 @@ export function useAccounts() {
 
   const warmupAllAccounts = useCallback(async () => {
     try {
-      return await invoke<WarmupSummary>("warmup_all_accounts");
+      return await invokeBackend<WarmupSummary>("warmup_all_accounts");
     } catch (err) {
       console.error("Failed to warm up all accounts:", err);
       throw err;
@@ -197,7 +197,7 @@ export function useAccounts() {
   const switchAccount = useCallback(
     async (accountId: string) => {
       try {
-        await invoke("switch_account", { accountId });
+        await invokeBackend("switch_account", { accountId });
         await loadAccounts(true); // Preserve usage data
       } catch (err) {
         throw err;
@@ -209,7 +209,7 @@ export function useAccounts() {
   const deleteAccount = useCallback(
     async (accountId: string) => {
       try {
-        await invoke("delete_account", { accountId });
+        await invokeBackend("delete_account", { accountId });
         await loadAccounts();
       } catch (err) {
         throw err;
@@ -221,7 +221,7 @@ export function useAccounts() {
   const renameAccount = useCallback(
     async (accountId: string, newName: string) => {
       try {
-        await invoke("rename_account", { accountId, newName });
+        await invokeBackend("rename_account", { accountId, newName });
         await loadAccounts(true); // Preserve usage data
       } catch (err) {
         throw err;
@@ -231,9 +231,17 @@ export function useAccounts() {
   );
 
   const importFromFile = useCallback(
-    async (path: string, name: string) => {
+    async (source: FileSource, name: string) => {
       try {
-        await invoke<AccountInfo>("add_account_from_file", { path, name });
+        if (typeof source === "string") {
+          await invokeBackend<AccountInfo>("add_account_from_file", { path: source, name });
+        } else {
+          const contents = await source.text();
+          await invokeBackend<AccountInfo>("add_account_from_auth_json_text", {
+            name,
+            contents,
+          });
+        }
         const accountList = await loadAccounts();
         await refreshUsage(accountList);
       } catch (err) {
@@ -245,7 +253,7 @@ export function useAccounts() {
 
   const startOAuthLogin = useCallback(async (accountName: string) => {
     try {
-      const info = await invoke<{ auth_url: string; callback_port: number }>(
+      const info = await invokeBackend<{ auth_url: string; callback_port: number }>(
         "start_login",
         { accountName }
       );
@@ -257,7 +265,7 @@ export function useAccounts() {
 
   const completeOAuthLogin = useCallback(async () => {
     try {
-      const account = await invoke<AccountInfo>("complete_login");
+      const account = await invokeBackend<AccountInfo>("complete_login");
       const accountList = await loadAccounts();
       await refreshUsage(accountList);
       return account;
@@ -268,7 +276,7 @@ export function useAccounts() {
 
   const exportAccountsSlimText = useCallback(async () => {
     try {
-      return await invoke<string>("export_accounts_slim_text");
+      return await invokeBackend<string>("export_accounts_slim_text");
     } catch (err) {
       throw err;
     }
@@ -277,7 +285,7 @@ export function useAccounts() {
   const importAccountsSlimText = useCallback(
     async (payload: string) => {
       try {
-        const summary = await invoke<ImportAccountsSummary>("import_accounts_slim_text", {
+        const summary = await invokeBackend<ImportAccountsSummary>("import_accounts_slim_text", {
           payload,
         });
         const accountList = await loadAccounts();
@@ -293,7 +301,7 @@ export function useAccounts() {
   const exportAccountsFullEncryptedFile = useCallback(
     async (path: string) => {
       try {
-        await invoke("export_accounts_full_encrypted_file", { path });
+        await invokeBackend("export_accounts_full_encrypted_file", { path });
       } catch (err) {
         throw err;
       }
@@ -304,7 +312,7 @@ export function useAccounts() {
   const importAccountsFullEncryptedFile = useCallback(
     async (path: string) => {
       try {
-        const summary = await invoke<ImportAccountsSummary>(
+        const summary = await invokeBackend<ImportAccountsSummary>(
           "import_accounts_full_encrypted_file",
           { path }
         );
@@ -320,7 +328,7 @@ export function useAccounts() {
 
   const cancelOAuthLogin = useCallback(async () => {
     try {
-      await invoke("cancel_login");
+      await invokeBackend("cancel_login");
     } catch (err) {
       console.error("Failed to cancel login:", err);
     }
@@ -328,7 +336,7 @@ export function useAccounts() {
 
   const loadMaskedAccountIds = useCallback(async () => {
     try {
-      return await invoke<string[]>("get_masked_account_ids");
+      return await invokeBackend<string[]>("get_masked_account_ids");
     } catch (err) {
       console.error("Failed to load masked account IDs:", err);
       return [];
@@ -337,7 +345,7 @@ export function useAccounts() {
 
   const saveMaskedAccountIds = useCallback(async (ids: string[]) => {
     try {
-      await invoke("set_masked_account_ids", { ids });
+      await invokeBackend("set_masked_account_ids", { ids });
     } catch (err) {
       console.error("Failed to save masked account IDs:", err);
     }

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -1,0 +1,195 @@
+import type { ImportAccountsSummary } from "../types";
+
+export type FileSource = string | File;
+
+export function isTauriRuntime(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+export async function invokeBackend<T>(
+  command: string,
+  args?: Record<string, unknown>
+): Promise<T> {
+  if (isTauriRuntime()) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return invoke<T>(command, args);
+  }
+
+  const response = await fetch(`/api/invoke/${command}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args ?? {}),
+  });
+
+  const payload = await readJsonResponse(response);
+  if (!response.ok) {
+    const message =
+      typeof payload?.error === "string"
+        ? payload.error
+        : `Request failed with status ${response.status}`;
+    throw new Error(message);
+  }
+
+  return payload as T;
+}
+
+export async function openExternalUrl(url: string): Promise<void> {
+  if (isTauriRuntime()) {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+    return;
+  }
+
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+export async function pickAuthJsonFile(): Promise<FileSource | null> {
+  if (isTauriRuntime()) {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const selected = await open({
+      multiple: false,
+      filters: [{ name: "JSON", extensions: ["json"] }],
+      title: "Select auth.json file",
+    });
+
+    if (!selected || Array.isArray(selected)) return null;
+    return selected;
+  }
+
+  return pickBrowserFile(".json,application/json");
+}
+
+export async function exportFullBackupFile(): Promise<boolean> {
+  if (isTauriRuntime()) {
+    const { save } = await import("@tauri-apps/plugin-dialog");
+    const selected = await save({
+      title: "Export Full Encrypted Account Config",
+      defaultPath: "codex-switcher-full.cswf",
+      filters: [{ name: "Codex Switcher Full Backup", extensions: ["cswf"] }],
+    });
+
+    if (!selected) return false;
+    await invokeBackend("export_accounts_full_encrypted_file", { path: selected });
+    return true;
+  }
+
+  const contentsBase64 = await invokeBackend<string>("export_accounts_full_encrypted_bytes");
+  downloadBase64File(
+    contentsBase64,
+    "codex-switcher-full.cswf",
+    "application/octet-stream"
+  );
+  return true;
+}
+
+export async function importFullBackupFile(): Promise<ImportAccountsSummary | null> {
+  if (isTauriRuntime()) {
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    const selected = await open({
+      multiple: false,
+      title: "Import Full Encrypted Account Config",
+      filters: [{ name: "Codex Switcher Full Backup", extensions: ["cswf"] }],
+    });
+
+    if (!selected || Array.isArray(selected)) return null;
+    return invokeBackend<ImportAccountsSummary>("import_accounts_full_encrypted_file", {
+      path: selected,
+    });
+  }
+
+  const selected = await pickBrowserFile(".cswf,application/octet-stream");
+  if (!selected) return null;
+
+  const contentsBase64 = await fileToBase64(selected);
+  return invokeBackend<ImportAccountsSummary>("import_accounts_full_encrypted_bytes", {
+    contentsBase64,
+  });
+}
+
+export function describeFileSource(source: FileSource | null): string {
+  if (!source) return "No file selected";
+  return typeof source === "string" ? source : source.name;
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  let binary = "";
+
+  for (let index = 0; index < bytes.length; index += 0x8000) {
+    const chunk = bytes.subarray(index, index + 0x8000);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  return window.btoa(binary);
+}
+
+function downloadBase64File(
+  base64: string,
+  fileName: string,
+  mimeType: string
+): void {
+  const binary = window.atob(base64);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  const blob = new Blob([bytes], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = fileName;
+  link.style.display = "none";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+async function pickBrowserFile(accept: string): Promise<File | null> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = accept;
+    input.style.display = "none";
+    let settled = false;
+
+    const finish = (file: File | null) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener("focus", handleWindowFocus);
+      input.remove();
+      resolve(file);
+    };
+
+    const handleWindowFocus = () => {
+      window.setTimeout(() => {
+        finish(input.files?.[0] ?? null);
+      }, 0);
+    };
+
+    input.addEventListener(
+      "change",
+      () => {
+        finish(input.files?.[0] ?? null);
+      },
+      { once: true }
+    );
+
+    document.body.appendChild(input);
+    window.addEventListener("focus", handleWindowFocus, { once: true });
+    input.click();
+  });
+}
+
+async function readJsonResponse(response: Response): Promise<any> {
+  const text = await response.text();
+  if (!text) return null;
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { error: text };
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds a browser-safe dashboard runtime so Codex Switcher can run outside the Tauri shell.

## What changed

- added a frontend platform bridge that uses Tauri APIs on desktop and `/api/invoke/*` HTTP endpoints in a browser
- added a `codex-web` binary plus a tiny HTTP server that serves the built dashboard and forwards the backend commands the existing UI uses
- updated auth import, encrypted backup import/export, updater, and process-check flows so they work without assuming native Tauri dialogs
- documented the browser launch flow and added a `pnpm lan` helper

## Why

The current app assumes Tauri-only APIs, which prevents opening the dashboard remotely in a normal browser even when the machine is reachable over LAN or a tunnel.

## Validation

- `pnpm build`
- `cargo build --manifest-path src-tauri/Cargo.toml --bin codex-web`
- opened `http://127.0.0.1:3320/` in a real browser and verified that the dashboard loads, usage refresh completes, and the browser console stays free of errors
