### PR TITLE
Add automatic account warm-up scheduling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAccounts } from "./hooks/useAccounts";
 import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
-import type { CodexProcessInfo } from "./types";
+import type { CodexProcessInfo, UsageInfo } from "./types";
 import {
   exportFullBackupFile,
   importFullBackupFile,
@@ -12,11 +12,92 @@ import {
 import "./App.css";
 
 const THEME_STORAGE_KEY = "codex-switcher-theme";
+const AUTO_WARMUP_ALL_STORAGE_KEY = "codex-switcher-auto-warmup-all";
+const AUTO_WARMUP_ACCOUNTS_STORAGE_KEY = "codex-switcher-auto-warmup-accounts";
+const AUTO_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-auto-warmup-last-success";
+const AUTO_WARMUP_CHECK_INTERVAL_MS = 30 * 1000;
+const AUTO_WARMUP_RETRY_BACKOFF_MS = 5 * 60 * 1000;
+const AUTO_WARMUP_MIN_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
+const AUTO_WARMUP_FULL_WINDOW_SLACK_MINUTES = 5;
+const DEFAULT_PRIMARY_WINDOW_MINUTES = 300;
+const LIMIT_FULL_THRESHOLD = 99.5;
 type ThemeMode = "light" | "dark";
+type AutoWarmupLedger = Record<
+  string,
+  {
+    lastSuccessfulWarmupAt?: number;
+  }
+>;
 const appWindow = getCurrentWindow();
 const isMacOs =
   typeof navigator !== "undefined" &&
   /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent);
+
+function readStoredStringArray(key: string): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(key) ?? "[]");
+    return Array.isArray(parsed) ? parsed.filter((item) => typeof item === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function readStoredAutoWarmupLedger(): AutoWarmupLedger {
+  if (typeof window === "undefined") return {};
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(AUTO_WARMUP_LEDGER_STORAGE_KEY) ?? "{}");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([accountId, value]) => {
+          const timestamp =
+            value &&
+            typeof value === "object" &&
+            "lastSuccessfulWarmupAt" in value &&
+            typeof value.lastSuccessfulWarmupAt === "number"
+              ? value.lastSuccessfulWarmupAt
+              : undefined;
+          return timestamp ? [accountId, { lastSuccessfulWarmupAt: timestamp }] : null;
+        })
+        .filter((entry): entry is [string, { lastSuccessfulWarmupAt: number }] => Boolean(entry))
+    );
+  } catch {
+    return {};
+  }
+}
+
+function isLimitFull(usedPercent: number | null | undefined): boolean {
+  return usedPercent !== null && usedPercent !== undefined && usedPercent >= LIMIT_FULL_THRESHOLD;
+}
+
+function getPrimaryWindowMinutes(usage: UsageInfo): number {
+  return usage.primary_window_minutes ?? DEFAULT_PRIMARY_WINDOW_MINUTES;
+}
+
+function getPrimaryRemainingMs(usage: UsageInfo): number | null {
+  if (!usage.primary_resets_at) return null;
+  return usage.primary_resets_at * 1000 - Date.now();
+}
+
+function isPrimaryFullWindow(usage: UsageInfo): boolean {
+  const remainingMs = getPrimaryRemainingMs(usage);
+  if (remainingMs === null) return false;
+
+  const thresholdMinutes = Math.max(
+    0,
+    getPrimaryWindowMinutes(usage) - AUTO_WARMUP_FULL_WINDOW_SLACK_MINUTES
+  );
+  return remainingMs >= thresholdMinutes * 60 * 1000;
+}
+
+function getLastSuccessfulWarmupAt(
+  ledger: AutoWarmupLedger,
+  accountId: string
+): number | undefined {
+  return ledger[accountId]?.lastSuccessfulWarmupAt;
+}
 
 function App() {
   const {
@@ -64,6 +145,18 @@ function App() {
     message: string;
     isError: boolean;
   } | null>(null);
+  const [autoWarmupAllEnabled, setAutoWarmupAllEnabled] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(AUTO_WARMUP_ALL_STORAGE_KEY) === "true";
+  });
+  const [autoWarmupAccountIds, setAutoWarmupAccountIds] = useState<Set<string>>(
+    () => new Set(readStoredStringArray(AUTO_WARMUP_ACCOUNTS_STORAGE_KEY))
+  );
+  const [autoWarmupLedger, setAutoWarmupLedger] =
+    useState<AutoWarmupLedger>(() => readStoredAutoWarmupLedger());
+  const [autoWarmupRunningIds, setAutoWarmupRunningIds] = useState<Set<string>>(
+    new Set()
+  );
   const [maskedAccounts, setMaskedAccounts] = useState<Set<string>>(new Set());
   const [otherAccountsSort, setOtherAccountsSort] = useState<
     | "deadline_asc"
@@ -85,6 +178,81 @@ function App() {
     }
   });
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
+  const accountsRef = useRef(accounts);
+  const autoWarmupAccountIdsRef = useRef(autoWarmupAccountIds);
+  const autoWarmupLedgerRef = useRef(autoWarmupLedger);
+  const autoWarmupRunningIdsRef = useRef(autoWarmupRunningIds);
+  const autoWarmupRetryAfterRef = useRef<Record<string, number>>({});
+
+  useEffect(() => {
+    accountsRef.current = accounts;
+  }, [accounts]);
+
+  useEffect(() => {
+    autoWarmupAccountIdsRef.current = autoWarmupAccountIds;
+  }, [autoWarmupAccountIds]);
+
+  useEffect(() => {
+    autoWarmupRunningIdsRef.current = autoWarmupRunningIds;
+  }, [autoWarmupRunningIds]);
+
+  useEffect(() => {
+    if (loading || error) return;
+
+    const validAccountIds = new Set(accounts.map((account) => account.id));
+
+    setAutoWarmupAccountIds((prev) => {
+      const next = new Set(Array.from(prev).filter((id) => validAccountIds.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+
+    setAutoWarmupLedger((prev) => {
+      const next = Object.fromEntries(
+        Object.entries(prev).filter(([accountId]) => validAccountIds.has(accountId))
+      );
+      return Object.keys(next).length === Object.keys(prev).length ? prev : next;
+    });
+
+    for (const accountId of Object.keys(autoWarmupRetryAfterRef.current)) {
+      if (!validAccountIds.has(accountId)) {
+        delete autoWarmupRetryAfterRef.current[accountId];
+      }
+    }
+  }, [accounts, error, loading]);
+
+  useEffect(() => {
+    autoWarmupLedgerRef.current = autoWarmupLedger;
+    try {
+      window.localStorage.setItem(
+        AUTO_WARMUP_LEDGER_STORAGE_KEY,
+        JSON.stringify(autoWarmupLedger)
+      );
+    } catch {
+      // Ignore storage errors; auto warm-up still works for the current session.
+    }
+  }, [autoWarmupLedger]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        AUTO_WARMUP_ALL_STORAGE_KEY,
+        String(autoWarmupAllEnabled)
+      );
+    } catch {
+      // Ignore storage errors; auto warm-up still works for the current session.
+    }
+  }, [autoWarmupAllEnabled]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        AUTO_WARMUP_ACCOUNTS_STORAGE_KEY,
+        JSON.stringify(Array.from(autoWarmupAccountIds))
+      );
+    } catch {
+      // Ignore storage errors; auto warm-up still works for the current session.
+    }
+  }, [autoWarmupAccountIds]);
 
   const handleTitlebarDrag = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -262,12 +430,12 @@ function App() {
     }
   };
 
-  const showWarmupToast = (message: string, isError = false) => {
+  const showWarmupToast = useCallback((message: string, isError = false) => {
     setWarmupToast({ message, isError });
     setTimeout(() => setWarmupToast(null), 2500);
-  };
+  }, []);
 
-  const formatWarmupError = (err: unknown) => {
+  const formatWarmupError = useCallback((err: unknown) => {
     if (!err) return "Unknown error";
     if (err instanceof Error && err.message) return err.message;
     if (typeof err === "string") return err;
@@ -276,12 +444,20 @@ function App() {
     } catch {
       return "Unknown error";
     }
-  };
+  }, []);
+
+  const markSuccessfulWarmup = useCallback((accountId: string, timestamp = Date.now()) => {
+    setAutoWarmupLedger((prev) => ({
+      ...prev,
+      [accountId]: { lastSuccessfulWarmupAt: timestamp },
+    }));
+  }, []);
 
   const handleWarmupAccount = async (accountId: string, accountName: string) => {
     try {
       setWarmingUpId(accountId);
       await warmupAccount(accountId);
+      markSuccessfulWarmup(accountId);
       showWarmupToast(`Warm-up sent for ${accountName}`);
     } catch (err) {
       console.error("Failed to warm up account:", err);
@@ -303,6 +479,14 @@ function App() {
         return;
       }
 
+      const warmedAt = Date.now();
+      const failedAccountIds = new Set(summary.failed_account_ids);
+      accounts.forEach((account) => {
+        if (!failedAccountIds.has(account.id)) {
+          markSuccessfulWarmup(account.id, warmedAt);
+        }
+      });
+
       if (summary.failed_account_ids.length === 0) {
         showWarmupToast(
           `Warm-up sent for all ${summary.warmed_accounts} account${
@@ -322,6 +506,154 @@ function App() {
       setIsWarmingAll(false);
     }
   };
+
+  const toggleAutoWarmupAccount = (accountId: string) => {
+    setAutoWarmupAccountIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(accountId)) {
+        next.delete(accountId);
+      } else {
+        next.add(accountId);
+      }
+      return next;
+    });
+  };
+
+  const isAutoWarmupDue = useCallback(
+    (accountId: string, usage: UsageInfo | undefined) => {
+      if (!usage || usage.error || !usage.primary_resets_at) return false;
+      if (isLimitFull(usage.secondary_used_percent)) return false;
+      if (!isPrimaryFullWindow(usage)) return false;
+
+      const lastSuccessfulWarmupAt = getLastSuccessfulWarmupAt(
+        autoWarmupLedgerRef.current,
+        accountId
+      );
+      if (
+        lastSuccessfulWarmupAt &&
+        Date.now() - lastSuccessfulWarmupAt < AUTO_WARMUP_MIN_SUCCESS_INTERVAL_MS
+      ) {
+        return false;
+      }
+
+      return true;
+    },
+    []
+  );
+
+  const getAutoWarmupLabel = useCallback(
+    (
+      usage: UsageInfo | undefined,
+      isEnabled: boolean,
+      isRunning: boolean
+    ) => {
+      if (isRunning) return "Warming...";
+      if (!isEnabled) return "Auto: off";
+      if (!usage || usage.error || !usage.primary_resets_at) return "Auto: on";
+
+      if (isLimitFull(usage.secondary_used_percent)) {
+        return "Waiting weekly reset";
+      }
+
+      return "Auto: on";
+    },
+    []
+  );
+
+  const headerAutoWarmupLabel = useMemo(() => {
+    if (autoWarmupRunningIds.size > 0) return "Auto warming...";
+    return autoWarmupAllEnabled || autoWarmupAccountIds.size > 0
+      ? "Auto: on"
+      : "Auto: off";
+  }, [autoWarmupAccountIds.size, autoWarmupAllEnabled, autoWarmupRunningIds]);
+
+  const backOffAutoWarmupRetry = useCallback((accountId: string) => {
+    autoWarmupRetryAfterRef.current[accountId] =
+      Date.now() + AUTO_WARMUP_RETRY_BACKOFF_MS;
+  }, []);
+
+  const runAutoWarmupForAccount = useCallback(
+    async (accountId: string, accountName: string) => {
+      setAutoWarmupRunningIds((prev) => new Set(prev).add(accountId));
+
+      try {
+        let freshUsage: UsageInfo;
+        try {
+          freshUsage = await refreshSingleUsage(accountId);
+        } catch (err) {
+          console.error("Auto warm-up usage refresh failed:", err);
+          backOffAutoWarmupRetry(accountId);
+          return;
+        }
+
+        if (freshUsage.error || !freshUsage.primary_resets_at) {
+          backOffAutoWarmupRetry(accountId);
+          return;
+        }
+        if (!isAutoWarmupDue(accountId, freshUsage)) {
+          return;
+        }
+
+        await warmupAccount(accountId);
+        markSuccessfulWarmup(accountId);
+        showWarmupToast(`Auto warm-up sent for ${accountName}`);
+      } catch (err) {
+        console.error("Auto warm-up failed:", err);
+        backOffAutoWarmupRetry(accountId);
+        showWarmupToast(
+          `Auto warm-up failed for ${accountName}: ${formatWarmupError(err)}`,
+          true
+        );
+      } finally {
+        setAutoWarmupRunningIds((prev) => {
+          const next = new Set(prev);
+          next.delete(accountId);
+          return next;
+        });
+      }
+    },
+    [
+      backOffAutoWarmupRetry,
+      formatWarmupError,
+      isAutoWarmupDue,
+      markSuccessfulWarmup,
+      refreshSingleUsage,
+      showWarmupToast,
+      warmupAccount,
+    ]
+  );
+
+  useEffect(() => {
+    if (!autoWarmupAllEnabled && autoWarmupAccountIds.size === 0) return;
+
+    const checkAutoWarmup = () => {
+      for (const account of accountsRef.current) {
+        const autoEnabled =
+          autoWarmupAllEnabled || autoWarmupAccountIdsRef.current.has(account.id);
+        if (!autoEnabled || autoWarmupRunningIdsRef.current.has(account.id)) continue;
+
+        const retryAfter = autoWarmupRetryAfterRef.current[account.id];
+        if (retryAfter && Date.now() < retryAfter) continue;
+
+        if (!isAutoWarmupDue(account.id, account.usage)) continue;
+
+        void runAutoWarmupForAccount(account.id, account.name);
+      }
+    };
+
+    checkAutoWarmup();
+    const interval = window.setInterval(
+      checkAutoWarmup,
+      AUTO_WARMUP_CHECK_INTERVAL_MS
+    );
+
+    return () => window.clearInterval(interval);
+  }, [
+    autoWarmupAccountIds.size,
+    autoWarmupAllEnabled,
+    isAutoWarmupDue,
+    runAutoWarmupForAccount,
+  ]);
 
   const handleExportSlimText = async () => {
     setConfigModalMode("slim_export");
@@ -630,6 +962,22 @@ function App() {
                 <span className={isWarmingAll ? "animate-pulse" : ""}>⚡</span>
               </button>
               <button
+                onClick={() => setAutoWarmupAllEnabled((prev) => !prev)}
+                disabled={accounts.length === 0}
+                className={`flex h-10 items-center justify-center rounded-lg px-3 text-xs font-semibold transition-colors disabled:opacity-50 shrink-0 whitespace-nowrap ${
+                  autoWarmupAllEnabled
+                    ? "bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-900/20 dark:text-emerald-300 dark:hover:bg-emerald-900/30"
+                    : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                }`}
+                title={
+                  autoWarmupAllEnabled
+                    ? "Disable auto warm-up for all accounts"
+                    : "Enable auto warm-up for all accounts"
+                }
+              >
+                {headerAutoWarmupLabel}
+              </button>
+              <button
                 onClick={() => setThemeMode((prev) => (prev === "dark" ? "light" : "dark"))}
                 className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 text-lg text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 shrink-0"
                 title={themeMode === "dark" ? "Switch to light mode" : "Switch to dark mode"}
@@ -754,9 +1102,23 @@ function App() {
                   onRename={(newName) => renameAccount(activeAccount.id, newName)}
                   switching={switchingId === activeAccount.id}
                   switchDisabled={hasRunningProcesses ?? false}
-                  warmingUp={isWarmingAll || warmingUpId === activeAccount.id}
+                  warmingUp={
+                    isWarmingAll ||
+                    warmingUpId === activeAccount.id ||
+                    autoWarmupRunningIds.has(activeAccount.id)
+                  }
                   masked={maskedAccounts.has(activeAccount.id)}
                   onToggleMask={() => toggleMask(activeAccount.id)}
+                  autoWarmupEnabled={
+                    autoWarmupAllEnabled || autoWarmupAccountIds.has(activeAccount.id)
+                  }
+                  autoWarmupManagedByAll={autoWarmupAllEnabled}
+                  autoWarmupLabel={getAutoWarmupLabel(
+                    activeAccount.usage,
+                    autoWarmupAllEnabled || autoWarmupAccountIds.has(activeAccount.id),
+                    autoWarmupRunningIds.has(activeAccount.id)
+                  )}
+                  onToggleAutoWarmup={() => toggleAutoWarmupAccount(activeAccount.id)}
                 />
               </section>
             )}
@@ -832,9 +1194,23 @@ function App() {
                       onRename={(newName) => renameAccount(account.id, newName)}
                       switching={switchingId === account.id}
                       switchDisabled={hasRunningProcesses ?? false}
-                      warmingUp={isWarmingAll || warmingUpId === account.id}
+                      warmingUp={
+                        isWarmingAll ||
+                        warmingUpId === account.id ||
+                        autoWarmupRunningIds.has(account.id)
+                      }
                       masked={maskedAccounts.has(account.id)}
                       onToggleMask={() => toggleMask(account.id)}
+                      autoWarmupEnabled={
+                        autoWarmupAllEnabled || autoWarmupAccountIds.has(account.id)
+                      }
+                      autoWarmupManagedByAll={autoWarmupAllEnabled}
+                      autoWarmupLabel={getAutoWarmupLabel(
+                        account.usage,
+                        autoWarmupAllEnabled || autoWarmupAccountIds.has(account.id),
+                        autoWarmupRunningIds.has(account.id)
+                      )}
+                      onToggleAutoWarmup={() => toggleAutoWarmupAccount(account.id)}
                     />
                   ))}
                 </div>

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -7,13 +7,17 @@ interface AccountCardProps {
   onSwitch: () => void;
   onWarmup: () => Promise<void>;
   onDelete: () => void;
-  onRefresh: () => Promise<void>;
+  onRefresh: () => Promise<unknown>;
   onRename: (newName: string) => Promise<void>;
   switching?: boolean;
   switchDisabled?: boolean;
   warmingUp?: boolean;
   masked?: boolean;
   onToggleMask?: () => void;
+  autoWarmupEnabled?: boolean;
+  autoWarmupManagedByAll?: boolean;
+  autoWarmupLabel?: string;
+  onToggleAutoWarmup?: () => void;
 }
 
 function formatLastRefresh(date: Date | null): string {
@@ -96,6 +100,10 @@ export function AccountCard({
   warmingUp,
   masked = false,
   onToggleMask,
+  autoWarmupEnabled = false,
+  autoWarmupManagedByAll = false,
+  autoWarmupLabel,
+  onToggleAutoWarmup,
 }: AccountCardProps) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastRefresh, setLastRefresh] = useState<Date | null>(
@@ -298,6 +306,26 @@ export function AccountCard({
         >
           ⚡
         </button>
+        {onToggleAutoWarmup && (
+          <button
+            onClick={onToggleAutoWarmup}
+            disabled={autoWarmupManagedByAll}
+            className={`px-3 py-2 text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
+              autoWarmupEnabled
+                ? "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300"
+                : "bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+            } disabled:opacity-60`}
+            title={
+              autoWarmupManagedByAll
+                ? "Auto warm-up is enabled for all accounts"
+                : autoWarmupEnabled
+                  ? "Disable auto warm-up for this account"
+                : "Enable auto warm-up for this account"
+            }
+          >
+            {autoWarmupLabel ?? `Auto: ${autoWarmupEnabled ? "on" : "off"}`}
+          </button>
+        )}
         <button
           onClick={handleRefresh}
           disabled={isRefreshing}

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -185,6 +185,7 @@ export function useAccounts() {
           a.id === accountId ? { ...a, usage, usageLoading: false } : a
         )
       );
+      return usage;
     } catch (err) {
       console.error("Failed to refresh single usage:", err);
       const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Adds automatic warm-up scheduling for ChatGPT accounts.

- Adds global and per-account auto warm-up controls
- Stores the last successful warm-up per account to avoid duplicate requests
- Re-checks fresh usage before sending an automatic warm-up
- Skips auto warm-up while the weekly quota is full
- Handles unused accounts whose 5h window resets back to a full window

Tested with:
- Weekly reset becoming available
- Unused account reaching the next 5h window
- Manual warm-up updating the scheduler state
- pnpm build