### PR TITLE
Add force close for blocking sessions

### DIFF
--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -5,6 +5,9 @@ use std::process::Command;
 #[cfg(windows)]
 use anyhow::Context;
 
+#[cfg(unix)]
+use std::collections::{HashMap, HashSet};
+
 #[cfg(windows)]
 use std::collections::HashSet;
 
@@ -40,6 +43,23 @@ pub struct CodexProcessInfo {
     pub pids: Vec<u32>,
 }
 
+/// Summary of a force-close operation for active Codex processes.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct KillCodexProcessesResult {
+    /// Number of active Codex sessions targeted before expanding child processes.
+    pub targeted_count: usize,
+    /// Process IDs that were successfully signalled for termination.
+    pub killed_pids: Vec<u32>,
+    /// Process IDs that could not be terminated.
+    pub failed_pids: Vec<u32>,
+}
+
+#[cfg(unix)]
+struct UnixProcessSnapshot {
+    children_by_parent: HashMap<u32, Vec<u32>>,
+    uid_by_pid: HashMap<u32, u32>,
+}
+
 /// Check for running Codex processes
 #[tauri::command]
 pub async fn check_codex_processes() -> Result<CodexProcessInfo, String> {
@@ -52,6 +72,268 @@ pub async fn check_codex_processes() -> Result<CodexProcessInfo, String> {
         can_switch: count == 0,
         pids,
     })
+}
+
+/// Force-close active Codex processes that currently block account switching.
+#[tauri::command]
+pub async fn kill_codex_processes() -> Result<KillCodexProcessesResult, String> {
+    tokio::task::spawn_blocking(kill_codex_processes_blocking)
+        .await
+        .map_err(|e| e.to_string())?
+}
+
+fn kill_codex_processes_blocking() -> Result<KillCodexProcessesResult, String> {
+    let (pids, _) = find_codex_processes().map_err(|e| e.to_string())?;
+    let targeted_count = pids.len();
+    let mut killed_pids = Vec::new();
+    let mut failed_pids = Vec::new();
+
+    #[cfg(target_os = "macos")]
+    let mut admin_targets: Vec<u32> = Vec::new();
+
+    #[cfg(unix)]
+    let snapshot = read_unix_process_snapshot();
+
+    #[cfg(unix)]
+    let targets = expand_process_targets(&pids, snapshot.as_ref());
+
+    #[cfg(windows)]
+    let targets = expand_process_targets(&pids);
+
+    #[cfg(target_os = "macos")]
+    let current_uid = current_unix_uid();
+
+    for pid in targets {
+        #[cfg(target_os = "macos")]
+        if snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.uid_by_pid.get(&pid).copied())
+            .zip(current_uid)
+            .is_some_and(|(owner_uid, current_uid)| owner_uid != current_uid)
+        {
+            admin_targets.push(pid);
+            continue;
+        }
+
+        if force_kill_process(pid) {
+            killed_pids.push(pid);
+        } else {
+            failed_pids.push(pid);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        admin_targets.extend(failed_pids.iter().copied());
+        admin_targets.sort_unstable();
+        admin_targets.dedup();
+
+        let mut still_failed = Vec::new();
+        if force_kill_processes_with_admin_privileges(&admin_targets) {
+            for pid in admin_targets.iter().copied() {
+                if process_exists(pid) {
+                    still_failed.push(pid);
+                } else if !killed_pids.contains(&pid) {
+                    killed_pids.push(pid);
+                }
+            }
+        } else {
+            still_failed.extend(
+                admin_targets
+                    .iter()
+                    .copied()
+                    .filter(|pid| process_exists(*pid)),
+            );
+        }
+        failed_pids = still_failed;
+    }
+
+    Ok(KillCodexProcessesResult {
+        targeted_count,
+        killed_pids,
+        failed_pids,
+    })
+}
+
+#[cfg(unix)]
+fn expand_process_targets(root_pids: &[u32], snapshot: Option<&UnixProcessSnapshot>) -> Vec<u32> {
+    let mut targets = Vec::new();
+    let mut visited = HashSet::new();
+
+    if let Some(snapshot) = snapshot {
+        for root_pid in root_pids {
+            let mut stack = snapshot
+                .children_by_parent
+                .get(root_pid)
+                .cloned()
+                .unwrap_or_default();
+            while let Some(pid) = stack.pop() {
+                if !visited.insert(pid) {
+                    continue;
+                }
+                targets.push(pid);
+
+                if let Some(children) = snapshot.children_by_parent.get(&pid) {
+                    stack.extend(children.iter().copied());
+                }
+            }
+        }
+    }
+
+    for root_pid in root_pids {
+        if visited.insert(*root_pid) {
+            targets.push(*root_pid);
+        }
+    }
+
+    targets
+}
+
+#[cfg(windows)]
+fn expand_process_targets(root_pids: &[u32]) -> Vec<u32> {
+    root_pids.to_vec()
+}
+
+#[cfg(unix)]
+fn read_unix_process_snapshot() -> Option<UnixProcessSnapshot> {
+    let output = Command::new("ps")
+        .args(["-axo", "pid=,ppid=,uid="])
+        .output()
+        .ok()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut children_by_parent = HashMap::new();
+    let mut uid_by_pid = HashMap::new();
+
+    for line in stdout.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(pid_str) = parts.next() else {
+            continue;
+        };
+        let Some(ppid_str) = parts.next() else {
+            continue;
+        };
+        let Some(uid_str) = parts.next() else {
+            continue;
+        };
+        let (Ok(pid), Ok(ppid), Ok(uid)) = (
+            pid_str.parse::<u32>(),
+            ppid_str.parse::<u32>(),
+            uid_str.parse::<u32>(),
+        ) else {
+            continue;
+        };
+
+        children_by_parent
+            .entry(ppid)
+            .or_insert_with(Vec::new)
+            .push(pid);
+        uid_by_pid.insert(pid, uid);
+    }
+
+    Some(UnixProcessSnapshot {
+        children_by_parent,
+        uid_by_pid,
+    })
+}
+
+fn force_kill_process(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let killed = Command::new("/bin/kill")
+            .arg("-9")
+            .arg(pid.to_string())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        return killed || !process_exists(pid);
+    }
+
+    #[cfg(windows)]
+    {
+        let killed = Command::new("taskkill")
+            .creation_flags(CREATE_NO_WINDOW)
+            .args(["/F", "/T", "/PID", &pid.to_string()])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        return killed || !process_exists(pid);
+    }
+
+    #[allow(unreachable_code)]
+    false
+}
+
+#[cfg(target_os = "macos")]
+fn force_kill_processes_with_admin_privileges(pids: &[u32]) -> bool {
+    if pids.is_empty() {
+        return true;
+    }
+
+    let pid_args = pids
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let script = format!(
+        r#"do shell script "for pid in {pid_args}; do /bin/kill -9 \"$pid\" 2>/dev/null || true; done" with administrator privileges with prompt "Codex Switcher needs permission to force close sudo/root Codex processes.""#
+    );
+
+    Command::new("/usr/bin/osascript")
+        .arg("-e")
+        .arg(script)
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "macos")]
+fn current_unix_uid() -> Option<u32> {
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8_lossy(&output.stdout)
+                    .trim()
+                    .parse::<u32>()
+                    .ok()
+            } else {
+                None
+            }
+        })
+}
+
+fn process_exists(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        return Command::new("ps")
+            .arg("-p")
+            .arg(pid.to_string())
+            .args(["-o", "pid="])
+            .output()
+            .map(|output| {
+                output.status.success()
+                    && String::from_utf8_lossy(&output.stdout)
+                        .split_whitespace()
+                        .any(|value| value == pid.to_string())
+            })
+            .unwrap_or(false);
+    }
+
+    #[cfg(windows)]
+    {
+        return Command::new("tasklist")
+            .creation_flags(CREATE_NO_WINDOW)
+            .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+            .output()
+            .map(|output| String::from_utf8_lossy(&output.stdout).contains(&pid.to_string()))
+            .unwrap_or(false);
+    }
+
+    #[allow(unreachable_code)]
+    false
 }
 
 /// Find all running codex processes. Returns (active_pids, background_count)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,9 +10,9 @@ use commands::{
     add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,
     export_accounts_full_encrypted_file, export_accounts_slim_text, get_active_account_info,
     get_masked_account_ids, get_usage, import_accounts_full_encrypted_file,
-    import_accounts_slim_text, list_accounts, refresh_account_metadata, refresh_all_accounts_usage,
-    rename_account, set_masked_account_ids, start_login, switch_account, warmup_account,
-    warmup_all_accounts,
+    import_accounts_slim_text, kill_codex_processes, list_accounts, refresh_account_metadata,
+    refresh_all_accounts_usage, rename_account, set_masked_account_ids, start_login,
+    switch_account, warmup_account, warmup_all_accounts,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -54,6 +54,7 @@ pub fn run() {
             warmup_all_accounts,
             // Process detection
             check_codex_processes,
+            kill_codex_processes,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -13,9 +13,9 @@ use crate::commands::{
     add_account_from_auth_json_text, add_account_from_file, cancel_login, check_codex_processes,
     complete_login, delete_account, export_accounts_full_encrypted_bytes,
     export_accounts_slim_text, get_active_account_info, get_masked_account_ids, get_usage,
-    import_accounts_full_encrypted_bytes, import_accounts_slim_text, list_accounts,
-    refresh_account_metadata, refresh_all_accounts_usage, rename_account, set_masked_account_ids,
-    start_login, switch_account, warmup_account, warmup_all_accounts,
+    import_accounts_full_encrypted_bytes, import_accounts_slim_text, kill_codex_processes,
+    list_accounts, refresh_account_metadata, refresh_all_accounts_usage, rename_account,
+    set_masked_account_ids, start_login, switch_account, warmup_account, warmup_all_accounts,
 };
 
 #[derive(Debug, Deserialize)]
@@ -191,6 +191,7 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
             to_json(set_masked_account_ids(args.ids).await?)
         }
         "check_codex_processes" => to_json(check_codex_processes().await?),
+        "kill_codex_processes" => to_json(kill_codex_processes().await?),
         _ => Err(format!("Unsupported web command: {command}")),
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAccounts } from "./hooks/useAccounts";
+import { useForceCloseCodexProcesses } from "./hooks/useForceCloseCodexProcesses";
 import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
 import type { CodexProcessInfo } from "./types";
 import {
@@ -277,6 +278,18 @@ function App() {
       return "Unknown error";
     }
   };
+
+  const {
+    forceCloseConfirmOpen,
+    setForceCloseConfirmOpen,
+    isForceClosingCodex,
+    forceCloseCodexProcesses,
+  } = useForceCloseCodexProcesses({
+    processCount: processInfo?.count ?? 0,
+    checkProcesses,
+    showToast: showWarmupToast,
+    formatError: formatWarmupError,
+  });
 
   const handleWarmupAccount = async (accountId: string, accountName: string) => {
     try {
@@ -567,22 +580,34 @@ function App() {
                     Codex Switcher
                   </h1>
                   {processInfo && (
-                    <span
-                      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs border ${hasRunningProcesses
-                          ? "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700"
-                          : "bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700"
-                        }`}
-                    >
+                    <div className="inline-flex items-center gap-1">
                       <span
-                        className={`inline-block w-1.5 h-1.5 rounded-full ${hasRunningProcesses ? "bg-amber-500" : "bg-green-500"
+                        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs border ${hasRunningProcesses
+                            ? "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-700"
+                            : "bg-green-50 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700"
                           }`}
-                      ></span>
-                      <span>
-                        {hasRunningProcesses
-                          ? `${processInfo.count} Codex running`
-                          : "0 Codex running"}
+                      >
+                        <span
+                          className={`inline-block w-1.5 h-1.5 rounded-full ${hasRunningProcesses ? "bg-amber-500" : "bg-green-500"
+                            }`}
+                        ></span>
+                        <span>
+                          {hasRunningProcesses
+                            ? `${processInfo.count} Codex running`
+                            : "0 Codex running"}
+                        </span>
                       </span>
-                    </span>
+                      {hasRunningProcesses && (
+                        <button
+                          onClick={() => setForceCloseConfirmOpen(true)}
+                          disabled={isForceClosingCodex}
+                          className="inline-flex items-center rounded-md border border-red-200 bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700 transition-colors hover:bg-red-100 disabled:opacity-50 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300 dark:hover:bg-red-900/30"
+                          title="Force close running Codex processes"
+                        >
+                          Force close
+                        </button>
+                      )}
+                    </div>
                   )}
                 </div>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
@@ -868,6 +893,48 @@ function App() {
       {deleteConfirmId && (
         <div className="fixed bottom-6 left-1/2 -translate-x-1/2 px-4 py-3 bg-red-600 text-white rounded-lg shadow-lg text-sm">
           Click delete again to confirm removal
+        </div>
+      )}
+
+      {forceCloseConfirmOpen && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl w-full max-w-md mx-4 shadow-xl">
+            <div className="p-5 border-b border-gray-100 dark:border-gray-800">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Force close running Codex processes?
+              </h2>
+            </div>
+            <div className="p-5 space-y-3">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                This will force close {processInfo?.count ?? 0} Codex process
+                {(processInfo?.count ?? 0) === 1 ? "" : "es"} that currently
+                block account switching.
+              </p>
+              <p className="text-sm text-red-600 dark:text-red-300">
+                Unsaved Codex work may be lost.
+              </p>
+            </div>
+            <div className="flex justify-end gap-3 p-5 border-t border-gray-100 dark:border-gray-800">
+              <button
+                onClick={() => setForceCloseConfirmOpen(false)}
+                disabled={isForceClosingCodex}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  void forceCloseCodexProcesses();
+                }}
+                disabled={isForceClosingCodex}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors disabled:opacity-50"
+              >
+                {isForceClosingCodex
+                  ? "Force closing..."
+                  : "Force close running Codex processes"}
+              </button>
+            </div>
+          </div>
         </div>
       )}
 

--- a/src/hooks/useForceCloseCodexProcesses.ts
+++ b/src/hooks/useForceCloseCodexProcesses.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from "react";
+import type { CodexProcessInfo } from "../types";
+import { invokeBackend } from "../lib/platform";
+
+interface KillCodexProcessesResult {
+  targeted_count: number;
+  killed_pids: number[];
+  failed_pids: number[];
+}
+
+interface UseForceCloseCodexProcessesOptions {
+  processCount: number;
+  checkProcesses: () => Promise<CodexProcessInfo | null>;
+  showToast: (message: string, isError?: boolean) => void;
+  formatError: (err: unknown) => string;
+}
+
+export function useForceCloseCodexProcesses({
+  processCount,
+  checkProcesses,
+  showToast,
+  formatError,
+}: UseForceCloseCodexProcessesOptions) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [isForceClosing, setIsForceClosing] = useState(false);
+
+  const forceCloseCodexProcesses = useCallback(async () => {
+    try {
+      setIsForceClosing(true);
+
+      const result = await invokeBackend<KillCodexProcessesResult>(
+        "kill_codex_processes"
+      );
+      const latestProcessInfo = await checkProcesses();
+      const remainingCount = latestProcessInfo?.count ?? 0;
+      const closedCount = Math.max(0, processCount - remainingCount);
+
+      if (result.targeted_count === 0) {
+        showToast("No running Codex processes found.");
+      } else if (remainingCount === 0) {
+        showToast(
+          `Force closed ${processCount} Codex session${
+            processCount === 1 ? "" : "s"
+          }.`
+        );
+      } else if (closedCount > 0) {
+        showToast(
+          `Force closed ${closedCount}/${processCount} Codex sessions. ${remainingCount} still running.`,
+          true
+        );
+      } else {
+        showToast(
+          `Could not force close ${remainingCount} Codex session${
+            remainingCount === 1 ? "" : "s"
+          }.`,
+          true
+        );
+      }
+    } catch (err) {
+      console.error("Failed to force close Codex processes:", err);
+      showToast(`Force close failed: ${formatError(err)}`, true);
+    } finally {
+      setConfirmOpen(false);
+      setIsForceClosing(false);
+    }
+  }, [checkProcesses, formatError, processCount, showToast]);
+
+  return {
+    forceCloseConfirmOpen: confirmOpen,
+    setForceCloseConfirmOpen: setConfirmOpen,
+    isForceClosingCodex: isForceClosing,
+    forceCloseCodexProcesses,
+  };
+}


### PR DESCRIPTION
Adds a guarded force-close action for running sessions that block account switching.

- Shows a force-close action next to the running session indicator
- Requires explicit confirmation before terminating processes
- Reports whether all sessions were closed or some are still running
- Expands process trees so child processes are included
- Supports macOS and Windows termination paths
- Uses an elevated macOS fallback for root-owned processes when needed
- Keeps the frontend behavior isolated in a dedicated hook

Tested with:
- macOS normal terminal session termination
- macOS sudo/root terminal session termination
- macOS Codex app session termination
- Windows Codex app force-close behavior
- cargo fmt --check
- cargo check
- pnpm build