### PR TITLE
[codex] Load config env on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,20 @@ Optional environment variables:
 
 The browser dashboard serves the same UI and backend actions through `/api/invoke/*`, which makes it usable over LAN, Tailscale, or a remote host tunnel when you expose the chosen port safely.
 
+## Environment Variables
+
+Codex Switcher loads optional environment variables from `~/.codex-switcher/.env` on startup. This is useful for settings that must be available when the macOS app is launched from Finder or the Dock, where shell startup files are not inherited.
+
+Example proxy configuration:
+
+```env
+HTTPS_PROXY=http://127.0.0.1:7890
+HTTP_PROXY=http://127.0.0.1:7890
+NO_PROXY=localhost,127.0.0.1
+```
+
+Values already present in the process environment take precedence over values from this file.
+
 ## Disclaimer
 
 This tool is designed **exclusively for individuals who personally own multiple OpenAI/ChatGPT accounts**. It is intended to help users manage their own accounts more conveniently.

--- a/src-tauri/src/bin/codex-web.rs
+++ b/src-tauri/src/bin/codex-web.rs
@@ -6,6 +6,8 @@ fn main() {
 }
 
 fn run() -> anyhow::Result<()> {
+    codex_switcher_lib::load_config_env()?;
+
     let host = std::env::var("CODEX_SWITCHER_WEB_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
     let port = std::env::var("CODEX_SWITCHER_WEB_PORT")
         .ok()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,9 @@ pub mod commands;
 pub mod types;
 pub mod web;
 
+use std::fs;
+
+use anyhow::{Context, Result};
 use commands::{
     add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,
     export_accounts_full_encrypted_file, export_accounts_slim_text, get_active_account_info,
@@ -15,8 +18,84 @@ use commands::{
     warmup_all_accounts,
 };
 
+/// Load optional environment variables from ~/.codex-switcher/.env.
+///
+/// GUI launches on macOS do not inherit shell startup files, so proxy variables
+/// placed in this file must be loaded before any reqwest clients are created.
+pub fn load_config_env() -> Result<()> {
+    let env_path = auth::storage::get_config_dir()?.join(".env");
+    if !env_path.exists() {
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&env_path)
+        .with_context(|| format!("Failed to read env file: {}", env_path.display()))?;
+
+    for (line_number, line) in content.lines().enumerate() {
+        if let Some((key, value)) = parse_env_line(line)
+            .with_context(|| format!("Invalid env file line {}", line_number + 1))?
+        {
+            if std::env::var_os(&key).is_none() {
+                std::env::set_var(key, value);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_env_line(line: &str) -> Result<Option<(String, String)>> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+        return Ok(None);
+    }
+
+    let line = line.strip_prefix("export ").unwrap_or(line).trim_start();
+    let Some((key, value)) = line.split_once('=') else {
+        anyhow::bail!("expected KEY=VALUE");
+    };
+
+    let key = key.trim();
+    if key.is_empty() || !key.chars().all(is_env_key_char) {
+        anyhow::bail!("invalid variable name");
+    }
+
+    Ok(Some((key.to_string(), parse_env_value(value.trim())?)))
+}
+
+fn is_env_key_char(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+fn parse_env_value(value: &str) -> Result<String> {
+    if let Some(rest) = value.strip_prefix('"') {
+        let Some(end) = rest.find('"') else {
+            anyhow::bail!("unterminated double-quoted value");
+        };
+        return Ok(rest[..end].to_string());
+    }
+
+    if let Some(rest) = value.strip_prefix('\'') {
+        let Some(end) = rest.find('\'') else {
+            anyhow::bail!("unterminated single-quoted value");
+        };
+        return Ok(rest[..end].to_string());
+    }
+
+    let value_without_comment = value
+        .split_once(" #")
+        .map(|(before_comment, _)| before_comment)
+        .unwrap_or(value);
+
+    Ok(value_without_comment.trim_end().to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    if let Err(error) = load_config_env() {
+        eprintln!("{error:#}");
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())


### PR DESCRIPTION
## Summary

This PR adds support for loading optional environment variables from `~/.codex-switcher/.env` when Codex Switcher starts.

This is especially useful for proxy and network-related settings when the macOS app is launched from Finder or the Dock, because GUI applications do not inherit shell startup files such as `.zshrc` or `.zprofile`.

## What changed

- Added `load_config_env()` in the shared Tauri library startup path.
- The desktop app now loads `~/.codex-switcher/.env` before creating the Tauri app and before any `reqwest` clients are used.
- The `codex-web` binary also loads the same config env file before reading its own environment-based settings.
- Documented the supported `.env` file and a proxy configuration example in the README.

## Behavior

The env file supports simple `KEY=VALUE` entries, optional `export KEY=VALUE` syntax, quoted values, blank lines, and comments.

Existing process environment variables take precedence. In other words, values from `~/.codex-switcher/.env` are only applied when the variable is not already set by the launcher or parent process.

Example:

```env
HTTPS_PROXY=http://127.0.0.1:7890
HTTP_PROXY=http://127.0.0.1:7890
NO_PROXY=localhost,127.0.0.1
```

## Why

Before this change, Codex Switcher only used environment variables that were already present in the process environment. That works when launching from a terminal, but not when launching the macOS app from Finder or the Dock. As a result, users who rely on proxy settings had no app-local way to configure network access for the desktop app.

Loading `~/.codex-switcher/.env` gives the app a predictable, local configuration point while preserving explicit environment variables when they are already set.

## Validation

- Ran `cargo fmt`.
- Ran `cargo check` successfully.
- Ran `pnpm tauri build --bundles app`; the `.app` bundle was produced successfully. The command then stopped at the updater signing step because `TAURI_SIGNING_PRIVATE_KEY` is not configured locally, which is expected for an unsigned local build environment.
