### PR TITLE
Add configurable proxy support

### DIFF
--- a/src-tauri/src/api/usage.rs
+++ b/src-tauri/src/api/usage.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 
 use crate::auth::{ensure_chatgpt_tokens_fresh, refresh_chatgpt_tokens};
+use crate::settings::build_http_client;
 use crate::types::{
     AuthData, CreditStatusDetails, RateLimitDetails, RateLimitStatusPayload, RateLimitWindow,
     StoredAccount, UsageInfo,
@@ -225,7 +226,7 @@ async fn warmup_with_chatgpt_auth(account: &StoredAccount) -> Result<()> {
 }
 
 async fn warmup_with_api_key(api_key: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = build_http_client()?;
     let payload = build_warmup_payload(false, true);
     let response = client
         .post(format!("{OPENAI_API}/responses"))
@@ -335,7 +336,7 @@ async fn send_chatgpt_get_request(
     access_token: &str,
     chatgpt_account_id: Option<&str>,
 ) -> Result<reqwest::Response> {
-    let client = reqwest::Client::new();
+    let client = build_http_client()?;
     let headers = build_chatgpt_headers(access_token, chatgpt_account_id)?;
     println!("[Usage] Requesting: {url}");
 
@@ -352,7 +353,7 @@ async fn send_chatgpt_warmup_request(
     chatgpt_account_id: Option<&str>,
     stream: bool,
 ) -> Result<reqwest::Response> {
-    let client = reqwest::Client::new();
+    let client = build_http_client()?;
     let headers = build_chatgpt_headers(access_token, chatgpt_account_id)?;
     let payload = build_warmup_payload(stream, false);
 

--- a/src-tauri/src/auth/oauth_server.rs
+++ b/src-tauri/src/auth/oauth_server.rs
@@ -12,6 +12,7 @@ use sha2::{Digest, Sha256};
 use tiny_http::{Header, Request, Response, Server};
 use tokio::sync::oneshot;
 
+use crate::settings::build_http_client;
 use crate::types::{parse_chatgpt_id_token_claims, OAuthLoginInfo, StoredAccount};
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
@@ -93,7 +94,7 @@ async fn exchange_code_for_tokens(
     pkce: &PkceCodes,
     code: &str,
 ) -> Result<TokenResponse> {
-    let client = reqwest::Client::new();
+    let client = build_http_client()?;
 
     let body = format!(
         "grant_type=authorization_code&code={}&redirect_uri={}&client_id={}&code_verifier={}",

--- a/src-tauri/src/auth/token_refresh.rs
+++ b/src-tauri/src/auth/token_refresh.rs
@@ -3,14 +3,18 @@
 use anyhow::{Context, Result};
 use base64::Engine;
 use chrono::Utc;
-use tokio::time::{sleep, Duration};
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
 
-use super::{load_accounts, switch_to_account, update_account_chatgpt_tokens};
+use super::{get_account, load_accounts, switch_to_account, update_account_chatgpt_tokens};
+use crate::settings::build_http_client;
 use crate::types::{parse_chatgpt_id_token_claims, AuthData, StoredAccount};
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const EXPIRY_SKEW_SECONDS: i64 = 60;
+
+static TOKEN_REFRESH_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 #[derive(Debug, serde::Deserialize)]
 struct RefreshTokenResponse {
@@ -42,18 +46,45 @@ pub async fn ensure_chatgpt_tokens_fresh(account: &StoredAccount) -> Result<Stor
 
 /// Force-refresh ChatGPT OAuth tokens for an account.
 pub async fn refresh_chatgpt_tokens(account: &StoredAccount) -> Result<StoredAccount> {
-    let (current_id_token, current_refresh_token, current_account_id) = match &account.auth_data {
+    let original_refresh_token = match &account.auth_data {
         AuthData::ApiKey { .. } => return Ok(account.clone()),
-        AuthData::ChatGPT {
-            id_token,
-            refresh_token,
-            account_id,
-            ..
-        } => (id_token.clone(), refresh_token.clone(), account_id.clone()),
+        AuthData::ChatGPT { refresh_token, .. } => refresh_token.clone(),
     };
+
+    if original_refresh_token.is_empty() {
+        anyhow::bail!("Missing refresh token for account {}", account.name);
+    }
+
+    let _guard = token_refresh_lock().lock().await;
+    let account = get_account(&account.id)?.unwrap_or_else(|| account.clone());
+    let (current_id_token, current_access_token, current_refresh_token, current_account_id) =
+        match &account.auth_data {
+            AuthData::ApiKey { .. } => return Ok(account.clone()),
+            AuthData::ChatGPT {
+                id_token,
+                access_token,
+                refresh_token,
+                account_id,
+            } => (
+                id_token.clone(),
+                access_token.clone(),
+                refresh_token.clone(),
+                account_id.clone(),
+            ),
+        };
 
     if current_refresh_token.is_empty() {
         anyhow::bail!("Missing refresh token for account {}", account.name);
+    }
+
+    if current_refresh_token != original_refresh_token
+        && !token_expired_or_near_expiry(&current_access_token)
+    {
+        println!(
+            "[Auth] Account {} was already refreshed by another request",
+            account.name
+        );
+        return Ok(account);
     }
 
     let refreshed = refresh_tokens_with_refresh_token(&current_refresh_token).await?;
@@ -138,44 +169,20 @@ fn parse_jwt_exp(token: &str) -> Option<i64> {
 }
 
 async fn refresh_tokens_with_refresh_token(refresh_token: &str) -> Result<RefreshTokenResponse> {
-    let client = reqwest::Client::new();
+    let client = build_http_client()?;
     let body = format!(
         "grant_type=refresh_token&refresh_token={}&client_id={}",
         urlencoding::encode(refresh_token),
         urlencoding::encode(CLIENT_ID),
     );
 
-    let mut last_send_error = None;
-    let mut response = None;
-
-    for attempt in 1..=3u8 {
-        match client
-            .post(format!("{DEFAULT_ISSUER}/oauth/token"))
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .body(body.clone())
-            .send()
-            .await
-        {
-            Ok(resp) => {
-                response = Some(resp);
-                break;
-            }
-            Err(err) => {
-                last_send_error = Some(err);
-                if attempt < 3 {
-                    sleep(Duration::from_millis(250 * u64::from(attempt))).await;
-                }
-            }
-        }
-    }
-
-    let response = match response {
-        Some(resp) => resp,
-        None => {
-            let err = last_send_error.context("Failed to send token refresh request")?;
-            return Err(err.into());
-        }
-    };
+    let response = client
+        .post(format!("{DEFAULT_ISSUER}/oauth/token"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .context("Failed to send token refresh request")?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -187,4 +194,8 @@ async fn refresh_tokens_with_refresh_token(refresh_token: &str) -> Result<Refres
         .json::<RefreshTokenResponse>()
         .await
         .context("Failed to parse token refresh response")
+}
+
+fn token_refresh_lock() -> &'static Mutex<()> {
+    TOKEN_REFRESH_LOCK.get_or_init(|| Mutex::new(()))
 }

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -5,6 +5,10 @@ use crate::auth::{
     import_from_auth_json, import_from_auth_json_contents, load_accounts, remove_account,
     save_accounts, set_active_account, switch_to_account, touch_account,
 };
+use crate::settings::{
+    load_settings as load_app_settings, replace_proxy_settings, validate_proxy_settings,
+    ProxySettings,
+};
 use crate::types::{AccountInfo, AccountsStore, AuthData, ImportAccountsSummary, StoredAccount};
 
 use anyhow::Context;
@@ -29,12 +33,14 @@ use std::os::windows::process::CommandExt;
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 const SLIM_EXPORT_PREFIX: &str = "css1.";
-const SLIM_FORMAT_VERSION: u8 = 1;
+const SLIM_FORMAT_VERSION: u8 = 2;
+const SLIM_MIN_FORMAT_VERSION: u8 = 1;
 const SLIM_AUTH_API_KEY: u8 = 0;
 const SLIM_AUTH_CHATGPT: u8 = 1;
 
 const FULL_FILE_MAGIC: &[u8; 4] = b"CSWF";
 const FULL_FILE_VERSION: u8 = 1;
+const FULL_BACKUP_PAYLOAD_VERSION: u8 = 1;
 const FULL_SALT_LEN: usize = 16;
 const FULL_NONCE_LEN: usize = 24;
 const FULL_KDF_ITERATIONS: u32 = 210_000;
@@ -50,6 +56,8 @@ struct SlimPayload {
     version: u8,
     #[serde(rename = "a", skip_serializing_if = "Option::is_none")]
     active_name: Option<String>,
+    #[serde(rename = "p", skip_serializing_if = "Option::is_none")]
+    proxy: Option<ProxySettings>,
     #[serde(rename = "c")]
     accounts: Vec<SlimAccountPayload>,
 }
@@ -64,6 +72,14 @@ struct SlimAccountPayload {
     api_key: Option<String>,
     #[serde(rename = "r", skip_serializing_if = "Option::is_none")]
     refresh_token: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct FullBackupPayload {
+    version: u8,
+    accounts: AccountsStore,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    proxy: Option<ProxySettings>,
 }
 
 /// List all accounts with their info
@@ -187,7 +203,8 @@ pub async fn rename_account(account_id: String, new_name: String) -> Result<(), 
 #[tauri::command]
 pub async fn export_accounts_slim_text() -> Result<String, String> {
     let store = load_accounts().map_err(|e| e.to_string())?;
-    encode_slim_payload_from_store(&store).map_err(|e| e.to_string())
+    let proxy = load_app_settings().map_err(|e| e.to_string())?.proxy;
+    encode_slim_payload_from_store(&store, proxy).map_err(|e| e.to_string())
 }
 
 /// Import minimal account config from a compact text string, skipping existing accounts.
@@ -195,6 +212,10 @@ pub async fn export_accounts_slim_text() -> Result<String, String> {
 pub async fn import_accounts_slim_text(payload: String) -> Result<ImportAccountsSummary, String> {
     let slim_payload = decode_slim_payload(&payload).map_err(|e| format!("{e:#}"))?;
     let total_in_payload = slim_payload.accounts.len();
+    let imported_proxy = slim_payload.proxy.clone();
+    if let Some(proxy) = imported_proxy.clone() {
+        replace_proxy_settings(Some(proxy)).map_err(|e| e.to_string())?;
+    }
 
     let current = load_accounts().map_err(|e| e.to_string())?;
     let existing_names: HashSet<String> = current.accounts.iter().map(|a| a.name.clone()).collect();
@@ -221,8 +242,9 @@ pub async fn import_accounts_slim_text(payload: String) -> Result<ImportAccounts
 #[tauri::command]
 pub async fn export_accounts_full_encrypted_file(path: String) -> Result<(), String> {
     let store = load_accounts().map_err(|e| e.to_string())?;
-    let encrypted =
-        encode_full_encrypted_store(&store, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())?;
+    let proxy = load_app_settings().map_err(|e| e.to_string())?.proxy;
+    let encrypted = encode_full_encrypted_store(&store, proxy, FULL_PRESET_PASSPHRASE)
+        .map_err(|e| e.to_string())?;
     write_encrypted_file(&path, &encrypted).map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -230,7 +252,8 @@ pub async fn export_accounts_full_encrypted_file(path: String) -> Result<(), Str
 /// Export full account config as encrypted bytes for browser clients.
 pub async fn export_accounts_full_encrypted_bytes() -> Result<Vec<u8>, String> {
     let store = load_accounts().map_err(|e| e.to_string())?;
-    encode_full_encrypted_store(&store, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())
+    let proxy = load_app_settings().map_err(|e| e.to_string())?.proxy;
+    encode_full_encrypted_store(&store, proxy, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())
 }
 
 /// Import full account config from an encrypted file, skipping existing accounts.
@@ -239,13 +262,16 @@ pub async fn import_accounts_full_encrypted_file(
     path: String,
 ) -> Result<ImportAccountsSummary, String> {
     let encrypted = read_encrypted_file(&path).map_err(|e| e.to_string())?;
-    let imported = decode_full_encrypted_store(&encrypted, FULL_PRESET_PASSPHRASE)
+    let imported = decode_full_encrypted_backup(&encrypted, FULL_PRESET_PASSPHRASE)
         .map_err(|e| e.to_string())?;
-    validate_imported_store(&imported).map_err(|e| e.to_string())?;
+    validate_imported_store(&imported.accounts).map_err(|e| e.to_string())?;
 
     let current = load_accounts().map_err(|e| e.to_string())?;
-    let (merged, summary) = merge_accounts_store(current, imported);
+    let (merged, summary) = merge_accounts_store(current, imported.accounts);
     save_accounts(&merged).map_err(|e| e.to_string())?;
+    if let Some(proxy) = imported.proxy {
+        replace_proxy_settings(Some(proxy)).map_err(|e| e.to_string())?;
+    }
     Ok(summary)
 }
 
@@ -254,12 +280,15 @@ pub async fn import_accounts_full_encrypted_bytes(
     bytes: Vec<u8>,
 ) -> Result<ImportAccountsSummary, String> {
     let imported =
-        decode_full_encrypted_store(&bytes, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())?;
-    validate_imported_store(&imported).map_err(|e| e.to_string())?;
+        decode_full_encrypted_backup(&bytes, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())?;
+    validate_imported_store(&imported.accounts).map_err(|e| e.to_string())?;
 
     let current = load_accounts().map_err(|e| e.to_string())?;
-    let (merged, summary) = merge_accounts_store(current, imported);
+    let (merged, summary) = merge_accounts_store(current, imported.accounts);
     save_accounts(&merged).map_err(|e| e.to_string())?;
+    if let Some(proxy) = imported.proxy {
+        replace_proxy_settings(Some(proxy)).map_err(|e| e.to_string())?;
+    }
     Ok(summary)
 }
 
@@ -328,7 +357,10 @@ fn find_antigravity_processes() -> anyhow::Result<Vec<u32>> {
     Ok(pids)
 }
 
-fn encode_slim_payload_from_store(store: &AccountsStore) -> anyhow::Result<String> {
+fn encode_slim_payload_from_store(
+    store: &AccountsStore,
+    proxy: Option<ProxySettings>,
+) -> anyhow::Result<String> {
     let active_name = store.active_account_id.as_ref().and_then(|active_id| {
         store
             .accounts
@@ -359,6 +391,7 @@ fn encode_slim_payload_from_store(store: &AccountsStore) -> anyhow::Result<Strin
     let payload = SlimPayload {
         version: SLIM_FORMAT_VERSION,
         active_name,
+        proxy,
         accounts: slim_accounts,
     };
 
@@ -396,7 +429,7 @@ fn decode_slim_payload(payload: &str) -> anyhow::Result<SlimPayload> {
 }
 
 fn validate_slim_payload(payload: &SlimPayload) -> anyhow::Result<()> {
-    if payload.version != SLIM_FORMAT_VERSION {
+    if !(SLIM_MIN_FORMAT_VERSION..=SLIM_FORMAT_VERSION).contains(&payload.version) {
         anyhow::bail!("Unsupported slim payload version: {}", payload.version);
     }
 
@@ -447,6 +480,10 @@ fn validate_slim_payload(payload: &SlimPayload) -> anyhow::Result<()> {
         if !names.contains(active_name) {
             anyhow::bail!("Slim import references missing active account: {active_name}");
         }
+    }
+
+    if let Some(proxy) = &payload.proxy {
+        validate_proxy_settings(proxy)?;
     }
 
     Ok(())
@@ -525,9 +562,22 @@ async fn restore_slim_accounts(
     Ok(restored)
 }
 
-fn encode_full_encrypted_store(store: &AccountsStore, passphrase: &str) -> anyhow::Result<Vec<u8>> {
-    let json = serde_json::to_vec(store).context("Failed to serialize account store")?;
-    let compressed = compress_bytes(&json).context("Failed to compress account store")?;
+fn encode_full_encrypted_store(
+    store: &AccountsStore,
+    proxy: Option<ProxySettings>,
+    passphrase: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let payload = FullBackupPayload {
+        version: FULL_BACKUP_PAYLOAD_VERSION,
+        accounts: store.clone(),
+        proxy,
+    };
+    let json = serde_json::to_vec(&payload).context("Failed to serialize backup payload")?;
+    encode_full_encrypted_json(&json, passphrase)
+}
+
+fn encode_full_encrypted_json(json: &[u8], passphrase: &str) -> anyhow::Result<Vec<u8>> {
+    let compressed = compress_bytes(json).context("Failed to compress backup payload")?;
 
     let mut salt = [0u8; FULL_SALT_LEN];
     rand::rng().fill_bytes(&mut salt);
@@ -551,10 +601,10 @@ fn encode_full_encrypted_store(store: &AccountsStore, passphrase: &str) -> anyho
     Ok(out)
 }
 
-fn decode_full_encrypted_store(
+fn decode_full_encrypted_backup(
     file_bytes: &[u8],
     passphrase: &str,
-) -> anyhow::Result<AccountsStore> {
+) -> anyhow::Result<FullBackupPayload> {
     if file_bytes.len() as u64 > MAX_IMPORT_FILE_BYTES {
         anyhow::bail!("Encrypted file is too large");
     }
@@ -592,10 +642,30 @@ fn decode_full_encrypted_store(
     let json = decompress_bytes_with_limit(&compressed, MAX_IMPORT_JSON_BYTES)
         .context("Failed to decompress decrypted payload")?;
 
-    let store: AccountsStore =
-        serde_json::from_slice(&json).context("Failed to parse decrypted account payload")?;
+    let payload = match serde_json::from_slice::<FullBackupPayload>(&json) {
+        Ok(payload) => payload,
+        Err(_) => FullBackupPayload {
+            version: FULL_BACKUP_PAYLOAD_VERSION,
+            accounts: serde_json::from_slice(&json)
+                .context("Failed to parse decrypted account payload")?,
+            proxy: None,
+        },
+    };
 
-    Ok(store)
+    validate_full_backup_payload(&payload)?;
+    Ok(payload)
+}
+
+fn validate_full_backup_payload(payload: &FullBackupPayload) -> anyhow::Result<()> {
+    if payload.version != FULL_BACKUP_PAYLOAD_VERSION {
+        anyhow::bail!("Unsupported backup payload version: {}", payload.version);
+    }
+
+    if let Some(proxy) = &payload.proxy {
+        validate_proxy_settings(proxy)?;
+    }
+
+    Ok(())
 }
 
 fn derive_encryption_key(passphrase: &str, salt: &[u8]) -> [u8; 32] {
@@ -735,4 +805,87 @@ pub async fn get_masked_account_ids() -> Result<Vec<String>, String> {
 #[tauri::command]
 pub async fn set_masked_account_ids(ids: Vec<String>) -> Result<(), String> {
     crate::auth::storage::set_masked_account_ids(ids).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        compress_bytes, decode_full_encrypted_backup, decode_slim_payload,
+        encode_full_encrypted_json, encode_full_encrypted_store, encode_slim_payload_from_store,
+        FULL_PRESET_PASSPHRASE, SLIM_AUTH_API_KEY, SLIM_EXPORT_PREFIX,
+    };
+    use crate::settings::ProxySettings;
+    use crate::types::AccountsStore;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+    fn test_proxy() -> ProxySettings {
+        ProxySettings {
+            enabled: true,
+            host: "192.0.2.10".to_string(),
+            port: 8000,
+            username: Some("user".to_string()),
+            password: Some("pass".to_string()),
+        }
+    }
+
+    #[test]
+    fn slim_backup_round_trips_structured_proxy_settings() {
+        let store = AccountsStore::default();
+        let proxy = test_proxy();
+
+        let encoded = encode_slim_payload_from_store(&store, Some(proxy.clone())).unwrap();
+        let decoded = decode_slim_payload(&encoded).unwrap();
+
+        assert_eq!(decoded.proxy, Some(proxy));
+    }
+
+    #[test]
+    fn slim_import_accepts_v1_payload_without_proxy() {
+        let payload = super::SlimPayload {
+            version: 1,
+            active_name: None,
+            proxy: None,
+            accounts: vec![super::SlimAccountPayload {
+                name: "api".to_string(),
+                auth_type: SLIM_AUTH_API_KEY,
+                api_key: Some("sk-test".to_string()),
+                refresh_token: None,
+            }],
+        };
+        let json = serde_json::to_vec(&payload).unwrap();
+        let compressed = compress_bytes(&json).unwrap();
+        let encoded = format!("{SLIM_EXPORT_PREFIX}{}", URL_SAFE_NO_PAD.encode(compressed));
+
+        let decoded = decode_slim_payload(&encoded).unwrap();
+
+        assert_eq!(decoded.version, 1);
+        assert_eq!(decoded.proxy, None);
+        assert_eq!(decoded.accounts.len(), 1);
+    }
+
+    #[test]
+    fn full_backup_round_trips_structured_proxy_settings() {
+        let store = AccountsStore::default();
+        let proxy = test_proxy();
+
+        let encrypted =
+            encode_full_encrypted_store(&store, Some(proxy.clone()), FULL_PRESET_PASSPHRASE)
+                .unwrap();
+        let decoded = decode_full_encrypted_backup(&encrypted, FULL_PRESET_PASSPHRASE).unwrap();
+
+        assert_eq!(decoded.accounts.accounts.len(), 0);
+        assert_eq!(decoded.proxy, Some(proxy));
+    }
+
+    #[test]
+    fn full_import_accepts_legacy_account_store_payload_without_proxy() {
+        let store = AccountsStore::default();
+        let json = serde_json::to_vec(&store).unwrap();
+        let encrypted = encode_full_encrypted_json(&json, FULL_PRESET_PASSPHRASE).unwrap();
+
+        let decoded = decode_full_encrypted_backup(&encrypted, FULL_PRESET_PASSPHRASE).unwrap();
+
+        assert_eq!(decoded.accounts.accounts.len(), 0);
+        assert_eq!(decoded.proxy, None);
+    }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,9 +3,11 @@
 pub mod account;
 pub mod oauth;
 pub mod process;
+pub mod settings;
 pub mod usage;
 
 pub use account::*;
 pub use oauth::*;
 pub use process::*;
+pub use settings::*;
 pub use usage::*;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,0 +1,65 @@
+//! Application settings Tauri commands.
+
+use std::time::Duration;
+
+use crate::settings::{
+    build_reqwest_proxy, clear_proxy_settings as clear_stored_proxy_settings,
+    get_proxy_settings_info, load_settings, parse_proxy_settings,
+    set_proxy_settings as save_proxy_settings, ProxySettingsInfo,
+};
+
+const PROXY_TEST_URL: &str = "https://auth.openai.com/.well-known/openid-configuration";
+
+#[tauri::command]
+pub async fn get_proxy_settings() -> Result<ProxySettingsInfo, String> {
+    get_proxy_settings_info().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn set_proxy_settings(
+    proxy: Option<String>,
+    enabled: bool,
+) -> Result<ProxySettingsInfo, String> {
+    save_proxy_settings(proxy, enabled).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn clear_proxy_settings() -> Result<ProxySettingsInfo, String> {
+    clear_stored_proxy_settings().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn test_proxy_settings(proxy: Option<String>) -> Result<(), String> {
+    let proxy_settings = match proxy
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(value) => parse_proxy_settings(value).map_err(|e| e.to_string())?,
+        None => load_settings()
+            .map_err(|e| e.to_string())?
+            .proxy
+            .ok_or_else(|| "Proxy is not configured".to_string())?,
+    };
+
+    let client = reqwest::Client::builder()
+        .proxy(build_reqwest_proxy(&proxy_settings).map_err(|e| e.to_string())?)
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("Failed to build proxy test client: {e}"))?;
+
+    let response = client
+        .get(PROXY_TEST_URL)
+        .send()
+        .await
+        .map_err(|e| format!("Proxy test request failed: {e}"))?;
+
+    if !response.status().is_success() {
+        return Err(format!(
+            "Proxy test failed with status {}",
+            response.status()
+        ));
+    }
+
+    Ok(())
+}

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -4,8 +4,12 @@ use crate::api::usage::{
     fetch_chatgpt_account_metadata, get_account_usage, refresh_all_usage,
     warmup_account as send_warmup,
 };
-use crate::auth::{get_account, load_accounts, refresh_chatgpt_tokens, update_account_metadata};
+use crate::auth::{
+    ensure_chatgpt_tokens_fresh, get_account, load_accounts, refresh_chatgpt_tokens,
+    update_account_metadata,
+};
 use crate::types::{AccountInfo, AuthData, UsageInfo, WarmupSummary};
+use anyhow::Error as AnyhowError;
 use futures::{stream, StreamExt};
 
 /// Get usage info for a specific account
@@ -18,8 +22,9 @@ pub async fn get_usage(account_id: String) -> Result<UsageInfo, String> {
     get_account_usage(&account).await.map_err(|e| e.to_string())
 }
 
-/// Force-refresh account metadata for a specific account.
-/// For ChatGPT accounts this refreshes OAuth tokens and pulls live subscription metadata.
+/// Refresh account metadata for a specific account.
+/// For ChatGPT accounts this only refreshes OAuth tokens when they are expired
+/// or when the metadata endpoint rejects the current access token.
 /// For API key accounts this is a no-op.
 #[tauri::command]
 pub async fn refresh_account_metadata(account_id: String) -> Result<AccountInfo, String> {
@@ -30,12 +35,21 @@ pub async fn refresh_account_metadata(account_id: String) -> Result<AccountInfo,
     let updated = match &account.auth_data {
         AuthData::ApiKey { .. } => account,
         AuthData::ChatGPT { .. } => {
-            let refreshed = refresh_chatgpt_tokens(&account)
+            let fresh_account = ensure_chatgpt_tokens_fresh(&account)
                 .await
                 .map_err(|e| e.to_string())?;
-            let live_metadata = fetch_chatgpt_account_metadata(&refreshed)
-                .await
-                .map_err(|e| e.to_string())?;
+            let live_metadata = match fetch_chatgpt_account_metadata(&fresh_account).await {
+                Ok(metadata) => metadata,
+                Err(err) if is_unauthorized_error(&err) => {
+                    let refreshed = refresh_chatgpt_tokens(&fresh_account)
+                        .await
+                        .map_err(|e| e.to_string())?;
+                    fetch_chatgpt_account_metadata(&refreshed)
+                        .await
+                        .map_err(|e| e.to_string())?
+                }
+                Err(err) => return Err(err.to_string()),
+            };
 
             update_account_metadata(
                 &account_id,
@@ -51,6 +65,11 @@ pub async fn refresh_account_metadata(account_id: String) -> Result<AccountInfo,
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();
     Ok(AccountInfo::from_stored(&updated, active_id))
+}
+
+fn is_unauthorized_error(err: &AnyhowError) -> bool {
+    err.chain()
+        .any(|cause| cause.to_string().contains("401 Unauthorized"))
 }
 
 /// Refresh usage info for all accounts
@@ -98,4 +117,25 @@ pub async fn warmup_all_accounts() -> Result<WarmupSummary, String> {
         warmed_accounts,
         failed_account_ids,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_unauthorized_error;
+
+    #[test]
+    fn detects_unauthorized_metadata_error() {
+        let err = anyhow::anyhow!(
+            "Accounts check API error: 401 Unauthorized - {{\"error\":\"expired\"}}"
+        );
+
+        assert!(is_unauthorized_error(&err));
+    }
+
+    #[test]
+    fn ignores_non_unauthorized_metadata_error() {
+        let err = anyhow::anyhow!("Accounts check API error: 500 Internal Server Error");
+
+        assert!(!is_unauthorized_error(&err));
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,20 +3,26 @@
 pub mod api;
 pub mod auth;
 pub mod commands;
+pub mod settings;
 pub mod types;
 pub mod web;
 
 use commands::{
-    add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,
-    export_accounts_full_encrypted_file, export_accounts_slim_text, get_active_account_info,
-    get_masked_account_ids, get_usage, import_accounts_full_encrypted_file,
-    import_accounts_slim_text, list_accounts, refresh_account_metadata, refresh_all_accounts_usage,
-    rename_account, set_masked_account_ids, start_login, switch_account, warmup_account,
+    add_account_from_file, cancel_login, check_codex_processes, clear_proxy_settings,
+    complete_login, delete_account, export_accounts_full_encrypted_file, export_accounts_slim_text,
+    get_active_account_info, get_masked_account_ids, get_proxy_settings, get_usage,
+    import_accounts_full_encrypted_file, import_accounts_slim_text, list_accounts,
+    refresh_account_metadata, refresh_all_accounts_usage, rename_account, set_masked_account_ids,
+    set_proxy_settings, start_login, switch_account, test_proxy_settings, warmup_account,
     warmup_all_accounts,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    if let Err(err) = settings::apply_stored_proxy_environment() {
+        eprintln!("[Settings] Failed to apply stored proxy settings: {err}");
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
@@ -42,6 +48,11 @@ pub fn run() {
             // Masked accounts
             get_masked_account_ids,
             set_masked_account_ids,
+            // Settings
+            get_proxy_settings,
+            set_proxy_settings,
+            clear_proxy_settings,
+            test_proxy_settings,
             // OAuth
             start_login,
             complete_login,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,0 +1,530 @@
+//! Application settings storage and proxy helpers.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result};
+use reqwest::Proxy;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::auth::get_config_dir;
+
+const PROXY_ENV_KEYS: [&str; 6] = [
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+];
+
+static ORIGINAL_PROXY_ENV: OnceLock<HashMap<&'static str, Option<OsString>>> = OnceLock::new();
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSettings {
+    pub version: u32,
+    #[serde(default)]
+    pub proxy: Option<ProxySettings>,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            proxy: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProxySettings {
+    pub enabled: bool,
+    pub host: String,
+    pub port: u16,
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProxySettingsInfo {
+    pub enabled: bool,
+    pub configured: bool,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub username: Option<String>,
+    pub has_password: bool,
+}
+
+impl ProxySettingsInfo {
+    fn empty() -> Self {
+        Self {
+            enabled: false,
+            configured: false,
+            host: None,
+            port: None,
+            username: None,
+            has_password: false,
+        }
+    }
+}
+
+impl From<Option<ProxySettings>> for ProxySettingsInfo {
+    fn from(proxy: Option<ProxySettings>) -> Self {
+        match proxy {
+            Some(proxy) => Self {
+                enabled: proxy.enabled,
+                configured: true,
+                host: Some(proxy.host),
+                port: Some(proxy.port),
+                username: proxy.username,
+                has_password: proxy.password.is_some(),
+            },
+            None => Self::empty(),
+        }
+    }
+}
+
+pub fn get_settings_file() -> Result<PathBuf> {
+    Ok(get_config_dir()?.join("settings.json"))
+}
+
+pub fn load_settings() -> Result<AppSettings> {
+    let path = get_settings_file()?;
+    if !path.exists() {
+        return Ok(AppSettings::default());
+    }
+
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read settings file: {}", path.display()))?;
+    let settings = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse settings file: {}", path.display()))?;
+    Ok(settings)
+}
+
+pub fn save_settings(settings: &AppSettings) -> Result<()> {
+    let path = get_settings_file()?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
+    }
+
+    let content = serde_json::to_string_pretty(settings).context("Failed to serialize settings")?;
+    fs::write(&path, content)
+        .with_context(|| format!("Failed to write settings file: {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&path, perms)?;
+    }
+
+    Ok(())
+}
+
+pub fn get_proxy_settings_info() -> Result<ProxySettingsInfo> {
+    Ok(ProxySettingsInfo::from(load_settings()?.proxy))
+}
+
+pub fn set_proxy_settings(proxy_input: Option<String>, enabled: bool) -> Result<ProxySettingsInfo> {
+    let mut settings = load_settings()?;
+
+    if let Some(proxy_input) = proxy_input {
+        let trimmed = proxy_input.trim();
+        if !trimmed.is_empty() {
+            let mut proxy = parse_proxy_settings(trimmed)?;
+            proxy.enabled = enabled;
+            settings.proxy = Some(proxy);
+        } else if let Some(proxy) = settings.proxy.as_mut() {
+            proxy.enabled = enabled;
+        } else if enabled {
+            anyhow::bail!("Proxy string is required to enable proxy");
+        }
+    } else if let Some(proxy) = settings.proxy.as_mut() {
+        proxy.enabled = enabled;
+    } else if enabled {
+        anyhow::bail!("Proxy string is required to enable proxy");
+    }
+
+    save_settings(&settings)?;
+    apply_proxy_environment(settings.proxy.as_ref())?;
+    Ok(ProxySettingsInfo::from(settings.proxy))
+}
+
+pub fn clear_proxy_settings() -> Result<ProxySettingsInfo> {
+    let mut settings = load_settings()?;
+    settings.proxy = None;
+    save_settings(&settings)?;
+    apply_proxy_environment(None)?;
+    Ok(ProxySettingsInfo::empty())
+}
+
+pub fn replace_proxy_settings(proxy: Option<ProxySettings>) -> Result<ProxySettingsInfo> {
+    if let Some(proxy) = &proxy {
+        validate_proxy_settings(proxy)?;
+    }
+
+    let mut settings = load_settings()?;
+    settings.proxy = proxy;
+    save_settings(&settings)?;
+    apply_proxy_environment(settings.proxy.as_ref())?;
+    Ok(ProxySettingsInfo::from(settings.proxy))
+}
+
+pub fn apply_stored_proxy_environment() -> Result<()> {
+    apply_proxy_environment(load_settings()?.proxy.as_ref())
+}
+
+pub fn build_http_client() -> Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder();
+
+    if let Some(proxy) = load_settings()?.proxy.filter(|proxy| proxy.enabled) {
+        builder = builder.proxy(build_reqwest_proxy(&proxy)?);
+    }
+
+    builder.build().context("Failed to build HTTP client")
+}
+
+pub fn build_reqwest_proxy(proxy: &ProxySettings) -> Result<Proxy> {
+    let proxy_url = build_proxy_url(proxy, false)?;
+    let reqwest_proxy = Proxy::all(&proxy_url)
+        .with_context(|| format!("Failed to configure HTTP proxy: {proxy_url}"))?;
+
+    match (&proxy.username, &proxy.password) {
+        (Some(username), Some(password)) => Ok(reqwest_proxy.basic_auth(username, password)),
+        (None, None) => Ok(reqwest_proxy),
+        _ => anyhow::bail!("Proxy username and password must be provided together"),
+    }
+}
+
+fn apply_proxy_environment(proxy: Option<&ProxySettings>) -> Result<()> {
+    let original_env = ORIGINAL_PROXY_ENV.get_or_init(|| {
+        PROXY_ENV_KEYS
+            .into_iter()
+            .map(|key| (key, std::env::var_os(key)))
+            .collect()
+    });
+
+    match proxy.filter(|proxy| proxy.enabled) {
+        Some(proxy) => {
+            let proxy_url = build_proxy_url(proxy, true)?;
+            for key in PROXY_ENV_KEYS {
+                std::env::set_var(key, &proxy_url);
+            }
+        }
+        None => {
+            for key in PROXY_ENV_KEYS {
+                match original_env.get(key).and_then(|value| value.as_ref()) {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn build_proxy_url(proxy: &ProxySettings, include_auth: bool) -> Result<String> {
+    let host = if proxy.host.contains(':') && !proxy.host.starts_with('[') {
+        format!("[{}]", proxy.host)
+    } else {
+        proxy.host.clone()
+    };
+    let mut url = Url::parse(&format!("http://{host}:{}", proxy.port))
+        .context("Failed to build proxy URL")?;
+
+    if include_auth {
+        if let (Some(username), Some(password)) = (&proxy.username, &proxy.password) {
+            url.set_username(username)
+                .map_err(|_| anyhow::anyhow!("Invalid proxy username"))?;
+            url.set_password(Some(password))
+                .map_err(|_| anyhow::anyhow!("Invalid proxy password"))?;
+        }
+    }
+
+    Ok(url.to_string())
+}
+
+pub fn parse_proxy_settings(input: &str) -> Result<ProxySettings> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("Proxy string is required");
+    }
+
+    if trimmed.contains("://") {
+        return parse_proxy_url(trimmed);
+    }
+
+    if trimmed.contains('@') {
+        if let Ok(proxy) = parse_proxy_parts(trimmed) {
+            return Ok(proxy);
+        }
+        return parse_proxy_at_parts(trimmed);
+    }
+
+    parse_proxy_parts(trimmed)
+}
+
+fn parse_proxy_url(input: &str) -> Result<ProxySettings> {
+    let url = Url::parse(input).context("Invalid proxy URL")?;
+    if url.scheme() != "http" {
+        anyhow::bail!("Only HTTP proxies are supported");
+    }
+
+    let host = url
+        .host_str()
+        .filter(|value| !value.trim().is_empty())
+        .context("Proxy host is required")?
+        .to_string();
+    let port = url.port().context("Proxy port is required")?;
+    if port == 0 {
+        anyhow::bail!("Proxy port must be greater than 0");
+    }
+    let username = decode_url_component(url.username())?;
+    let password = match url.password() {
+        Some(value) => decode_url_component(value)?,
+        None => None,
+    };
+
+    validate_auth_pair(&username, &password)?;
+
+    Ok(ProxySettings {
+        enabled: true,
+        host,
+        port,
+        username,
+        password,
+    })
+}
+
+fn parse_proxy_parts(input: &str) -> Result<ProxySettings> {
+    let parts = input.split(':').collect::<Vec<_>>();
+    let (host, port, username, password) = match parts.as_slice() {
+        [host, port] => ((*host).to_string(), parse_port(port)?, None, None),
+        [host, port, username, password] => (
+            (*host).to_string(),
+            parse_port(port)?,
+            Some((*username).to_string()),
+            Some((*password).to_string()),
+        ),
+        _ => anyhow::bail!("Use host:port or host:port:username:password"),
+    };
+
+    let proxy = ProxySettings {
+        enabled: true,
+        host,
+        port,
+        username,
+        password,
+    };
+    validate_proxy_settings(&proxy)?;
+    Ok(proxy)
+}
+
+fn parse_proxy_at_parts(input: &str) -> Result<ProxySettings> {
+    let parts = input.split('@').collect::<Vec<_>>();
+    let [left, right] = parts.as_slice() else {
+        anyhow::bail!("Use username:password@host:port or host:port@username:password");
+    };
+
+    let left_endpoint = parse_endpoint_auth_proxy(left, right);
+    let right_endpoint = parse_auth_endpoint_proxy(left, right);
+
+    match (left_endpoint, right_endpoint) {
+        (Ok(proxy), Err(_)) => Ok(proxy),
+        (Err(_), Ok(proxy)) => Ok(proxy),
+        (Ok(left_proxy), Ok(right_proxy)) => {
+            if looks_like_proxy_host(&left_proxy.host) && !looks_like_proxy_host(&right_proxy.host)
+            {
+                Ok(left_proxy)
+            } else if looks_like_proxy_host(&right_proxy.host)
+                && !looks_like_proxy_host(&left_proxy.host)
+            {
+                Ok(right_proxy)
+            } else {
+                Ok(left_proxy)
+            }
+        }
+        (Err(left_error), Err(_)) => Err(left_error)
+            .context("Use username:password@host:port or host:port@username:password"),
+    }
+}
+
+fn parse_endpoint_auth_proxy(endpoint: &str, auth: &str) -> Result<ProxySettings> {
+    let (host, port) = parse_host_port(endpoint)?;
+    let (username, password) = parse_username_password(auth)?;
+    let proxy = ProxySettings {
+        enabled: true,
+        host,
+        port,
+        username: Some(username),
+        password: Some(password),
+    };
+    validate_proxy_settings(&proxy)?;
+    Ok(proxy)
+}
+
+fn parse_auth_endpoint_proxy(auth: &str, endpoint: &str) -> Result<ProxySettings> {
+    let (username, password) = parse_username_password(auth)?;
+    let (host, port) = parse_host_port(endpoint)?;
+    let proxy = ProxySettings {
+        enabled: true,
+        host,
+        port,
+        username: Some(username),
+        password: Some(password),
+    };
+    validate_proxy_settings(&proxy)?;
+    Ok(proxy)
+}
+
+fn parse_host_port(input: &str) -> Result<(String, u16)> {
+    let (host, port) = input
+        .split_once(':')
+        .context("Proxy host and port must be separated by ':'")?;
+    Ok((host.to_string(), parse_port(port)?))
+}
+
+fn parse_username_password(input: &str) -> Result<(String, String)> {
+    let (username, password) = input
+        .split_once(':')
+        .context("Proxy username and password must be separated by ':'")?;
+    Ok((username.to_string(), password.to_string()))
+}
+
+fn looks_like_proxy_host(value: &str) -> bool {
+    let value = value.trim().trim_start_matches('[').trim_end_matches(']');
+    value.eq_ignore_ascii_case("localhost")
+        || value.parse::<std::net::IpAddr>().is_ok()
+        || value.contains('.')
+        || value.contains(':')
+}
+
+fn parse_port(value: &str) -> Result<u16> {
+    let port = value
+        .parse::<u16>()
+        .with_context(|| format!("Invalid proxy port: {value}"))?;
+    if port == 0 {
+        anyhow::bail!("Proxy port must be greater than 0");
+    }
+    Ok(port)
+}
+
+fn decode_url_component(value: &str) -> Result<Option<String>> {
+    if value.is_empty() {
+        return Ok(None);
+    }
+
+    let decoded =
+        urlencoding::decode(value).context("Invalid URL encoding in proxy credentials")?;
+    Ok(Some(decoded.into_owned()))
+}
+
+pub fn validate_proxy_settings(proxy: &ProxySettings) -> Result<()> {
+    if proxy.host.trim().is_empty() {
+        anyhow::bail!("Proxy host is required");
+    }
+    validate_auth_pair(&proxy.username, &proxy.password)
+}
+
+fn validate_auth_pair(username: &Option<String>, password: &Option<String>) -> Result<()> {
+    match (username, password) {
+        (Some(username), Some(password)) if username.is_empty() || password.is_empty() => {
+            anyhow::bail!("Proxy username and password cannot be empty")
+        }
+        (Some(_), Some(_)) | (None, None) => Ok(()),
+        _ => anyhow::bail!("Proxy username and password must be provided together"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_proxy_url, parse_proxy_settings, ProxySettingsInfo};
+
+    #[test]
+    fn parses_host_port_username_password() {
+        let proxy = parse_proxy_settings("192.0.2.10:8000:user:pass").unwrap();
+
+        assert!(proxy.enabled);
+        assert_eq!(proxy.host, "192.0.2.10");
+        assert_eq!(proxy.port, 8000);
+        assert_eq!(proxy.username.as_deref(), Some("user"));
+        assert_eq!(proxy.password.as_deref(), Some("pass"));
+    }
+
+    #[test]
+    fn parses_host_port_at_username_password_into_structured_settings() {
+        let proxy = parse_proxy_settings("192.0.2.10:8000@user:pass").unwrap();
+
+        assert!(proxy.enabled);
+        assert_eq!(proxy.host, "192.0.2.10");
+        assert_eq!(proxy.port, 8000);
+        assert_eq!(proxy.username.as_deref(), Some("user"));
+        assert_eq!(proxy.password.as_deref(), Some("pass"));
+    }
+
+    #[test]
+    fn parses_username_password_at_host_port_into_structured_settings() {
+        let proxy = parse_proxy_settings("user:pass@192.0.2.10:8000").unwrap();
+
+        assert!(proxy.enabled);
+        assert_eq!(proxy.host, "192.0.2.10");
+        assert_eq!(proxy.port, 8000);
+        assert_eq!(proxy.username.as_deref(), Some("user"));
+        assert_eq!(proxy.password.as_deref(), Some("pass"));
+    }
+
+    #[test]
+    fn parses_http_url_with_auth() {
+        let proxy = parse_proxy_settings("http://user:pass@example.com:8080").unwrap();
+
+        assert_eq!(proxy.host, "example.com");
+        assert_eq!(proxy.port, 8080);
+        assert_eq!(proxy.username.as_deref(), Some("user"));
+        assert_eq!(proxy.password.as_deref(), Some("pass"));
+    }
+
+    #[test]
+    fn parses_proxy_without_auth() {
+        let proxy = parse_proxy_settings("example.com:8080").unwrap();
+
+        assert_eq!(proxy.host, "example.com");
+        assert_eq!(proxy.port, 8080);
+        assert_eq!(proxy.username, None);
+        assert_eq!(proxy.password, None);
+    }
+
+    #[test]
+    fn rejects_invalid_proxy_inputs() {
+        assert!(parse_proxy_settings(":8080").is_err());
+        assert!(parse_proxy_settings("example.com:notaport").is_err());
+        assert!(parse_proxy_settings("socks5://example.com:1080").is_err());
+        assert!(parse_proxy_settings("http://user@example.com:8080").is_err());
+    }
+
+    #[test]
+    fn proxy_info_masks_password() {
+        let proxy = parse_proxy_settings("example.com:8080:user:pass").unwrap();
+        let info = ProxySettingsInfo::from(Some(proxy));
+
+        assert!(info.configured);
+        assert!(info.has_password);
+        assert_eq!(info.username.as_deref(), Some("user"));
+    }
+
+    #[test]
+    fn builds_proxy_url_with_encoded_auth_for_environment() {
+        let proxy = parse_proxy_settings("example.com:8080:user:p@ss word").unwrap();
+        let url = build_proxy_url(&proxy, true).unwrap();
+
+        assert_eq!(url, "http://user:p%40ss%20word@example.com:8080/");
+    }
+}

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -11,11 +11,12 @@ use tokio::runtime::Runtime;
 
 use crate::commands::{
     add_account_from_auth_json_text, add_account_from_file, cancel_login, check_codex_processes,
-    complete_login, delete_account, export_accounts_full_encrypted_bytes,
-    export_accounts_slim_text, get_active_account_info, get_masked_account_ids, get_usage,
-    import_accounts_full_encrypted_bytes, import_accounts_slim_text, list_accounts,
+    clear_proxy_settings, complete_login, delete_account, export_accounts_full_encrypted_bytes,
+    export_accounts_slim_text, get_active_account_info, get_masked_account_ids, get_proxy_settings,
+    get_usage, import_accounts_full_encrypted_bytes, import_accounts_slim_text, list_accounts,
     refresh_account_metadata, refresh_all_accounts_usage, rename_account, set_masked_account_ids,
-    start_login, switch_account, warmup_account, warmup_all_accounts,
+    set_proxy_settings, start_login, switch_account, test_proxy_settings, warmup_account,
+    warmup_all_accounts,
 };
 
 #[derive(Debug, Deserialize)]
@@ -68,6 +69,17 @@ struct UploadEncryptedArgs {
 struct FileImportArgs {
     path: String,
     name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProxySettingsArgs {
+    proxy: Option<String>,
+    enabled: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct TestProxySettingsArgs {
+    proxy: Option<String>,
 }
 
 pub fn run_lan_server(host: &str, port: u16) -> anyhow::Result<()> {
@@ -189,6 +201,16 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         "set_masked_account_ids" => {
             let args: MaskedIdsArgs = parse_args(payload)?;
             to_json(set_masked_account_ids(args.ids).await?)
+        }
+        "get_proxy_settings" => to_json(get_proxy_settings().await?),
+        "set_proxy_settings" => {
+            let args: ProxySettingsArgs = parse_args(payload)?;
+            to_json(set_proxy_settings(args.proxy, args.enabled).await?)
+        }
+        "clear_proxy_settings" => to_json(clear_proxy_settings().await?),
+        "test_proxy_settings" => {
+            let args: TestProxySettingsArgs = parse_args(payload)?;
+            to_json(test_proxy_settings(args.proxy).await?)
         }
         "check_codex_processes" => to_json(check_codex_processes().await?),
         _ => Err(format!("Unsupported web command: {command}")),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAccounts } from "./hooks/useAccounts";
-import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
+import { AccountCard, AddAccountModal, ProxySettingsModal, UpdateChecker } from "./components";
 import type { CodexProcessInfo } from "./types";
 import {
   exportFullBackupFile,
@@ -42,6 +42,7 @@ function App() {
   } = useAccounts();
 
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isProxySettingsOpen, setIsProxySettingsOpen] = useState(false);
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [configModalMode, setConfigModalMode] = useState<"slim_export" | "slim_import">(
     "slim_export"
@@ -658,6 +659,15 @@ function App() {
                     <button
                       onClick={() => {
                         setIsActionsMenuOpen(false);
+                        setIsProxySettingsOpen(true);
+                      }}
+                      className="w-full rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-gray-100 dark:text-white dark:hover:bg-neutral-900"
+                    >
+                      Proxy Settings
+                    </button>
+                    <button
+                      onClick={() => {
+                        setIsActionsMenuOpen(false);
                         void handleExportSlimText();
                       }}
                       disabled={isExportingSlim}
@@ -881,6 +891,12 @@ function App() {
         onCancelOAuth={cancelOAuthLogin}
       />
 
+      <ProxySettingsModal
+        isOpen={isProxySettingsOpen}
+        onClose={() => setIsProxySettingsOpen(false)}
+        onToast={showWarmupToast}
+      />
+
       {/* Import/Export Config Modal */}
       {isConfigModalOpen && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
@@ -899,11 +915,12 @@ function App() {
             <div className="p-5 space-y-4">
               {configModalMode === "slim_import" ? (
                 <p className="text-sm text-amber-700 dark:text-amber-200 bg-amber-50 dark:bg-amber-900/30 border border-amber-200 dark:border-amber-700 rounded-lg px-3 py-2">
-                  Existing accounts are kept. Only missing accounts are imported.
+                  Existing accounts are kept. Only missing accounts are imported. Included proxy
+                  settings will replace the current proxy.
                 </p>
               ) : (
                 <p className="text-sm text-gray-500 dark:text-gray-400">
-                  This slim string contains account secrets. Keep it private.
+                  This slim string contains account and proxy secrets. Keep it private.
                 </p>
               )}
               <textarea

--- a/src/components/ProxySettingsModal.tsx
+++ b/src/components/ProxySettingsModal.tsx
@@ -1,0 +1,240 @@
+import { useEffect, useState } from "react";
+import type { ProxySettingsInfo } from "../types";
+import { invokeBackend } from "../lib/platform";
+
+interface ProxySettingsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onToast: (message: string, isError?: boolean) => void;
+}
+
+export function ProxySettingsModal({
+  isOpen,
+  onClose,
+  onToast,
+}: ProxySettingsModalProps) {
+  const [settings, setSettings] = useState<ProxySettingsInfo | null>(null);
+  const [proxyInput, setProxyInput] = useState("");
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [testSuccess, setTestSuccess] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+    const loadSettings = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        setTestSuccess(false);
+        const next = await invokeBackend<ProxySettingsInfo>("get_proxy_settings");
+        if (cancelled) return;
+        setSettings(next);
+        setEnabled(next.enabled);
+        setProxyInput("");
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void loadSettings();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const currentProxyLabel =
+    settings?.configured && settings.host && settings.port
+      ? `${settings.host}:${settings.port}`
+      : "Not configured";
+  const currentAuthLabel = settings?.configured
+    ? settings.username
+      ? `${settings.username}${settings.has_password ? " / password saved" : ""}`
+      : "No authentication"
+    : "No authentication";
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      setError(null);
+      setTestSuccess(false);
+      const next = await invokeBackend<ProxySettingsInfo>("set_proxy_settings", {
+        proxy: proxyInput.trim() || null,
+        enabled,
+      });
+      setSettings(next);
+      setEnabled(next.enabled);
+      setProxyInput("");
+      onToast(next.enabled ? "Proxy settings saved." : "Proxy disabled.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      onToast("Proxy save failed", true);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    try {
+      setTesting(true);
+      setError(null);
+      setTestSuccess(false);
+      await invokeBackend("test_proxy_settings", {
+        proxy: proxyInput.trim() || null,
+      });
+      setTestSuccess(true);
+      onToast("Proxy test succeeded.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      onToast("Proxy test failed", true);
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleClear = async () => {
+    try {
+      setClearing(true);
+      setError(null);
+      setTestSuccess(false);
+      const next = await invokeBackend<ProxySettingsInfo>("clear_proxy_settings");
+      setSettings(next);
+      setEnabled(false);
+      setProxyInput("");
+      onToast("Proxy settings cleared.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
+      onToast("Proxy clear failed", true);
+    } finally {
+      setClearing(false);
+    }
+  };
+
+  const busy = loading || saving || testing || clearing;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl w-full max-w-lg mx-4 shadow-xl">
+        <div className="flex items-center justify-between p-5 border-b border-gray-100 dark:border-gray-800">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Proxy Settings
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            title="Close"
+          >
+            x
+          </button>
+        </div>
+
+        <div className="p-5 space-y-4">
+          <div className="rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-gray-500 dark:text-gray-400">Current proxy</span>
+              <span className="font-medium text-gray-900 dark:text-gray-100">
+                {loading ? "Loading..." : currentProxyLabel}
+              </span>
+            </div>
+            <div className="mt-2 flex items-center justify-between gap-3">
+              <span className="text-gray-500 dark:text-gray-400">Authentication</span>
+              <span className="font-medium text-gray-900 dark:text-gray-100">
+                {loading ? "Loading..." : currentAuthLabel}
+              </span>
+            </div>
+          </div>
+
+          <label className="flex items-center justify-between gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-700">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+              Enable proxy
+            </span>
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(event) => setEnabled(event.target.checked)}
+              className="h-4 w-4"
+            />
+          </label>
+
+          <div>
+            <label
+              htmlFor="proxy-input"
+              className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              Proxy string
+            </label>
+            <input
+              id="proxy-input"
+              value={proxyInput}
+              onChange={(event) => {
+                setProxyInput(event.target.value);
+                setTestSuccess(false);
+              }}
+              placeholder="host:port@user:password"
+              className="w-full rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-mono text-sm text-gray-800 placeholder-gray-400 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:placeholder-gray-500 dark:focus:border-gray-500 dark:focus:ring-gray-500"
+            />
+            <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+              Example: host:port@username:password. Saved proxy settings are normalized.
+            </p>
+          </div>
+
+          {testSuccess && (
+            <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700 dark:border-green-700 dark:bg-green-900/20 dark:text-green-300">
+              Proxy test succeeded.
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-3 p-5 border-t border-gray-100 dark:border-gray-800">
+          <button
+            onClick={onClose}
+            className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors"
+          >
+            Close
+          </button>
+          <button
+            onClick={handleTest}
+            disabled={busy || (!proxyInput.trim() && !settings?.configured)}
+            className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors"
+          >
+            {testing ? "Testing..." : "Test"}
+          </button>
+          <button
+            onClick={handleClear}
+            disabled={busy || !settings?.configured}
+            className="px-4 py-2.5 text-sm font-medium rounded-lg bg-red-50 hover:bg-red-100 disabled:opacity-50 dark:bg-red-900/20 dark:hover:bg-red-900/30 text-red-700 dark:text-red-300 transition-colors"
+          >
+            {clearing ? "Clearing..." : "Clear"}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={busy}
+            className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 transition-colors disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,3 +2,4 @@ export { AccountCard } from "./AccountCard";
 export { UsageBar } from "./UsageBar";
 export { AddAccountModal } from "./AddAccountModal";
 export { UpdateChecker } from "./UpdateChecker";
+export { ProxySettingsModal } from "./ProxySettingsModal";

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -170,8 +170,12 @@ export function useAccounts() {
   ) => {
     try {
       if (options?.refreshMetadata) {
-        await invokeBackend<AccountInfo>("refresh_account_metadata", { accountId });
-        await loadAccounts(true);
+        try {
+          await invokeBackend<AccountInfo>("refresh_account_metadata", { accountId });
+          await loadAccounts(true);
+        } catch (err) {
+          console.warn("Failed to refresh account metadata:", err);
+        }
       }
 
       setAccounts((prev) =>
@@ -197,9 +201,8 @@ export function useAccounts() {
                 usageLoading: false,
               }
             : a
-        )
+          )
       );
-      throw err;
     }
   }, [buildUsageError, loadAccounts]);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,3 +57,12 @@ export interface ImportAccountsSummary {
   imported_count: number;
   skipped_count: number;
 }
+
+export interface ProxySettingsInfo {
+  enabled: boolean;
+  configured: boolean;
+  host: string | null;
+  port: number | null;
+  username: string | null;
+  has_password: boolean;
+}


### PR DESCRIPTION

<img width="689" height="584" alt="изображение" src="https://github.com/user-attachments/assets/eb0e7aef-41b2-487b-b93a-8659882a2f8a" />

## Summary
  - Add persistent app-level proxy settings with optional
  authentication.
  - Route app OpenAI/ChatGPT HTTP requests through the
  configured proxy.
  - Support normalized proxy input, including `@` separator
  variants.
  - Include proxy settings in slim text and full encrypted
  backup import/export.
  - Harden ChatGPT token refresh handling to avoid unnecessary
  refresh-token rotation.

  ## Details
  - Proxy settings are stored separately in app settings and
  masked in the UI.
  - Supported proxy input examples:
    - `host:port`
    - `host:port:user:password`
    - `host:port@user:password`
    - `user:password@host:port`
    - `http://user:password@host:port`
  - Imported proxy settings are applied immediately.
  - Full encrypted backups remain backward-compatible with older
  files that do not include proxy settings.
  - Slim import remains backward-compatible with v1 payloads
  without proxy settings.

  ## Testing
  - `cargo fmt --manifest-path src-tauri/Cargo.toml`
  - `cargo test --manifest-path src-tauri/Cargo.toml`
  - `pnpm build`