### PR TITLE
fix(process): ignore stale Codex helper trees on Windows

### DIFF
--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -1,6 +1,10 @@
 //! Process detection commands
 
+use anyhow::Context;
 use std::process::Command;
+
+#[cfg(windows)]
+use std::collections::HashSet;
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -8,16 +12,29 @@ use std::os::windows::process::CommandExt;
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
+#[cfg(windows)]
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct WindowsCodexProcess {
+    name: String,
+    process_id: u32,
+    parent_process_id: u32,
+    #[serde(default)]
+    command_line: String,
+    #[serde(default)]
+    main_window_title: String,
+}
+
 /// Information about running Codex processes
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CodexProcessInfo {
-    /// Number of running codex processes
+    /// Number of active Codex app instances
     pub count: usize,
-    /// Number of background IDE/extension codex processes (like Antigravity)
+    /// Number of ignored background/stale Codex-related processes
     pub background_count: usize,
-    /// Whether switching is allowed (no processes running)
+    /// Whether switching is allowed (no active Codex app instances)
     pub can_switch: bool,
-    /// Process IDs of running codex processes
+    /// Process IDs of active Codex app instances
     pub pids: Vec<u32>,
 }
 
@@ -37,12 +54,11 @@ pub async fn check_codex_processes() -> Result<CodexProcessInfo, String> {
 
 /// Find all running codex processes. Returns (active_pids, background_count)
 fn find_codex_processes() -> anyhow::Result<(Vec<u32>, usize)> {
-    let mut pids = Vec::new();
-    #[allow(unused_mut)]
-    let mut bg_count = 0;
-
     #[cfg(unix)]
     {
+        let mut pids = Vec::new();
+        let mut bg_count = 0;
+
         // Use ps with custom format to get the pid and full command line
         let output = Command::new("ps").args(["-eo", "pid,command"]).output();
 
@@ -67,9 +83,7 @@ fn find_codex_processes() -> anyhow::Result<(Vec<u32>, usize)> {
 
                     // Exclude if it's running from an extension or IDE integration (like Antigravity)
                     // These are expected background processes we shouldn't block on
-                    let is_ide_plugin = command.contains(".antigravity")
-                        || command.contains("openai.chatgpt")
-                        || command.contains(".vscode");
+                    let is_ide_plugin = is_ide_plugin_process(command);
 
                     // Skip our own app
                     let is_switcher =
@@ -89,39 +103,165 @@ fn find_codex_processes() -> anyhow::Result<(Vec<u32>, usize)> {
                 }
             }
         }
+
+        return Ok((pids, bg_count));
     }
 
     #[cfg(windows)]
     {
-        // Use tasklist on Windows - match exact "codex.exe"
-        let output = Command::new("tasklist")
-            // Prevent a console window from flashing when this command is invoked from the GUI app.
-            .creation_flags(CREATE_NO_WINDOW)
-            .args(["/FI", "IMAGENAME eq codex.exe", "/FO", "CSV", "/NH"])
-            .output();
+        return find_windows_codex_processes();
+    }
 
-        if let Ok(output) = output {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            for line in stdout.lines() {
-                // CSV format: "name","pid",...
-                let parts: Vec<&str> = line.split(',').collect();
-                if parts.len() > 1 {
-                    let name = parts[0].trim_matches('"').to_lowercase();
-                    // Only match exact "codex.exe", not "codex-switcher.exe"
-                    if name == "codex.exe" {
-                        let pid_str = parts[1].trim_matches('"');
-                        if let Ok(pid) = pid_str.parse::<u32>() {
-                            if pid != std::process::id() {
-                                // For Windows, we don't have an easy way to check if it's an IDE plugin
-                                // just from the tasklist output, so assume they're regular for now
-                                pids.push(pid);
-                            }
-                        }
-                    }
-                }
-            }
+    #[allow(unreachable_code)]
+    Ok((Vec::new(), 0))
+}
+
+#[cfg(windows)]
+fn find_windows_codex_processes() -> anyhow::Result<(Vec<u32>, usize)> {
+    // tasklist counts every Electron helper (`--type=gpu-process`, crashpad, renderer, etc.),
+    // which inflates the badge and incorrectly blocks switching. Use PowerShell so we can inspect
+    // the command line and only count live top-level app instances.
+    const POWERSHELL_SCRIPT: &str = r#"
+$windowTitles = @{}
+Get-Process -Name Codex -ErrorAction SilentlyContinue | ForEach-Object {
+  $windowTitles[[uint32]$_.Id] = $_.MainWindowTitle
+}
+
+Get-CimInstance Win32_Process |
+  Where-Object { $_.Name -ieq 'Codex.exe' -or $_.Name -ieq 'codex.exe' } |
+  ForEach-Object {
+    [PSCustomObject]@{
+      Name = $_.Name
+      ProcessId = [uint32]$_.ProcessId
+      ParentProcessId = [uint32]$_.ParentProcessId
+      CommandLine = if ($_.CommandLine) { $_.CommandLine } else { '' }
+      MainWindowTitle = if ($windowTitles.ContainsKey([uint32]$_.ProcessId)) {
+        [string]$windowTitles[[uint32]$_.ProcessId]
+      } else {
+        ''
+      }
+    }
+  } |
+  ConvertTo-Json -Compress
+"#;
+
+    let output = Command::new("powershell.exe")
+        .creation_flags(CREATE_NO_WINDOW)
+        .args(["-NoProfile", "-NonInteractive", "-Command", POWERSHELL_SCRIPT])
+        .output()
+        .context("failed to query Windows process list")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("PowerShell process query failed: {}", stderr.trim());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let processes = parse_windows_codex_processes(&stdout)?;
+
+    let mut active_pids = Vec::new();
+    let mut ignored_count = 0;
+
+    for process in processes.iter().filter(|process| is_windows_codex_root_process(process)) {
+        let command = process.command_line.to_ascii_lowercase();
+        if is_ide_plugin_process(&command) {
+            ignored_count += 1;
+            continue;
+        }
+
+        let has_window = !process.main_window_title.trim().is_empty();
+        let has_renderer = windows_has_descendant_matching(process.process_id, &processes, |child| {
+            child.command_line.to_ascii_lowercase().contains("--type=renderer")
+        });
+        let has_app_server =
+            windows_has_descendant_matching(process.process_id, &processes, |child| {
+                let command = child.command_line.to_ascii_lowercase();
+                command.contains("resources\\codex.exe") && command.contains("app-server")
+            });
+
+        if has_window || has_renderer || has_app_server {
+            active_pids.push(process.process_id);
+        } else {
+            // Ignore stale helper trees left behind after the window has already closed.
+            ignored_count += 1;
         }
     }
 
-    Ok((pids, bg_count))
+    active_pids.sort_unstable();
+    active_pids.dedup();
+
+    Ok((active_pids, ignored_count))
+}
+
+#[cfg(windows)]
+fn parse_windows_codex_processes(stdout: &str) -> anyhow::Result<Vec<WindowsCodexProcess>> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let value: serde_json::Value =
+        serde_json::from_str(trimmed).context("failed to parse Windows process JSON")?;
+
+    match value {
+        serde_json::Value::Array(values) => values
+            .into_iter()
+            .map(|value| {
+                serde_json::from_value(value)
+                    .context("failed to deserialize Windows Codex process entry")
+            })
+            .collect(),
+        value => Ok(vec![serde_json::from_value(value)
+            .context("failed to deserialize Windows Codex process entry")?]),
+    }
+}
+
+#[cfg(windows)]
+fn is_windows_codex_root_process(process: &WindowsCodexProcess) -> bool {
+    let name = process.name.to_ascii_lowercase();
+    let command = process.command_line.to_ascii_lowercase();
+
+    name == "codex.exe"
+        && !command.contains("codex-switcher")
+        && !command.contains("--type=")
+        && !command.contains("resources\\codex.exe")
+}
+
+#[cfg(any(unix, windows))]
+fn is_ide_plugin_process(command: &str) -> bool {
+    command.contains(".antigravity")
+        || command.contains("openai.chatgpt")
+        || command.contains(".vscode")
+}
+
+#[cfg(windows)]
+fn windows_has_descendant_matching<F>(
+    root_pid: u32,
+    processes: &[WindowsCodexProcess],
+    mut predicate: F,
+) -> bool
+where
+    F: FnMut(&WindowsCodexProcess) -> bool,
+{
+    let mut queue = vec![root_pid];
+    let mut visited = HashSet::new();
+
+    while let Some(parent_pid) = queue.pop() {
+        for process in processes
+            .iter()
+            .filter(|process| process.parent_process_id == parent_pid)
+        {
+            if !visited.insert(process.process_id) {
+                continue;
+            }
+
+            if predicate(process) {
+                return true;
+            }
+
+            queue.push(process.process_id);
+        }
+    }
+
+    false
 }


### PR DESCRIPTION
## Summary
- ignore stale Windows Codex helper process trees when deriving active Codex processes
- avoid counting IDE/plugin helper trees as active Codex roots
- keep the PR scoped to the single process fix from 39435fe

## Testing
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo fmt --check currently reports formatting diffs in the Rust sources, so this PR stays scoped to the process fix only