### PR TITLE
fix: Update warm-up model with a supported model

### DIFF
--- a/src-tauri/src/api/usage.rs
+++ b/src-tauri/src/api/usage.rs
@@ -178,7 +178,7 @@ async fn warmup_with_api_key(api_key: &str) -> Result<()> {
 
 fn build_warmup_payload(stream: bool, include_max_output_tokens: bool) -> serde_json::Value {
     let mut payload = json!({
-        "model": "gpt-5.2-codex",
+        "model": "gpt-5.4",
         "instructions": "You are Codex.",
         "input": [
             {


### PR DESCRIPTION
**Problem:**  
5.2 codex isn't supported anymore.   
**Fix:**  
Switched to 5.4  
`[Warmup] ChatGPT warm-up error response: {"detail":"The 'gpt-5.2-codex' model is not supported when using Codex with a ChatGPT account."}`