### PR TITLE
feat(auth): add subscription expiry tracking and display

### DIFF
--- a/src-tauri/src/api/usage.rs
+++ b/src-tauri/src/api/usage.rs
@@ -126,8 +126,7 @@ async fn warmup_with_chatgpt_auth(account: &StoredAccount) -> Result<()> {
     let fresh_account = ensure_chatgpt_tokens_fresh(account).await?;
     let (access_token, chatgpt_account_id) = extract_chatgpt_auth(&fresh_account)?;
 
-    let mut response =
-        send_chatgpt_warmup_request(access_token, chatgpt_account_id, true).await?;
+    let mut response = send_chatgpt_warmup_request(access_token, chatgpt_account_id, true).await?;
     if response.status() == StatusCode::UNAUTHORIZED {
         println!(
             "[Warmup] Unauthorized for account {}, refreshing token and retrying once",

--- a/src-tauri/src/api/usage.rs
+++ b/src-tauri/src/api/usage.rs
@@ -1,12 +1,15 @@
 //! Usage API client for fetching rate limits and credits
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use futures::{stream, StreamExt};
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, USER_AGENT},
     StatusCode,
 };
+use serde::Deserialize;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 
 use crate::auth::{ensure_chatgpt_tokens_fresh, refresh_chatgpt_tokens};
 use crate::types::{
@@ -15,9 +18,43 @@ use crate::types::{
 };
 
 const CHATGPT_BACKEND_API: &str = "https://chatgpt.com/backend-api";
+const CHATGPT_ACCOUNTS_CHECK_API: &str =
+    "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27";
 const CHATGPT_CODEX_RESPONSES_API: &str = "https://chatgpt.com/backend-api/codex/responses";
 const OPENAI_API: &str = "https://api.openai.com/v1";
 const CODEX_USER_AGENT: &str = "codex-cli/1.0.0";
+
+#[derive(Debug, Clone)]
+pub struct ChatGptAccountMetadata {
+    pub plan_type: Option<String>,
+    pub subscription_expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountsCheckResponse {
+    #[serde(default)]
+    accounts: HashMap<String, AccountsCheckEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountsCheckEntry {
+    #[serde(default)]
+    account: Option<AccountsCheckAccount>,
+    #[serde(default)]
+    entitlement: Option<AccountsCheckEntitlement>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountsCheckAccount {
+    #[serde(default)]
+    plan_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountsCheckEntitlement {
+    #[serde(default)]
+    expires_at: Option<DateTime<Utc>>,
+}
 
 /// Get usage information for an account
 pub async fn get_account_usage(account: &StoredAccount) -> Result<UsageInfo> {
@@ -56,6 +93,43 @@ pub async fn warmup_account(account: &StoredAccount) -> Result<()> {
         AuthData::ApiKey { key } => warmup_with_api_key(key).await,
         AuthData::ChatGPT { .. } => warmup_with_chatgpt_auth(account).await,
     }
+}
+
+pub async fn fetch_chatgpt_account_metadata(
+    account: &StoredAccount,
+) -> Result<ChatGptAccountMetadata> {
+    let (access_token, chatgpt_account_id) = extract_chatgpt_auth(account)?;
+    let response =
+        send_chatgpt_get_request(CHATGPT_ACCOUNTS_CHECK_API, access_token, chatgpt_account_id)
+            .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("Accounts check API error: {status} - {body}");
+    }
+
+    let payload: AccountsCheckResponse = response
+        .json()
+        .await
+        .context("Failed to parse accounts check response")?;
+
+    let selected_entry = chatgpt_account_id
+        .and_then(|account_id| payload.accounts.get(account_id))
+        .or_else(|| payload.accounts.get("default"))
+        .or_else(|| payload.accounts.values().next())
+        .context("Accounts check response did not include an account entry")?;
+
+    Ok(ChatGptAccountMetadata {
+        plan_type: selected_entry
+            .account
+            .as_ref()
+            .and_then(|account| account.plan_type.clone()),
+        subscription_expires_at: selected_entry
+            .entitlement
+            .as_ref()
+            .and_then(|entitlement| entitlement.expires_at),
+    })
 }
 
 async fn get_usage_with_chatgpt_auth(account: &StoredAccount) -> Result<UsageInfo> {
@@ -248,17 +322,29 @@ async fn send_chatgpt_usage_request(
     access_token: &str,
     chatgpt_account_id: Option<&str>,
 ) -> Result<reqwest::Response> {
+    send_chatgpt_get_request(
+        &format!("{CHATGPT_BACKEND_API}/wham/usage"),
+        access_token,
+        chatgpt_account_id,
+    )
+    .await
+}
+
+async fn send_chatgpt_get_request(
+    url: &str,
+    access_token: &str,
+    chatgpt_account_id: Option<&str>,
+) -> Result<reqwest::Response> {
     let client = reqwest::Client::new();
     let headers = build_chatgpt_headers(access_token, chatgpt_account_id)?;
-    let url = format!("{CHATGPT_BACKEND_API}/wham/usage");
     println!("[Usage] Requesting: {url}");
 
     client
-        .get(&url)
+        .get(url)
         .headers(headers)
         .send()
         .await
-        .context("Failed to send usage request")
+        .with_context(|| format!("Failed to send GET request to {url}"))
 }
 
 async fn send_chatgpt_warmup_request(

--- a/src-tauri/src/auth/oauth_server.rs
+++ b/src-tauri/src/auth/oauth_server.rs
@@ -12,7 +12,7 @@ use sha2::{Digest, Sha256};
 use tiny_http::{Header, Request, Response, Server};
 use tokio::sync::oneshot;
 
-use crate::types::{OAuthLoginInfo, StoredAccount};
+use crate::types::{parse_chatgpt_id_token_claims, OAuthLoginInfo, StoredAccount};
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -122,40 +122,6 @@ async fn exchange_code_for_tokens(
         .await
         .context("Failed to parse token response")?;
     Ok(tokens)
-}
-
-/// Parse claims from JWT ID token
-fn parse_id_token_claims(id_token: &str) -> (Option<String>, Option<String>, Option<String>) {
-    let parts: Vec<&str> = id_token.split('.').collect();
-    if parts.len() != 3 {
-        return (None, None, None);
-    }
-
-    let payload = match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(parts[1]) {
-        Ok(bytes) => bytes,
-        Err(_) => return (None, None, None),
-    };
-
-    let json: serde_json::Value = match serde_json::from_slice(&payload) {
-        Ok(v) => v,
-        Err(_) => return (None, None, None),
-    };
-
-    let email = json.get("email").and_then(|v| v.as_str()).map(String::from);
-
-    let auth_claims = json.get("https://api.openai.com/auth");
-
-    let plan_type = auth_claims
-        .and_then(|auth| auth.get("chatgpt_plan_type"))
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    let account_id = auth_claims
-        .and_then(|auth| auth.get("chatgpt_account_id"))
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    (email, plan_type, account_id)
 }
 
 /// OAuth login flow result
@@ -362,18 +328,18 @@ async fn handle_oauth_request(
             Ok(tokens) => {
                 println!("[OAuth] Token exchange successful!");
                 // Parse claims from ID token
-                let (email, plan_type, chatgpt_account_id) =
-                    parse_id_token_claims(&tokens.id_token);
+                let claims = parse_chatgpt_id_token_claims(&tokens.id_token);
 
                 // Create the account
                 let account = StoredAccount::new_chatgpt(
                     account_name.to_string(),
-                    email,
-                    plan_type,
+                    claims.email,
+                    claims.plan_type,
+                    claims.subscription_expires_at,
                     tokens.id_token,
                     tokens.access_token,
                     tokens.refresh_token,
-                    chatgpt_account_id,
+                    claims.account_id,
                 );
 
                 // Send success response

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 
 use crate::types::{AccountsStore, AuthData, StoredAccount};
 
@@ -197,6 +198,7 @@ pub fn update_account_chatgpt_tokens(
     chatgpt_account_id: Option<String>,
     email: Option<String>,
     plan_type: Option<String>,
+    subscription_expires_at: Option<DateTime<Utc>>,
 ) -> Result<StoredAccount> {
     let mut store = load_accounts()?;
 
@@ -231,6 +233,10 @@ pub fn update_account_chatgpt_tokens(
 
     if let Some(new_plan_type) = plan_type {
         account.plan_type = Some(new_plan_type);
+    }
+
+    if let Some(subscription_expires_at) = subscription_expires_at {
+        account.subscription_expires_at = Some(subscription_expires_at);
     }
 
     let updated = account.clone();

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -146,13 +146,14 @@ pub fn touch_account(account_id: &str) -> Result<()> {
     Ok(())
 }
 
-/// Update an account's metadata (name, email, plan_type)
+/// Update an account's metadata (name, email, plan_type, subscription expiry)
 pub fn update_account_metadata(
     account_id: &str,
     name: Option<String>,
     email: Option<String>,
     plan_type: Option<String>,
-) -> Result<()> {
+    subscription_expires_at: Option<Option<DateTime<Utc>>>,
+) -> Result<StoredAccount> {
     let mut store = load_accounts()?;
 
     // Check for duplicate names first (if renaming)
@@ -185,8 +186,13 @@ pub fn update_account_metadata(
         account.plan_type = plan_type;
     }
 
+    if let Some(subscription_expires_at) = subscription_expires_at {
+        account.subscription_expires_at = subscription_expires_at;
+    }
+
+    let updated = account.clone();
     save_accounts(&store)?;
-    Ok(())
+    Ok(updated)
 }
 
 /// Update ChatGPT OAuth tokens for an account and return the updated account.

--- a/src-tauri/src/auth/switcher.rs
+++ b/src-tauri/src/auth/switcher.rs
@@ -6,7 +6,9 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use chrono::Utc;
 
-use crate::types::{AuthData, AuthDotJson, StoredAccount, TokenData};
+use crate::types::{
+    parse_chatgpt_id_token_claims, AuthData, AuthDotJson, StoredAccount, TokenData,
+};
 
 /// Get the official Codex home directory
 pub fn get_codex_home() -> Result<PathBuf> {
@@ -99,52 +101,21 @@ pub fn import_from_auth_json_contents(
     if let Some(api_key) = auth.openai_api_key {
         Ok(StoredAccount::new_api_key(account_name, api_key))
     } else if let Some(tokens) = auth.tokens {
-        // Try to extract email and plan from id_token
-        let (email, plan_type) = parse_id_token_claims(&tokens.id_token);
+        let claims = parse_chatgpt_id_token_claims(&tokens.id_token);
 
         Ok(StoredAccount::new_chatgpt(
             account_name,
-            email,
-            plan_type,
+            claims.email,
+            claims.plan_type,
+            claims.subscription_expires_at,
             tokens.id_token,
             tokens.access_token,
             tokens.refresh_token,
-            tokens.account_id,
+            claims.account_id.or(tokens.account_id),
         ))
     } else {
         anyhow::bail!("auth.json contains neither API key nor tokens");
     }
-}
-
-/// Parse claims from a JWT ID token (without validation)
-fn parse_id_token_claims(id_token: &str) -> (Option<String>, Option<String>) {
-    let parts: Vec<&str> = id_token.split('.').collect();
-    if parts.len() != 3 {
-        return (None, None);
-    }
-
-    // Decode the payload (second part)
-    let payload =
-        match base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, parts[1]) {
-            Ok(bytes) => bytes,
-            Err(_) => return (None, None),
-        };
-
-    let json: serde_json::Value = match serde_json::from_slice(&payload) {
-        Ok(v) => v,
-        Err(_) => return (None, None),
-    };
-
-    let email = json.get("email").and_then(|v| v.as_str()).map(String::from);
-
-    // Look for plan type in the OpenAI auth claims
-    let plan_type = json
-        .get("https://api.openai.com/auth")
-        .and_then(|auth| auth.get("chatgpt_plan_type"))
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    (email, plan_type)
 }
 
 /// Read the current auth.json file if it exists

--- a/src-tauri/src/auth/token_refresh.rs
+++ b/src-tauri/src/auth/token_refresh.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use tokio::time::{sleep, Duration};
 
 use super::{load_accounts, switch_to_account, update_account_chatgpt_tokens};
-use crate::types::{AuthData, StoredAccount};
+use crate::types::{parse_chatgpt_id_token_claims, AuthData, StoredAccount};
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -62,8 +62,8 @@ pub async fn refresh_chatgpt_tokens(account: &StoredAccount) -> Result<StoredAcc
         .refresh_token
         .unwrap_or_else(|| current_refresh_token.clone());
 
-    let (email, plan_type, parsed_account_id) = parse_id_token_claims(&next_id_token);
-    let next_account_id = parsed_account_id.or(current_account_id);
+    let claims = parse_chatgpt_id_token_claims(&next_id_token);
+    let next_account_id = claims.account_id.or(current_account_id);
 
     let is_active = load_accounts()?.active_account_id.as_deref() == Some(account.id.as_str());
 
@@ -73,8 +73,9 @@ pub async fn refresh_chatgpt_tokens(account: &StoredAccount) -> Result<StoredAcc
         refreshed.access_token,
         next_refresh_token,
         next_account_id,
-        email,
-        plan_type,
+        claims.email,
+        claims.plan_type,
+        claims.subscription_expires_at,
     )?;
 
     // Keep ~/.codex/auth.json in sync when this is the active account.
@@ -102,16 +103,17 @@ pub async fn create_chatgpt_account_from_refresh_token(
         .id_token
         .context("Refresh response did not include id_token")?;
     let next_refresh_token = refreshed.refresh_token.unwrap_or(refresh_token);
-    let (email, plan_type, account_id) = parse_id_token_claims(&id_token);
+    let claims = parse_chatgpt_id_token_claims(&id_token);
 
     Ok(StoredAccount::new_chatgpt(
         account_name,
-        email,
-        plan_type,
+        claims.email,
+        claims.plan_type,
+        claims.subscription_expires_at,
         id_token,
         refreshed.access_token,
         next_refresh_token,
-        account_id,
+        claims.account_id,
     ))
 }
 
@@ -133,36 +135,6 @@ fn parse_jwt_exp(token: &str) -> Option<i64> {
         .ok()?;
     let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
     json.get("exp").and_then(|v| v.as_i64())
-}
-
-fn parse_id_token_claims(id_token: &str) -> (Option<String>, Option<String>, Option<String>) {
-    let parts: Vec<&str> = id_token.split('.').collect();
-    if parts.len() != 3 {
-        return (None, None, None);
-    }
-
-    let payload = match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(parts[1]) {
-        Ok(bytes) => bytes,
-        Err(_) => return (None, None, None),
-    };
-
-    let json: serde_json::Value = match serde_json::from_slice(&payload) {
-        Ok(v) => v,
-        Err(_) => return (None, None, None),
-    };
-
-    let email = json.get("email").and_then(|v| v.as_str()).map(String::from);
-    let auth_claims = json.get("https://api.openai.com/auth");
-    let plan_type = auth_claims
-        .and_then(|auth| auth.get("chatgpt_plan_type"))
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    let account_id = auth_claims
-        .and_then(|auth| auth.get("chatgpt_account_id"))
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    (email, plan_type, account_id)
 }
 
 async fn refresh_tokens_with_refresh_token(refresh_token: &str) -> Result<RefreshTokenResponse> {

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -177,7 +177,7 @@ pub async fn delete_account(account_id: String) -> Result<(), String> {
 /// Rename an account
 #[tauri::command]
 pub async fn rename_account(account_id: String, new_name: String) -> Result<(), String> {
-    crate::auth::storage::update_account_metadata(&account_id, Some(new_name), None, None)
+    crate::auth::storage::update_account_metadata(&account_id, Some(new_name), None, None, None)
         .map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -146,7 +146,12 @@ Get-CimInstance Win32_Process |
 
     let output = Command::new("powershell.exe")
         .creation_flags(CREATE_NO_WINDOW)
-        .args(["-NoProfile", "-NonInteractive", "-Command", POWERSHELL_SCRIPT])
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            POWERSHELL_SCRIPT,
+        ])
         .output()
         .context("failed to query Windows process list")?;
 
@@ -161,7 +166,10 @@ Get-CimInstance Win32_Process |
     let mut active_pids = Vec::new();
     let mut ignored_count = 0;
 
-    for process in processes.iter().filter(|process| is_windows_codex_root_process(process)) {
+    for process in processes
+        .iter()
+        .filter(|process| is_windows_codex_root_process(process))
+    {
         let command = process.command_line.to_ascii_lowercase();
         if is_ide_plugin_process(&command) {
             ignored_count += 1;
@@ -169,9 +177,13 @@ Get-CimInstance Win32_Process |
         }
 
         let has_window = !process.main_window_title.trim().is_empty();
-        let has_renderer = windows_has_descendant_matching(process.process_id, &processes, |child| {
-            child.command_line.to_ascii_lowercase().contains("--type=renderer")
-        });
+        let has_renderer =
+            windows_has_descendant_matching(process.process_id, &processes, |child| {
+                child
+                    .command_line
+                    .to_ascii_lowercase()
+                    .contains("--type=renderer")
+            });
         let has_app_server =
             windows_has_descendant_matching(process.process_id, &processes, |child| {
                 let command = child.command_line.to_ascii_lowercase();

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -1,8 +1,11 @@
 //! Usage query Tauri commands
 
-use crate::api::usage::{get_account_usage, refresh_all_usage, warmup_account as send_warmup};
-use crate::auth::{get_account, load_accounts};
-use crate::types::{UsageInfo, WarmupSummary};
+use crate::api::usage::{
+    fetch_chatgpt_account_metadata, get_account_usage, refresh_all_usage,
+    warmup_account as send_warmup,
+};
+use crate::auth::{get_account, load_accounts, refresh_chatgpt_tokens, update_account_metadata};
+use crate::types::{AccountInfo, AuthData, UsageInfo, WarmupSummary};
 use futures::{stream, StreamExt};
 
 /// Get usage info for a specific account
@@ -13,6 +16,41 @@ pub async fn get_usage(account_id: String) -> Result<UsageInfo, String> {
         .ok_or_else(|| format!("Account not found: {account_id}"))?;
 
     get_account_usage(&account).await.map_err(|e| e.to_string())
+}
+
+/// Force-refresh account metadata for a specific account.
+/// For ChatGPT accounts this refreshes OAuth tokens and pulls live subscription metadata.
+/// For API key accounts this is a no-op.
+#[tauri::command]
+pub async fn refresh_account_metadata(account_id: String) -> Result<AccountInfo, String> {
+    let account = get_account(&account_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("Account not found: {account_id}"))?;
+
+    let updated = match &account.auth_data {
+        AuthData::ApiKey { .. } => account,
+        AuthData::ChatGPT { .. } => {
+            let refreshed = refresh_chatgpt_tokens(&account)
+                .await
+                .map_err(|e| e.to_string())?;
+            let live_metadata = fetch_chatgpt_account_metadata(&refreshed)
+                .await
+                .map_err(|e| e.to_string())?;
+
+            update_account_metadata(
+                &account_id,
+                None,
+                None,
+                live_metadata.plan_type,
+                Some(live_metadata.subscription_expires_at),
+            )
+            .map_err(|e| e.to_string())?
+        }
+    };
+
+    let store = load_accounts().map_err(|e| e.to_string())?;
+    let active_id = store.active_account_id.as_deref();
+    Ok(AccountInfo::from_stored(&updated, active_id))
 }
 
 /// Refresh usage info for all accounts

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,8 +10,9 @@ use commands::{
     add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,
     export_accounts_full_encrypted_file, export_accounts_slim_text, get_active_account_info,
     get_masked_account_ids, get_usage, import_accounts_full_encrypted_file,
-    import_accounts_slim_text, list_accounts, refresh_all_accounts_usage, rename_account,
-    set_masked_account_ids, start_login, switch_account, warmup_account, warmup_all_accounts,
+    import_accounts_slim_text, list_accounts, refresh_account_metadata, refresh_all_accounts_usage,
+    rename_account, set_masked_account_ids, start_login, switch_account, warmup_account,
+    warmup_all_accounts,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -47,6 +48,7 @@ pub fn run() {
             cancel_login,
             // Usage
             get_usage,
+            refresh_account_metadata,
             refresh_all_accounts_usage,
             warmup_account,
             warmup_all_accounts,

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -1,5 +1,6 @@
 //! Core types for Codex Switcher
 
+use base64::Engine;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -40,6 +41,9 @@ pub struct StoredAccount {
     pub email: Option<String>,
     /// Plan type: free, plus, pro, team, business, enterprise, edu
     pub plan_type: Option<String>,
+    /// Subscription expiration extracted from ChatGPT ID token, when available
+    #[serde(default)]
+    pub subscription_expires_at: Option<DateTime<Utc>>,
     /// Authentication mode
     pub auth_mode: AuthMode,
     /// Authentication credentials
@@ -58,6 +62,7 @@ impl StoredAccount {
             name,
             email: None,
             plan_type: None,
+            subscription_expires_at: None,
             auth_mode: AuthMode::ApiKey,
             auth_data: AuthData::ApiKey { key: api_key },
             created_at: Utc::now(),
@@ -70,6 +75,7 @@ impl StoredAccount {
         name: String,
         email: Option<String>,
         plan_type: Option<String>,
+        subscription_expires_at: Option<DateTime<Utc>>,
         id_token: String,
         access_token: String,
         refresh_token: String,
@@ -80,6 +86,7 @@ impl StoredAccount {
             name,
             email,
             plan_type,
+            subscription_expires_at,
             auth_mode: AuthMode::ChatGPT,
             auth_data: AuthData::ChatGPT {
                 id_token,
@@ -125,6 +132,50 @@ pub enum AuthData {
     },
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ChatGptIdTokenClaims {
+    pub email: Option<String>,
+    pub plan_type: Option<String>,
+    pub account_id: Option<String>,
+    pub subscription_expires_at: Option<DateTime<Utc>>,
+}
+
+pub fn parse_chatgpt_id_token_claims(id_token: &str) -> ChatGptIdTokenClaims {
+    let parts: Vec<&str> = id_token.split('.').collect();
+    if parts.len() != 3 {
+        return ChatGptIdTokenClaims::default();
+    }
+
+    let payload = match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(parts[1]) {
+        Ok(bytes) => bytes,
+        Err(_) => return ChatGptIdTokenClaims::default(),
+    };
+
+    let json: serde_json::Value = match serde_json::from_slice(&payload) {
+        Ok(value) => value,
+        Err(_) => return ChatGptIdTokenClaims::default(),
+    };
+
+    let auth_claims = json.get("https://api.openai.com/auth");
+
+    ChatGptIdTokenClaims {
+        email: json.get("email").and_then(|v| v.as_str()).map(String::from),
+        plan_type: auth_claims
+            .and_then(|auth| auth.get("chatgpt_plan_type"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        account_id: auth_claims
+            .and_then(|auth| auth.get("chatgpt_account_id"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        subscription_expires_at: auth_claims
+            .and_then(|auth| auth.get("chatgpt_subscription_active_until"))
+            .and_then(|v| v.as_str())
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|value| value.with_timezone(&Utc)),
+    }
+}
+
 // ============================================================================
 // Types for Codex's auth.json format (for compatibility)
 // ============================================================================
@@ -168,6 +219,7 @@ pub struct AccountInfo {
     pub name: String,
     pub email: Option<String>,
     pub plan_type: Option<String>,
+    pub subscription_expires_at: Option<DateTime<Utc>>,
     pub auth_mode: AuthMode,
     pub is_active: bool,
     pub created_at: DateTime<Utc>,
@@ -176,11 +228,22 @@ pub struct AccountInfo {
 
 impl AccountInfo {
     pub fn from_stored(account: &StoredAccount, active_id: Option<&str>) -> Self {
+        let fallback_subscription_expires_at = match &account.auth_data {
+            AuthData::ChatGPT { id_token, .. } => {
+                parse_chatgpt_id_token_claims(id_token).subscription_expires_at
+            }
+            AuthData::ApiKey { .. } => None,
+        };
+
         Self {
             id: account.id.clone(),
             name: account.name.clone(),
             email: account.email.clone(),
             plan_type: account.plan_type.clone(),
+            subscription_expires_at: account
+                .subscription_expires_at
+                .clone()
+                .or(fallback_subscription_expires_at),
             auth_mode: account.auth_mode,
             is_active: active_id == Some(&account.id),
             created_at: account.created_at,
@@ -301,4 +364,29 @@ pub struct CreditStatusDetails {
     pub unlimited: bool,
     #[serde(default)]
     pub balance: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_chatgpt_id_token_claims;
+    use base64::Engine;
+
+    #[test]
+    fn parses_subscription_expiry_from_realistic_id_token_claims() {
+        let payload = r#"{"email":"user@example.com","https://api.openai.com/auth":{"chatgpt_plan_type":"plus","chatgpt_account_id":"acc_123","chatgpt_subscription_active_until":"2026-04-23T05:03:38+00:00"}}"#;
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+        let token = format!("header.{encoded}.signature");
+
+        let claims = parse_chatgpt_id_token_claims(&token);
+
+        assert_eq!(claims.email.as_deref(), Some("user@example.com"));
+        assert_eq!(claims.plan_type.as_deref(), Some("plus"));
+        assert_eq!(claims.account_id.as_deref(), Some("acc_123"));
+        assert_eq!(
+            claims
+                .subscription_expires_at
+                .map(|value| value.to_rfc3339()),
+            Some("2026-04-23T05:03:38+00:00".to_string())
+        );
+    }
 }

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -14,8 +14,8 @@ use crate::commands::{
     complete_login, delete_account, export_accounts_full_encrypted_bytes,
     export_accounts_slim_text, get_active_account_info, get_masked_account_ids, get_usage,
     import_accounts_full_encrypted_bytes, import_accounts_slim_text, list_accounts,
-    refresh_all_accounts_usage, rename_account, set_masked_account_ids, start_login,
-    switch_account, warmup_account, warmup_all_accounts,
+    refresh_account_metadata, refresh_all_accounts_usage, rename_account, set_masked_account_ids,
+    start_login, switch_account, warmup_account, warmup_all_accounts,
 };
 
 #[derive(Debug, Deserialize)]
@@ -140,6 +140,10 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         "get_usage" => {
             let args: AccountIdArgs = parse_args(payload)?;
             to_json(get_usage(args.account_id).await?)
+        }
+        "refresh_account_metadata" => {
+            let args: AccountIdArgs = parse_args(payload)?;
+            to_json(refresh_account_metadata(args.account_id).await?)
         }
         "refresh_all_accounts_usage" => to_json(refresh_all_accounts_usage().await?),
         "warmup_account" => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,12 @@ function App() {
   } | null>(null);
   const [maskedAccounts, setMaskedAccounts] = useState<Set<string>>(new Set());
   const [otherAccountsSort, setOtherAccountsSort] = useState<
-    "deadline_asc" | "deadline_desc" | "remaining_desc" | "remaining_asc"
+    | "deadline_asc"
+    | "deadline_desc"
+    | "remaining_desc"
+    | "remaining_asc"
+    | "subscription_asc"
+    | "subscription_desc"
   >("deadline_asc");
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
@@ -350,6 +355,23 @@ function App() {
     const getResetDeadline = (resetAt: number | null | undefined) =>
       resetAt ?? Number.POSITIVE_INFINITY;
 
+    const getSubscriptionDeadline = (expiresAt: string | null | undefined) => {
+      if (!expiresAt) return null;
+      const timestamp = new Date(expiresAt).getTime();
+      return Number.isNaN(timestamp) ? null : timestamp;
+    };
+
+    const compareOptionalNumber = (
+      aValue: number | null,
+      bValue: number | null,
+      direction: "asc" | "desc"
+    ) => {
+      if (aValue === null && bValue === null) return 0;
+      if (aValue === null) return 1;
+      if (bValue === null) return -1;
+      return direction === "asc" ? aValue - bValue : bValue - aValue;
+    };
+
     const getRemainingPercent = (usedPercent: number | null | undefined) => {
       if (usedPercent === null || usedPercent === undefined) {
         return Number.NEGATIVE_INFINITY;
@@ -358,6 +380,30 @@ function App() {
     };
 
     return [...otherAccounts].sort((a, b) => {
+      if (
+        otherAccountsSort === "subscription_asc" ||
+        otherAccountsSort === "subscription_desc"
+      ) {
+        const subscriptionDiff = compareOptionalNumber(
+          getSubscriptionDeadline(a.subscription_expires_at),
+          getSubscriptionDeadline(b.subscription_expires_at),
+          otherAccountsSort === "subscription_asc" ? "asc" : "desc"
+        );
+        if (subscriptionDiff !== 0) return subscriptionDiff;
+
+        const deadlineDiff =
+          getResetDeadline(a.usage?.primary_resets_at) -
+          getResetDeadline(b.usage?.primary_resets_at);
+        if (deadlineDiff !== 0) return deadlineDiff;
+
+        const remainingDiff =
+          getRemainingPercent(b.usage?.primary_used_percent) -
+          getRemainingPercent(a.usage?.primary_used_percent);
+        if (remainingDiff !== 0) return remainingDiff;
+
+        return a.name.localeCompare(b.name);
+      }
+
       if (otherAccountsSort === "deadline_asc" || otherAccountsSort === "deadline_desc") {
         const deadlineDiff =
           getResetDeadline(a.usage?.primary_resets_at) -
@@ -629,6 +675,8 @@ function App() {
                               | "deadline_desc"
                               | "remaining_desc"
                               | "remaining_asc"
+                              | "subscription_asc"
+                              | "subscription_desc"
                           )
                         }
                         className="appearance-none font-sans text-xs sm:text-sm font-medium pl-3 pr-9 py-2 rounded-xl border border-gray-300 dark:border-gray-700 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800 text-gray-700 dark:text-gray-200 shadow-sm hover:border-gray-400 dark:hover:border-gray-600 hover:shadow focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600 focus:border-gray-400 dark:focus:border-gray-600 transition-all"
@@ -640,6 +688,12 @@ function App() {
                         </option>
                         <option value="remaining_asc">
                           % remaining: lowest to highest
+                        </option>
+                        <option value="subscription_asc">
+                          Expiry: earliest to latest
+                        </option>
+                        <option value="subscription_desc">
+                          Expiry: latest to earliest
                         </option>
                       </select>
                       <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-gray-500 dark:text-gray-400">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -189,7 +189,7 @@ function App() {
     setIsRefreshing(true);
     setRefreshSuccess(false);
     try {
-      await refreshUsage();
+      await refreshUsage(undefined, { refreshMetadata: true });
       setRefreshSuccess(true);
       setTimeout(() => setRefreshSuccess(false), 2000);
     } finally {
@@ -642,7 +642,9 @@ function App() {
                     handleWarmupAccount(activeAccount.id, activeAccount.name)
                   }
                   onDelete={() => handleDelete(activeAccount.id)}
-                  onRefresh={() => refreshSingleUsage(activeAccount.id)}
+                  onRefresh={() =>
+                    refreshSingleUsage(activeAccount.id, { refreshMetadata: true })
+                  }
                   onRename={(newName) => renameAccount(activeAccount.id, newName)}
                   switching={switchingId === activeAccount.id}
                   switchDisabled={hasRunningProcesses ?? false}
@@ -718,7 +720,9 @@ function App() {
                       onSwitch={() => handleSwitch(account.id)}
                       onWarmup={() => handleWarmupAccount(account.id, account.name)}
                       onDelete={() => handleDelete(account.id)}
-                      onRefresh={() => refreshSingleUsage(account.id)}
+                      onRefresh={() =>
+                        refreshSingleUsage(account.id, { refreshMetadata: true })
+                      }
                       onRename={(newName) => renameAccount(account.id, newName)}
                       switching={switchingId === account.id}
                       switchDisabled={hasRunningProcesses ?? false}

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -27,6 +27,52 @@ function formatLastRefresh(date: Date | null): string {
   return date.toLocaleDateString();
 }
 
+function getSubscriptionStatus(timestamp: string | null | undefined): {
+  label: string;
+  className: string;
+} {
+  if (!timestamp) {
+    return {
+      label: "Expiry unavailable",
+      className: "text-gray-400 dark:text-gray-500",
+    };
+  }
+
+  const expiryDate = new Date(timestamp);
+  const formattedDate = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(expiryDate);
+
+  const remainingMs = expiryDate.getTime() - Date.now();
+  if (remainingMs <= 0) {
+    return {
+      label: `Expired ${formattedDate}`,
+      className: "text-red-500 dark:text-red-400",
+    };
+  }
+
+  if (remainingMs <= 3 * 24 * 60 * 60 * 1000) {
+    return {
+      label: `Until ${formattedDate}`,
+      className: "text-red-500 dark:text-red-400",
+    };
+  }
+
+  if (remainingMs <= 7 * 24 * 60 * 60 * 1000) {
+    return {
+      label: `Until ${formattedDate}`,
+      className: "text-amber-500 dark:text-amber-400",
+    };
+  }
+
+  return {
+    label: `Until ${formattedDate}`,
+    className: "text-gray-400 dark:text-gray-500",
+  };
+}
+
 function BlurredText({ children, blur }: { children: React.ReactNode; blur: boolean }) {
   return (
     <span
@@ -116,6 +162,8 @@ export function AccountCard({
 
   const planKey = account.plan_type?.toLowerCase() || "api_key";
   const planColorClass = planColors[planKey] || planColors.free;
+  const showSubscriptionStatus = account.auth_mode === "chat_g_p_t";
+  const subscriptionStatus = getSubscriptionStatus(account.subscription_expires_at);
 
 
   return (
@@ -202,8 +250,15 @@ export function AccountCard({
       </div>
 
       {/* Last refresh time */}
-      <div className="text-xs text-gray-400 dark:text-gray-500 mb-3">
-        Last updated: {formatLastRefresh(lastRefresh)}
+      <div className="flex flex-wrap items-center justify-between gap-2 text-xs mb-3">
+        <div className="text-gray-400 dark:text-gray-500">
+          Last updated: {formatLastRefresh(lastRefresh)}
+        </div>
+        {showSubscriptionStatus && (
+          <div className={`text-right ${subscriptionStatus.className}`}>
+            {subscriptionStatus.label}
+          </div>
+        )}
       </div>
 
       {/* Actions */}

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -89,15 +89,31 @@ export function useAccounts() {
   }, []);
 
   const refreshUsage = useCallback(
-    async (accountList?: AccountInfo[] | AccountWithUsage[]) => {
+    async (
+      accountList?: AccountInfo[] | AccountWithUsage[],
+      options?: { refreshMetadata?: boolean }
+    ) => {
     try {
-      const list = accountList ?? accountsRef.current;
+      let list = accountList ?? accountsRef.current;
       if (list.length === 0) {
         return;
       }
 
-      const accountIds = list.map((account) => account.id);
+      let accountIds = list.map((account) => account.id);
       const accountIdSet = new Set(accountIds);
+
+      if (options?.refreshMetadata) {
+        await runWithConcurrency(
+          accountIds,
+          async (accountId) => {
+            await invokeBackend<AccountInfo>("refresh_account_metadata", { accountId });
+          },
+          maxConcurrentUsageRequests
+        );
+
+        list = await loadAccounts(true);
+        accountIds = list.map((account) => account.id);
+      }
 
       setAccounts((prev) =>
         prev.map((account) =>
@@ -142,11 +158,19 @@ export function useAccounts() {
       throw err;
     }
     },
-    [buildUsageError, maxConcurrentUsageRequests, runWithConcurrency]
+    [buildUsageError, loadAccounts, maxConcurrentUsageRequests, runWithConcurrency]
   );
 
-  const refreshSingleUsage = useCallback(async (accountId: string) => {
+  const refreshSingleUsage = useCallback(async (
+    accountId: string,
+    options?: { refreshMetadata?: boolean }
+  ) => {
     try {
+      if (options?.refreshMetadata) {
+        await invokeBackend<AccountInfo>("refresh_account_metadata", { accountId });
+        await loadAccounts(true);
+      }
+
       setAccounts((prev) =>
         prev.map((a) =>
           a.id === accountId ? { ...a, usageLoading: true } : a
@@ -174,7 +198,7 @@ export function useAccounts() {
       );
       throw err;
     }
-  }, []);
+  }, [buildUsageError, loadAccounts]);
 
   const warmupAccount = useCallback(async (accountId: string) => {
     try {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,13 @@
 // Types matching the Rust backend
 
-export type AuthMode = "api_key" | "chat_gpt";
+export type AuthMode = "api_key" | "chat_g_p_t";
 
 export interface AccountInfo {
   id: string;
   name: string;
   email: string | null;
   plan_type: string | null;
+  subscription_expires_at: string | null;
   auth_mode: AuthMode;
   is_active: boolean;
   created_at: string;


### PR DESCRIPTION
Add subscription expiration date extraction from ChatGPT ID tokens and display it in the account cards with color-coded status indicators.

Backend changes:
- Add `subscription_expires_at` field to `StoredAccount` and `AccountInfo`
- Create `parse_chatgpt_id_token_claims` function to extract expiry from JWT
- Update auth flow (OAuth, token refresh, storage) to populate expiry data
- Add unit test for claims parsing

Frontend changes:
- Display subscription expiry status on account cards (expired, expiring soon, normal)
- Add subscription-based sorting options (earliest/latest expiry)
- Update TypeScript types to include `subscription_expires_at`

This enables users to track when their ChatGPT subscriptions expire and prioritize accounts accordingly.