### PR TITLE
[codex] improve usage auto-switch process handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This is a Tauri 2 desktop app with a React 19 + TypeScript frontend and Rust backend. Frontend code lives in `src/`: `components/` for UI, `hooks/` for React state logic, `lib/platform.ts` for Tauri/web backend calls, and `types/` for shared TypeScript shapes. Rust code lives in `src-tauri/src/`, grouped by `auth/`, `api/`, `commands/`, and `web.rs`. Icons and platform assets are under `src-tauri/icons/`; release/version helpers are in `scripts/`.
+
+## Build, Test, and Development Commands
+
+- `pnpm install`: install JavaScript dependencies from `pnpm-lock.yaml`.
+- `pnpm tauri dev`: run the desktop app in development mode.
+- `pnpm build`: run TypeScript checks and build the Vite frontend.
+- `pnpm tauri build`: build the production desktop bundles under `src-tauri/target/release/bundle/`.
+- `pnpm lan`: build the frontend and run the Rust web dashboard on `0.0.0.0:3210`.
+- `cargo test --manifest-path src-tauri/Cargo.toml`: run Rust tests when backend tests are added.
+
+## Coding Style & Naming Conventions
+
+Use TypeScript strict mode as enforced by `tsconfig.json`: no unused locals or parameters, no implicit type looseness, and JSX via `react-jsx`. Match existing formatting: two-space indentation, double-quoted imports, semicolons, and named exports for components. Name React components in `PascalCase`, hooks as `useSomething`, and shared types/interfaces descriptively. For Rust, follow `rustfmt`, use `snake_case` for modules/functions, and keep Tauri command handlers in `src-tauri/src/commands/`.
+
+## Testing Guidelines
+
+There is no dedicated frontend test runner configured yet, so treat `pnpm build` as required validation for TypeScript and Vite changes. For backend logic, add focused Rust unit tests near the module under test or integration tests under `src-tauri/tests/`. Name tests by behavior, for example `refreshes_expired_token`. Manually verify UI changes with `pnpm tauri dev`; include platform checks when changing Tauri config, updater behavior, process handling, or file dialogs.
+
+## Commit & Pull Request Guidelines
+
+Recent history uses short imperative subjects, with Conventional-style prefixes for release chores, for example `chore: release 0.2.2` and `Add release script`. Keep commits focused and describe the user-visible change or maintenance task. Pull requests should include a summary, validation commands, linked issues when applicable, and screenshots or recordings for UI changes. For Tauri/Rust changes, note tested platforms and relevant environment variables such as `CODEX_SWITCHER_WEB_HOST` or `CODEX_SWITCHER_WEB_PORT`.
+
+## Security & Configuration Tips
+
+This app manages Codex account data. Do not commit `auth.json`, decrypted exports, local backups, tokens, or machine-specific secrets. Prefer encrypted full exports for backups, and document new configuration in `README.md`.
+
+<!-- chinese-language-config:start -->
+## Language
+Use **Chinese** for:
+- Task execution results and error messages
+- Confirmations and clarifications with the user
+- Solution descriptions and to-do items
+- Commit info for git
+<!-- chinese-language-config:end -->

--- a/README.md
+++ b/README.md
@@ -14,7 +14,20 @@
 - **Multi-Account Management** – Add and manage multiple Codex accounts in one place
 - **Quick Switching** – Switch between accounts with a single click
 - **Usage Monitoring** – View real-time usage for both 5-hour and weekly limits
+- **Usage Automation** – Configure low-usage warnings, automatic switching, and manual account priority
 - **Dual Login Mode** – OAuth authentication or import existing `auth.json` files
+
+## Usage Automation
+
+Codex Switcher can warn you when the active account is running low on 5-hour quota and can optionally switch to another account automatically.
+
+- Warning threshold defaults to `10%` remaining.
+- Auto-switch threshold defaults to `5%` remaining.
+- Auto-switch is disabled by default.
+- When auto-switch is enabled, choose either **Usage first** or **Reset first**.
+- When auto-switch is disabled, adjust the manual account priority and switch accounts yourself.
+
+Automatic switching only uses 5-hour limit data. If Codex is currently running, the app will pause automatic switching and show a reminder instead of changing `~/.codex/auth.json`.
 
 ## Installation
 

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -1,12 +1,13 @@
 //! Account storage module - manages reading and writing accounts.json
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 
-use crate::types::{AccountsStore, AuthData, StoredAccount};
+use crate::types::{AccountsStore, AuthData, StoredAccount, UsageAutomationSettings};
 
 /// Get the path to the codex-switcher config directory
 pub fn get_config_dir() -> Result<PathBuf> {
@@ -63,6 +64,37 @@ pub fn save_accounts(store: &AccountsStore) -> Result<()> {
     Ok(())
 }
 
+/// Return a priority list containing each current account exactly once.
+pub fn normalized_priority_account_ids(
+    accounts: &[StoredAccount],
+    priority_account_ids: &[String],
+) -> Vec<String> {
+    let account_ids: HashSet<&str> = accounts.iter().map(|account| account.id.as_str()).collect();
+    let mut seen = HashSet::new();
+    let mut normalized = Vec::with_capacity(accounts.len());
+
+    for account_id in priority_account_ids {
+        if account_ids.contains(account_id.as_str()) && seen.insert(account_id.as_str()) {
+            normalized.push(account_id.clone());
+        }
+    }
+
+    for account in accounts {
+        if seen.insert(account.id.as_str()) {
+            normalized.push(account.id.clone());
+        }
+    }
+
+    normalized
+}
+
+fn sync_usage_automation_priority(store: &mut AccountsStore) {
+    store.usage_automation.priority_account_ids = normalized_priority_account_ids(
+        &store.accounts,
+        &store.usage_automation.priority_account_ids,
+    );
+}
+
 /// Add a new account to the store
 pub fn add_account(account: StoredAccount) -> Result<StoredAccount> {
     let mut store = load_accounts()?;
@@ -74,6 +106,7 @@ pub fn add_account(account: StoredAccount) -> Result<StoredAccount> {
 
     let account_clone = account.clone();
     store.accounts.push(account);
+    sync_usage_automation_priority(&mut store);
 
     // If this is the first account, make it active
     if store.accounts.len() == 1 {
@@ -99,6 +132,7 @@ pub fn remove_account(account_id: &str) -> Result<()> {
     if store.active_account_id.as_deref() == Some(account_id) {
         store.active_account_id = store.accounts.first().map(|a| a.id.clone());
     }
+    sync_usage_automation_priority(&mut store);
 
     save_accounts(&store)?;
     Ok(())
@@ -262,4 +296,80 @@ pub fn set_masked_account_ids(ids: Vec<String>) -> Result<()> {
     store.masked_account_ids = ids;
     save_accounts(&store)?;
     Ok(())
+}
+
+/// Get usage warning and automatic switching settings.
+pub fn get_usage_automation_settings() -> Result<UsageAutomationSettings> {
+    let store = load_accounts()?;
+    let mut settings = store.usage_automation.clone();
+    settings.priority_account_ids =
+        normalized_priority_account_ids(&store.accounts, &settings.priority_account_ids);
+    Ok(settings)
+}
+
+/// Set usage warning and automatic switching settings.
+pub fn set_usage_automation_settings(mut settings: UsageAutomationSettings) -> Result<()> {
+    if !settings.warning_remaining_percent.is_finite()
+        || !settings.auto_switch_remaining_percent.is_finite()
+    {
+        anyhow::bail!("Usage thresholds must be finite numbers");
+    }
+
+    if !(0.0..=100.0).contains(&settings.warning_remaining_percent)
+        || !(0.0..=100.0).contains(&settings.auto_switch_remaining_percent)
+    {
+        anyhow::bail!("Usage thresholds must be between 0 and 100");
+    }
+
+    if settings.warning_remaining_percent < settings.auto_switch_remaining_percent {
+        anyhow::bail!("Warning threshold must be greater than or equal to auto-switch threshold");
+    }
+
+    let mut store = load_accounts()?;
+    settings.priority_account_ids =
+        normalized_priority_account_ids(&store.accounts, &settings.priority_account_ids);
+    store.usage_automation = settings;
+    save_accounts(&store)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalized_priority_account_ids;
+    use crate::types::StoredAccount;
+
+    fn account_with_id(id: &str) -> StoredAccount {
+        let mut account = StoredAccount::new_api_key(id.to_string(), format!("key-{id}"));
+        account.id = id.to_string();
+        account
+    }
+
+    #[test]
+    fn normalized_priority_removes_invalid_and_duplicate_ids() {
+        let accounts = vec![
+            account_with_id("first"),
+            account_with_id("second"),
+            account_with_id("third"),
+        ];
+
+        let normalized = normalized_priority_account_ids(
+            &accounts,
+            &[
+                "missing".to_string(),
+                "second".to_string(),
+                "second".to_string(),
+                "first".to_string(),
+            ],
+        );
+
+        assert_eq!(normalized, vec!["second", "first", "third"]);
+    }
+
+    #[test]
+    fn normalized_priority_preserves_account_order_when_empty() {
+        let accounts = vec![account_with_id("first"), account_with_id("second")];
+        let normalized = normalized_priority_account_ids(&accounts, &[]);
+
+        assert_eq!(normalized, vec!["first", "second"]);
+    }
 }

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -2,10 +2,14 @@
 
 use crate::auth::{
     add_account, create_chatgpt_account_from_refresh_token, get_active_account,
-    import_from_auth_json, import_from_auth_json_contents, load_accounts, remove_account,
-    save_accounts, set_active_account, switch_to_account, touch_account,
+    import_from_auth_json, import_from_auth_json_contents, load_accounts,
+    normalized_priority_account_ids, remove_account, save_accounts, set_active_account,
+    switch_to_account, touch_account,
 };
-use crate::types::{AccountInfo, AccountsStore, AuthData, ImportAccountsSummary, StoredAccount};
+use crate::types::{
+    AccountInfo, AccountsStore, AuthData, ImportAccountsSummary, StoredAccount,
+    UsageAutomationSettings,
+};
 
 use anyhow::Context;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -18,7 +22,7 @@ use futures::{stream, StreamExt};
 use pbkdf2::pbkdf2_hmac;
 use rand::RngCore;
 use sha2::Sha256;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{Read, Write};
 
@@ -71,10 +75,26 @@ struct SlimAccountPayload {
 pub async fn list_accounts() -> Result<Vec<AccountInfo>, String> {
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();
-
-    let accounts: Vec<AccountInfo> = store
-        .accounts
+    let priority_account_ids = normalized_priority_account_ids(
+        &store.accounts,
+        &store.usage_automation.priority_account_ids,
+    );
+    let priority_index: HashMap<&str, usize> = priority_account_ids
         .iter()
+        .enumerate()
+        .map(|(index, account_id)| (account_id.as_str(), index))
+        .collect();
+
+    let mut accounts = store.accounts.iter().collect::<Vec<_>>();
+    accounts.sort_by_key(|account| {
+        priority_index
+            .get(account.id.as_str())
+            .copied()
+            .unwrap_or(usize::MAX)
+    });
+
+    let accounts: Vec<AccountInfo> = accounts
+        .into_iter()
         .map(|a| AccountInfo::from_stored(a, active_id))
         .collect();
 
@@ -482,6 +502,10 @@ async fn build_store_from_slim_payload(
         accounts,
         active_account_id,
         masked_account_ids: Vec::new(),
+        usage_automation: UsageAutomationSettings {
+            priority_account_ids: Vec::new(),
+            ..UsageAutomationSettings::default()
+        },
     })
 }
 
@@ -678,8 +702,10 @@ fn merge_accounts_store(
     mut current: AccountsStore,
     imported: AccountsStore,
 ) -> (AccountsStore, ImportAccountsSummary) {
+    let current_was_empty = current.accounts.is_empty();
     let imported_version = imported.version;
     let imported_active_id = imported.active_account_id;
+    let imported_usage_automation = imported.usage_automation;
     let total_in_payload = imported.accounts.len();
     let mut imported_count = 0usize;
     let mut existing_ids: HashSet<String> = current.accounts.iter().map(|a| a.id.clone()).collect();
@@ -697,6 +723,13 @@ fn merge_accounts_store(
     }
 
     current.version = current.version.max(imported_version).max(1);
+    if current_was_empty {
+        current.usage_automation = imported_usage_automation;
+    }
+    current.usage_automation.priority_account_ids = normalized_priority_account_ids(
+        &current.accounts,
+        &current.usage_automation.priority_account_ids,
+    );
 
     let current_active_is_valid = current
         .active_account_id
@@ -735,4 +768,18 @@ pub async fn get_masked_account_ids() -> Result<Vec<String>, String> {
 #[tauri::command]
 pub async fn set_masked_account_ids(ids: Vec<String>) -> Result<(), String> {
     crate::auth::storage::set_masked_account_ids(ids).map_err(|e| e.to_string())
+}
+
+/// Get usage warning and automatic switching settings
+#[tauri::command]
+pub async fn get_usage_automation_settings() -> Result<UsageAutomationSettings, String> {
+    crate::auth::storage::get_usage_automation_settings().map_err(|e| e.to_string())
+}
+
+/// Set usage warning and automatic switching settings
+#[tauri::command]
+pub async fn set_usage_automation_settings(
+    settings: UsageAutomationSettings,
+) -> Result<(), String> {
+    crate::auth::storage::set_usage_automation_settings(settings).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -62,6 +62,12 @@ pub async fn close_codex_processes() -> Result<CodexProcessInfo, String> {
     close_active_codex_processes().map_err(|e| e.to_string())
 }
 
+/// Open the Codex desktop app.
+#[tauri::command]
+pub async fn open_codex_app() -> Result<CodexProcessInfo, String> {
+    open_codex_desktop_app().map_err(|e| e.to_string())
+}
+
 fn close_active_codex_processes() -> anyhow::Result<CodexProcessInfo> {
     let (pids, _) = find_codex_processes()?;
 
@@ -98,11 +104,91 @@ fn close_active_codex_processes() -> anyhow::Result<CodexProcessInfo> {
     })
 }
 
+fn open_codex_desktop_app() -> anyhow::Result<CodexProcessInfo> {
+    #[cfg(windows)]
+    {
+        const POWERSHELL_SCRIPT: &str = r#"
+$app = Get-StartApps |
+  Where-Object { $_.Name -eq 'Codex' -and $_.AppID -notmatch 'codex-switcher' } |
+  Select-Object -First 1
+
+if (-not $app) {
+  $app = Get-StartApps |
+    Where-Object { $_.AppID -match '^OpenAI\.Codex_' } |
+    Select-Object -First 1
+}
+
+if (-not $app) {
+  throw 'Codex desktop app was not found.'
+}
+
+Start-Process "shell:AppsFolder\$($app.AppID)"
+"#;
+
+        let output = Command::new("powershell.exe")
+            .creation_flags(CREATE_NO_WINDOW)
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                POWERSHELL_SCRIPT,
+            ])
+            .output()
+            .context("failed to launch Codex desktop app")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to launch Codex desktop app: {}", stderr.trim());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let output = Command::new("open")
+            .args(["-a", "Codex"])
+            .output()
+            .context("failed to launch Codex desktop app")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("Failed to launch Codex desktop app: {}", stderr.trim());
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        Command::new("codex")
+            .spawn()
+            .context("failed to launch codex")?;
+    }
+
+    let (pids, background_count) = wait_for_active_codex_start(Duration::from_secs(10))?;
+    Ok(CodexProcessInfo {
+        count: pids.len(),
+        background_count,
+        can_switch: pids.is_empty(),
+        pids,
+    })
+}
+
 fn wait_for_active_codex_exit(timeout: Duration) -> anyhow::Result<(Vec<u32>, usize)> {
     let deadline = Instant::now() + timeout;
     loop {
         let (pids, background_count) = find_codex_processes()?;
         if pids.is_empty() || Instant::now() >= deadline {
+            return Ok((pids, background_count));
+        }
+        sleep(Duration::from_millis(250));
+    }
+}
+
+fn wait_for_active_codex_start(timeout: Duration) -> anyhow::Result<(Vec<u32>, usize)> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let (pids, background_count) = find_codex_processes()?;
+        if !pids.is_empty() || Instant::now() >= deadline {
             return Ok((pids, background_count));
         }
         sleep(Duration::from_millis(250));

--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -1,6 +1,8 @@
 //! Process detection commands
 
 use std::process::Command;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
 
 #[cfg(windows)]
 use anyhow::Context;
@@ -52,6 +54,80 @@ pub async fn check_codex_processes() -> Result<CodexProcessInfo, String> {
         can_switch: count == 0,
         pids,
     })
+}
+
+/// Close active Codex desktop or CLI processes and verify they are gone.
+#[tauri::command]
+pub async fn close_codex_processes() -> Result<CodexProcessInfo, String> {
+    close_active_codex_processes().map_err(|e| e.to_string())
+}
+
+fn close_active_codex_processes() -> anyhow::Result<CodexProcessInfo> {
+    let (pids, _) = find_codex_processes()?;
+
+    for pid in &pids {
+        terminate_process(*pid, false);
+    }
+
+    let (mut remaining_pids, mut background_count) =
+        wait_for_active_codex_exit(Duration::from_secs(4))?;
+
+    if !remaining_pids.is_empty() {
+        for pid in &remaining_pids {
+            terminate_process(*pid, true);
+        }
+        (remaining_pids, background_count) = wait_for_active_codex_exit(Duration::from_secs(8))?;
+    }
+
+    if !remaining_pids.is_empty() {
+        anyhow::bail!(
+            "Timed out while closing Codex processes: {}",
+            remaining_pids
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    Ok(CodexProcessInfo {
+        count: 0,
+        background_count,
+        can_switch: true,
+        pids: Vec::new(),
+    })
+}
+
+fn wait_for_active_codex_exit(timeout: Duration) -> anyhow::Result<(Vec<u32>, usize)> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let (pids, background_count) = find_codex_processes()?;
+        if pids.is_empty() || Instant::now() >= deadline {
+            return Ok((pids, background_count));
+        }
+        sleep(Duration::from_millis(250));
+    }
+}
+
+fn terminate_process(pid: u32, force: bool) {
+    #[cfg(unix)]
+    {
+        let signal = if force { "-KILL" } else { "-TERM" };
+        let _ = Command::new("kill")
+            .args([signal, &pid.to_string()])
+            .output();
+    }
+
+    #[cfg(windows)]
+    {
+        let mut command = Command::new("taskkill");
+        command.creation_flags(CREATE_NO_WINDOW);
+        command.args(["/PID", &pid.to_string(), "/T"]);
+        if force {
+            command.arg("/F");
+        }
+        let _ = command.output();
+    }
 }
 
 /// Find all running codex processes. Returns (active_pids, background_count)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,11 +7,12 @@ pub mod types;
 pub mod web;
 
 use commands::{
-    add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,
-    export_accounts_full_encrypted_file, export_accounts_slim_text, get_active_account_info,
-    get_masked_account_ids, get_usage, import_accounts_full_encrypted_file,
-    import_accounts_slim_text, list_accounts, refresh_account_metadata, refresh_all_accounts_usage,
-    rename_account, set_masked_account_ids, start_login, switch_account, warmup_account,
+    add_account_from_file, cancel_login, check_codex_processes, close_codex_processes,
+    complete_login, delete_account, export_accounts_full_encrypted_file, export_accounts_slim_text,
+    get_active_account_info, get_masked_account_ids, get_usage, get_usage_automation_settings,
+    import_accounts_full_encrypted_file, import_accounts_slim_text, list_accounts,
+    refresh_account_metadata, refresh_all_accounts_usage, rename_account, set_masked_account_ids,
+    set_usage_automation_settings, start_login, switch_account, warmup_account,
     warmup_all_accounts,
 };
 
@@ -42,6 +43,9 @@ pub fn run() {
             // Masked accounts
             get_masked_account_ids,
             set_masked_account_ids,
+            // Usage automation
+            get_usage_automation_settings,
+            set_usage_automation_settings,
             // OAuth
             start_login,
             complete_login,
@@ -54,6 +58,7 @@ pub fn run() {
             warmup_all_accounts,
             // Process detection
             check_codex_processes,
+            close_codex_processes,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ use commands::{
     add_account_from_file, cancel_login, check_codex_processes, close_codex_processes,
     complete_login, delete_account, export_accounts_full_encrypted_file, export_accounts_slim_text,
     get_active_account_info, get_masked_account_ids, get_usage, get_usage_automation_settings,
-    import_accounts_full_encrypted_file, import_accounts_slim_text, list_accounts,
+    import_accounts_full_encrypted_file, import_accounts_slim_text, list_accounts, open_codex_app,
     refresh_account_metadata, refresh_all_accounts_usage, rename_account, set_masked_account_ids,
     set_usage_automation_settings, start_login, switch_account, warmup_account,
     warmup_all_accounts,
@@ -59,6 +59,7 @@ pub fn run() {
             // Process detection
             check_codex_processes,
             close_codex_processes,
+            open_codex_app,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -17,6 +17,9 @@ pub struct AccountsStore {
     /// Set of account IDs that are masked (hidden)
     #[serde(default)]
     pub masked_account_ids: Vec<String>,
+    /// Usage warning and auto-switch settings
+    #[serde(default)]
+    pub usage_automation: UsageAutomationSettings,
 }
 
 impl Default for AccountsStore {
@@ -26,6 +29,49 @@ impl Default for AccountsStore {
             accounts: Vec::new(),
             active_account_id: None,
             masked_account_ids: Vec::new(),
+            usage_automation: UsageAutomationSettings::default(),
+        }
+    }
+}
+
+/// Strategy used when choosing an automatic switch target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutoSwitchStrategy {
+    /// Choose the account with the most remaining 5h usage.
+    RemainingDesc,
+    /// Choose the account whose 5h usage window resets soonest.
+    ResetTimeAsc,
+}
+
+impl Default for AutoSwitchStrategy {
+    fn default() -> Self {
+        Self::RemainingDesc
+    }
+}
+
+/// Configurable usage warning and automatic switching behavior.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageAutomationSettings {
+    pub warning_remaining_percent: f64,
+    pub auto_switch_remaining_percent: f64,
+    pub auto_switch_enabled: bool,
+    #[serde(default)]
+    pub auto_close_codex_on_switch: bool,
+    pub auto_switch_strategy: AutoSwitchStrategy,
+    #[serde(default)]
+    pub priority_account_ids: Vec<String>,
+}
+
+impl Default for UsageAutomationSettings {
+    fn default() -> Self {
+        Self {
+            warning_remaining_percent: 10.0,
+            auto_switch_remaining_percent: 5.0,
+            auto_switch_enabled: false,
+            auto_close_codex_on_switch: false,
+            auto_switch_strategy: AutoSwitchStrategy::default(),
+            priority_account_ids: Vec::new(),
         }
     }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -58,9 +58,15 @@ pub struct UsageAutomationSettings {
     pub auto_switch_enabled: bool,
     #[serde(default)]
     pub auto_close_codex_on_switch: bool,
+    #[serde(default = "default_auto_reopen_codex_after_switch")]
+    pub auto_reopen_codex_after_switch: bool,
     pub auto_switch_strategy: AutoSwitchStrategy,
     #[serde(default)]
     pub priority_account_ids: Vec<String>,
+}
+
+fn default_auto_reopen_codex_after_switch() -> bool {
+    true
 }
 
 impl Default for UsageAutomationSettings {
@@ -70,6 +76,7 @@ impl Default for UsageAutomationSettings {
             auto_switch_remaining_percent: 5.0,
             auto_switch_enabled: false,
             auto_close_codex_on_switch: false,
+            auto_reopen_codex_after_switch: true,
             auto_switch_strategy: AutoSwitchStrategy::default(),
             priority_account_ids: Vec::new(),
         }

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -11,12 +11,14 @@ use tokio::runtime::Runtime;
 
 use crate::commands::{
     add_account_from_auth_json_text, add_account_from_file, cancel_login, check_codex_processes,
-    complete_login, delete_account, export_accounts_full_encrypted_bytes,
+    close_codex_processes, complete_login, delete_account, export_accounts_full_encrypted_bytes,
     export_accounts_slim_text, get_active_account_info, get_masked_account_ids, get_usage,
-    import_accounts_full_encrypted_bytes, import_accounts_slim_text, list_accounts,
-    refresh_account_metadata, refresh_all_accounts_usage, rename_account, set_masked_account_ids,
-    start_login, switch_account, warmup_account, warmup_all_accounts,
+    get_usage_automation_settings, import_accounts_full_encrypted_bytes, import_accounts_slim_text,
+    list_accounts, refresh_account_metadata, refresh_all_accounts_usage, rename_account,
+    set_masked_account_ids, set_usage_automation_settings, start_login, switch_account,
+    warmup_account, warmup_all_accounts,
 };
+use crate::types::UsageAutomationSettings;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,6 +51,11 @@ struct ImportSlimArgs {
 #[derive(Debug, Deserialize)]
 struct MaskedIdsArgs {
     ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct UsageAutomationSettingsArgs {
+    settings: UsageAutomationSettings,
 }
 
 #[derive(Debug, Deserialize)]
@@ -190,7 +197,13 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
             let args: MaskedIdsArgs = parse_args(payload)?;
             to_json(set_masked_account_ids(args.ids).await?)
         }
+        "get_usage_automation_settings" => to_json(get_usage_automation_settings().await?),
+        "set_usage_automation_settings" => {
+            let args: UsageAutomationSettingsArgs = parse_args(payload)?;
+            to_json(set_usage_automation_settings(args.settings).await?)
+        }
         "check_codex_processes" => to_json(check_codex_processes().await?),
+        "close_codex_processes" => to_json(close_codex_processes().await?),
         _ => Err(format!("Unsupported web command: {command}")),
     }
 }

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -14,9 +14,9 @@ use crate::commands::{
     close_codex_processes, complete_login, delete_account, export_accounts_full_encrypted_bytes,
     export_accounts_slim_text, get_active_account_info, get_masked_account_ids, get_usage,
     get_usage_automation_settings, import_accounts_full_encrypted_bytes, import_accounts_slim_text,
-    list_accounts, refresh_account_metadata, refresh_all_accounts_usage, rename_account,
-    set_masked_account_ids, set_usage_automation_settings, start_login, switch_account,
-    warmup_account, warmup_all_accounts,
+    list_accounts, open_codex_app, refresh_account_metadata, refresh_all_accounts_usage,
+    rename_account, set_masked_account_ids, set_usage_automation_settings, start_login,
+    switch_account, warmup_account, warmup_all_accounts,
 };
 use crate::types::UsageAutomationSettings;
 
@@ -204,6 +204,7 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         }
         "check_codex_processes" => to_json(check_codex_processes().await?),
         "close_codex_processes" => to_json(close_codex_processes().await?),
+        "open_codex_app" => to_json(open_codex_app().await?),
         _ => Err(format!("Unsupported web command: {command}")),
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const DEFAULT_USAGE_AUTOMATION_SETTINGS: UsageAutomationSettings = {
   auto_switch_remaining_percent: 5,
   auto_switch_enabled: false,
   auto_close_codex_on_switch: false,
+  auto_reopen_codex_after_switch: true,
   auto_switch_strategy: "remaining_desc",
   priority_account_ids: [],
 };
@@ -244,6 +245,12 @@ function App() {
 
   const closeCodexProcesses = useCallback(async () => {
     const info = await invokeBackend<CodexProcessInfo>("close_codex_processes");
+    setProcessInfo(info);
+    return info;
+  }, []);
+
+  const openCodexApp = useCallback(async () => {
+    const info = await invokeBackend<CodexProcessInfo>("open_codex_app");
     setProcessInfo(info);
     return info;
   }, []);
@@ -683,6 +690,7 @@ function App() {
       effectiveUsageAutomationSettings.auto_switch_remaining_percent,
       effectiveUsageAutomationSettings.auto_switch_strategy,
       effectiveUsageAutomationSettings.auto_close_codex_on_switch ? "close" : "pause",
+      effectiveUsageAutomationSettings.auto_reopen_codex_after_switch ? "reopen" : "stay-closed",
       effectiveUsageAutomationSettings.priority_account_ids.join(","),
       processInfo?.count ?? "unknown",
       accountUsageSnapshot,
@@ -696,6 +704,7 @@ function App() {
     const runAutoSwitch = async () => {
       const latestProcessInfo = await checkProcesses();
       if (cancelled) return;
+      let closedCodexForSwitch = false;
 
       if (!latestProcessInfo) {
         showWarmupToast("Auto-switch paused. Could not check Codex processes.", true);
@@ -719,6 +728,7 @@ function App() {
             showWarmupToast("Auto-switch paused. Codex is still running.", true);
             return;
           }
+          closedCodexForSwitch = true;
         } catch (err) {
           console.error("Failed to close Codex before auto-switch:", err);
           showWarmupToast(
@@ -770,7 +780,23 @@ function App() {
       try {
         setSwitchingId(nextAccount.id);
         await switchAccount(nextAccount.id);
-        showWarmupToast(`Auto-switched to ${nextAccount.name}.`);
+        if (
+          closedCodexForSwitch &&
+          effectiveUsageAutomationSettings.auto_reopen_codex_after_switch
+        ) {
+          try {
+            await openCodexApp();
+            showWarmupToast(`Auto-switched to ${nextAccount.name} and reopened Codex.`);
+          } catch (err) {
+            console.error("Failed to reopen Codex after auto-switch:", err);
+            showWarmupToast(
+              `Auto-switched to ${nextAccount.name}, but Codex did not reopen: ${formatWarmupError(err)}`,
+              true
+            );
+          }
+        } else {
+          showWarmupToast(`Auto-switched to ${nextAccount.name}.`);
+        }
       } catch (err) {
         console.error("Failed to auto-switch account:", err);
         showWarmupToast(`Auto-switch failed: ${formatWarmupError(err)}`, true);
@@ -791,6 +817,7 @@ function App() {
     closeCodexProcesses,
     effectiveUsageAutomationSettings,
     formatWarmupError,
+    openCodexApp,
     priorityIndex,
     processInfo?.count,
     settingsLoaded,
@@ -1444,6 +1471,49 @@ function App() {
                       />
                     </button>
                   </div>
+
+                  {settingsDraft.auto_close_codex_on_switch && (
+                    <div className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 px-4 py-3 dark:border-gray-700">
+                      <div>
+                        <div className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                          Reopen Codex after switching
+                        </div>
+                        <div className="text-xs text-gray-500 dark:text-gray-400">
+                          {settingsDraft.auto_reopen_codex_after_switch
+                            ? "Codex will launch again after the account changes."
+                            : "Codex stays closed after the account changes."}
+                        </div>
+                      </div>
+                      <button
+                        onClick={() =>
+                          setSettingsDraft((prev) => ({
+                            ...prev,
+                            auto_reopen_codex_after_switch:
+                              !prev.auto_reopen_codex_after_switch,
+                          }))
+                        }
+                        className={`relative h-7 w-12 rounded-full transition-colors ${
+                          settingsDraft.auto_reopen_codex_after_switch
+                            ? "bg-emerald-500"
+                            : "bg-gray-300 dark:bg-gray-700"
+                        }`}
+                        aria-pressed={settingsDraft.auto_reopen_codex_after_switch}
+                        title={
+                          settingsDraft.auto_reopen_codex_after_switch
+                            ? "Keep Codex closed after switching"
+                            : "Reopen Codex after switching"
+                        }
+                      >
+                        <span
+                          className={`absolute left-1 top-1 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                            settingsDraft.auto_reopen_codex_after_switch
+                              ? "translate-x-5"
+                              : "translate-x-0"
+                          }`}
+                        />
+                      </button>
+                    </div>
+                  )}
 
                   <div className="text-sm font-medium text-gray-700 dark:text-gray-200">
                     Auto-switch strategy

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,12 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAccounts } from "./hooks/useAccounts";
 import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
-import type { CodexProcessInfo } from "./types";
+import type {
+  AutoSwitchStrategy,
+  CodexProcessInfo,
+  UsageAutomationSettings,
+  UsageInfo,
+} from "./types";
 import {
   exportFullBackupFile,
   importFullBackupFile,
@@ -13,10 +18,40 @@ import "./App.css";
 
 const THEME_STORAGE_KEY = "codex-switcher-theme";
 type ThemeMode = "light" | "dark";
+type OtherAccountsSort =
+  | "priority"
+  | "deadline_asc"
+  | "deadline_desc"
+  | "remaining_desc"
+  | "remaining_asc"
+  | "subscription_asc"
+  | "subscription_desc";
+
+const DEFAULT_USAGE_AUTOMATION_SETTINGS: UsageAutomationSettings = {
+  warning_remaining_percent: 10,
+  auto_switch_remaining_percent: 5,
+  auto_switch_enabled: false,
+  auto_close_codex_on_switch: false,
+  auto_switch_strategy: "remaining_desc",
+  priority_account_ids: [],
+};
+
 const appWindow = getCurrentWindow();
 const isMacOs =
   typeof navigator !== "undefined" &&
   /(Mac|iPhone|iPod|iPad)/i.test(navigator.userAgent);
+
+function getPrimaryRemainingPercent(usage: UsageInfo | undefined): number | null {
+  if (!usage || usage.error) return null;
+  if (usage.primary_used_percent === null || usage.primary_used_percent === undefined) {
+    return null;
+  }
+  return Math.max(0, 100 - usage.primary_used_percent);
+}
+
+function formatThreshold(value: number): string {
+  return Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+}
 
 function App() {
   const {
@@ -39,9 +74,12 @@ function App() {
     cancelOAuthLogin,
     loadMaskedAccountIds,
     saveMaskedAccountIds,
+    loadUsageAutomationSettings,
+    saveUsageAutomationSettings,
   } = useAccounts();
 
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [configModalMode, setConfigModalMode] = useState<"slim_export" | "slim_import">(
     "slim_export"
@@ -65,16 +103,18 @@ function App() {
     isError: boolean;
   } | null>(null);
   const [maskedAccounts, setMaskedAccounts] = useState<Set<string>>(new Set());
-  const [otherAccountsSort, setOtherAccountsSort] = useState<
-    | "deadline_asc"
-    | "deadline_desc"
-    | "remaining_desc"
-    | "remaining_asc"
-    | "subscription_asc"
-    | "subscription_desc"
-  >("deadline_asc");
+  const [usageAutomationSettings, setUsageAutomationSettings] =
+    useState<UsageAutomationSettings>(DEFAULT_USAGE_AUTOMATION_SETTINGS);
+  const [settingsDraft, setSettingsDraft] =
+    useState<UsageAutomationSettings>(DEFAULT_USAGE_AUTOMATION_SETTINGS);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
+  const [isSavingSettings, setIsSavingSettings] = useState(false);
+  const [settingsLoaded, setSettingsLoaded] = useState(false);
+  const [otherAccountsSort, setOtherAccountsSort] =
+    useState<OtherAccountsSort>("priority");
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
+  const lastAutomationActionRef = useRef<string | null>(null);
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
     if (typeof window === "undefined") return "light";
     try {
@@ -85,6 +125,61 @@ function App() {
     }
   });
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
+
+  const accountIds = useMemo(() => accounts.map((account) => account.id), [accounts]);
+
+  const normalizePriorityAccountIds = useCallback(
+    (priorityAccountIds: string[]) => {
+      const validIds = new Set(accountIds);
+      const seen = new Set<string>();
+      const normalized: string[] = [];
+
+      priorityAccountIds.forEach((accountId) => {
+        if (validIds.has(accountId) && !seen.has(accountId)) {
+          seen.add(accountId);
+          normalized.push(accountId);
+        }
+      });
+
+      accountIds.forEach((accountId) => {
+        if (!seen.has(accountId)) {
+          seen.add(accountId);
+          normalized.push(accountId);
+        }
+      });
+
+      return normalized;
+    },
+    [accountIds]
+  );
+
+  const effectiveUsageAutomationSettings = useMemo<UsageAutomationSettings>(
+    () => ({
+      ...usageAutomationSettings,
+      priority_account_ids: normalizePriorityAccountIds(
+        usageAutomationSettings.priority_account_ids
+      ),
+    }),
+    [normalizePriorityAccountIds, usageAutomationSettings]
+  );
+
+  const priorityIndex = useMemo(() => {
+    return new Map(
+      effectiveUsageAutomationSettings.priority_account_ids.map((accountId, index) => [
+        accountId,
+        index,
+      ])
+    );
+  }, [effectiveUsageAutomationSettings.priority_account_ids]);
+
+  const accountsById = useMemo(() => {
+    return new Map(accounts.map((account) => [account.id, account]));
+  }, [accounts]);
+
+  const settingsDraftPriorityAccountIds = useMemo(
+    () => normalizePriorityAccountIds(settingsDraft.priority_account_ids),
+    [normalizePriorityAccountIds, settingsDraft.priority_account_ids]
+  );
 
   const handleTitlebarDrag = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -147,6 +242,12 @@ function App() {
     }
   }, []);
 
+  const closeCodexProcesses = useCallback(async () => {
+    const info = await invokeBackend<CodexProcessInfo>("close_codex_processes");
+    setProcessInfo(info);
+    return info;
+  }, []);
+
   // Check processes on mount and periodically
   useEffect(() => {
     checkProcesses();
@@ -162,6 +263,30 @@ function App() {
       }
     });
   }, [loadMaskedAccountIds]);
+
+  // Load usage automation settings from storage on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    loadUsageAutomationSettings()
+      .then((settings) => {
+        if (cancelled) return;
+        setUsageAutomationSettings(settings);
+        setSettingsDraft(settings);
+      })
+      .catch((err) => {
+        console.error("Failed to load usage automation settings:", err);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setSettingsLoaded(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadUsageAutomationSettings]);
 
   useEffect(() => {
     if (!isActionsMenuOpen) return;
@@ -262,12 +387,12 @@ function App() {
     }
   };
 
-  const showWarmupToast = (message: string, isError = false) => {
+  const showWarmupToast = useCallback((message: string, isError = false) => {
     setWarmupToast({ message, isError });
     setTimeout(() => setWarmupToast(null), 2500);
-  };
+  }, []);
 
-  const formatWarmupError = (err: unknown) => {
+  const formatWarmupError = useCallback((err: unknown) => {
     if (!err) return "Unknown error";
     if (err instanceof Error && err.message) return err.message;
     if (typeof err === "string") return err;
@@ -275,6 +400,107 @@ function App() {
       return JSON.stringify(err);
     } catch {
       return "Unknown error";
+    }
+  }, []);
+
+  const openSettingsModal = () => {
+    setSettingsDraft({
+      ...effectiveUsageAutomationSettings,
+      priority_account_ids: normalizePriorityAccountIds(
+        effectiveUsageAutomationSettings.priority_account_ids
+      ),
+    });
+    setSettingsError(null);
+    setIsSettingsModalOpen(true);
+  };
+
+  const updateSettingsDraftPercent = (
+    key: "warning_remaining_percent" | "auto_switch_remaining_percent",
+    value: string
+  ) => {
+    const parsed = Number(value);
+    setSettingsDraft((prev) => ({
+      ...prev,
+      [key]: Number.isFinite(parsed) ? parsed : 0,
+    }));
+  };
+
+  const movePriorityAccount = (accountId: string, direction: -1 | 1) => {
+    setSettingsDraft((prev) => {
+      const priorityIds = normalizePriorityAccountIds(prev.priority_account_ids);
+      const currentIndex = priorityIds.indexOf(accountId);
+      const nextIndex = currentIndex + direction;
+
+      if (
+        currentIndex < 0 ||
+        nextIndex < 0 ||
+        nextIndex >= priorityIds.length
+      ) {
+        return prev;
+      }
+
+      const nextPriorityIds = [...priorityIds];
+      const [moved] = nextPriorityIds.splice(currentIndex, 1);
+      nextPriorityIds.splice(nextIndex, 0, moved);
+
+      return {
+        ...prev,
+        priority_account_ids: nextPriorityIds,
+      };
+    });
+  };
+
+  const handleSaveSettings = async () => {
+    const nextSettings: UsageAutomationSettings = {
+      ...settingsDraft,
+      warning_remaining_percent: Number(settingsDraft.warning_remaining_percent),
+      auto_switch_remaining_percent: Number(
+        settingsDraft.auto_switch_remaining_percent
+      ),
+      priority_account_ids: normalizePriorityAccountIds(
+        settingsDraft.priority_account_ids
+      ),
+    };
+
+    if (
+      !Number.isFinite(nextSettings.warning_remaining_percent) ||
+      !Number.isFinite(nextSettings.auto_switch_remaining_percent)
+    ) {
+      setSettingsError("Thresholds must be valid numbers.");
+      return;
+    }
+
+    if (
+      nextSettings.warning_remaining_percent < 0 ||
+      nextSettings.warning_remaining_percent > 100 ||
+      nextSettings.auto_switch_remaining_percent < 0 ||
+      nextSettings.auto_switch_remaining_percent > 100
+    ) {
+      setSettingsError("Thresholds must be between 0 and 100.");
+      return;
+    }
+
+    if (
+      nextSettings.warning_remaining_percent <
+      nextSettings.auto_switch_remaining_percent
+    ) {
+      setSettingsError("Warning threshold must be greater than or equal to auto-switch threshold.");
+      return;
+    }
+
+    try {
+      setIsSavingSettings(true);
+      setSettingsError(null);
+      await saveUsageAutomationSettings(nextSettings);
+      setUsageAutomationSettings(nextSettings);
+      setSettingsDraft(nextSettings);
+      setIsSettingsModalOpen(false);
+      showWarmupToast("Usage automation settings saved.");
+    } catch (err) {
+      console.error("Failed to save usage automation settings:", err);
+      setSettingsError(formatWarmupError(err));
+    } finally {
+      setIsSavingSettings(false);
     }
   };
 
@@ -415,6 +641,163 @@ function App() {
   const activeAccount = accounts.find((a) => a.is_active);
   const otherAccounts = accounts.filter((a) => !a.is_active);
   const hasRunningProcesses = processInfo && processInfo.count > 0;
+  const activeRemainingPercent = getPrimaryRemainingPercent(activeAccount?.usage);
+
+  const usageWarningMessage =
+    activeAccount &&
+    activeRemainingPercent !== null &&
+    activeRemainingPercent < effectiveUsageAutomationSettings.warning_remaining_percent
+      ? `${activeAccount.name} has ${formatThreshold(activeRemainingPercent)}% 5h usage remaining.`
+      : null;
+
+  useEffect(() => {
+    if (!settingsLoaded || !activeAccount) return;
+    if (switchingId || accounts.some((account) => account.usageLoading)) return;
+
+    const remainingPercent = getPrimaryRemainingPercent(activeAccount.usage);
+    if (
+      remainingPercent === null ||
+      remainingPercent >=
+        effectiveUsageAutomationSettings.auto_switch_remaining_percent
+    ) {
+      lastAutomationActionRef.current = null;
+      return;
+    }
+
+    if (!effectiveUsageAutomationSettings.auto_switch_enabled) return;
+
+    const accountUsageSnapshot = accounts
+      .map((account) => {
+        const remaining = getPrimaryRemainingPercent(account.usage);
+        return [
+          account.id,
+          remaining === null ? "unknown" : formatThreshold(remaining),
+          account.usage?.primary_resets_at ?? "no-reset",
+        ].join("/");
+      })
+      .join("|");
+
+    const actionKey = [
+      activeAccount.id,
+      formatThreshold(remainingPercent),
+      effectiveUsageAutomationSettings.auto_switch_remaining_percent,
+      effectiveUsageAutomationSettings.auto_switch_strategy,
+      effectiveUsageAutomationSettings.auto_close_codex_on_switch ? "close" : "pause",
+      effectiveUsageAutomationSettings.priority_account_ids.join(","),
+      processInfo?.count ?? "unknown",
+      accountUsageSnapshot,
+    ].join(":");
+
+    if (lastAutomationActionRef.current === actionKey) return;
+    lastAutomationActionRef.current = actionKey;
+
+    let cancelled = false;
+
+    const runAutoSwitch = async () => {
+      const latestProcessInfo = await checkProcesses();
+      if (cancelled) return;
+
+      if (!latestProcessInfo) {
+        showWarmupToast("Auto-switch paused. Could not check Codex processes.", true);
+        return;
+      }
+
+      if (!latestProcessInfo.can_switch) {
+        if (!effectiveUsageAutomationSettings.auto_close_codex_on_switch) {
+          showWarmupToast(
+            "Auto-switch paused. Close all Codex processes before switching.",
+            true
+          );
+          return;
+        }
+
+        try {
+          showWarmupToast("Auto-switch is closing Codex before switching.");
+          const closedInfo = await closeCodexProcesses();
+          if (cancelled) return;
+          if (!closedInfo.can_switch) {
+            showWarmupToast("Auto-switch paused. Codex is still running.", true);
+            return;
+          }
+        } catch (err) {
+          console.error("Failed to close Codex before auto-switch:", err);
+          showWarmupToast(
+            `Auto-switch paused. Could not close Codex: ${formatWarmupError(err)}`,
+            true
+          );
+          return;
+        }
+      }
+
+      const switchThreshold =
+        effectiveUsageAutomationSettings.auto_switch_remaining_percent;
+      const priorityRank = (accountId: string) =>
+        priorityIndex.get(accountId) ?? Number.MAX_SAFE_INTEGER;
+      const candidates = accounts
+        .filter((account) => {
+          if (account.id === activeAccount.id) return false;
+          const accountRemaining = getPrimaryRemainingPercent(account.usage);
+          return accountRemaining !== null && accountRemaining >= switchThreshold;
+        })
+        .sort((a, b) => {
+          const aRemaining = getPrimaryRemainingPercent(a.usage) ?? -1;
+          const bRemaining = getPrimaryRemainingPercent(b.usage) ?? -1;
+
+          if (
+            effectiveUsageAutomationSettings.auto_switch_strategy ===
+            "remaining_desc"
+          ) {
+            const remainingDiff = bRemaining - aRemaining;
+            if (remainingDiff !== 0) return remainingDiff;
+          } else {
+            const aReset = a.usage?.primary_resets_at ?? Number.POSITIVE_INFINITY;
+            const bReset = b.usage?.primary_resets_at ?? Number.POSITIVE_INFINITY;
+            const resetDiff = aReset - bReset;
+            if (resetDiff !== 0) return resetDiff;
+          }
+
+          const priorityDiff = priorityRank(a.id) - priorityRank(b.id);
+          if (priorityDiff !== 0) return priorityDiff;
+          return a.name.localeCompare(b.name);
+        });
+
+      const nextAccount = candidates[0];
+      if (!nextAccount) {
+        showWarmupToast("Auto-switch skipped. No eligible account is available.", true);
+        return;
+      }
+
+      try {
+        setSwitchingId(nextAccount.id);
+        await switchAccount(nextAccount.id);
+        showWarmupToast(`Auto-switched to ${nextAccount.name}.`);
+      } catch (err) {
+        console.error("Failed to auto-switch account:", err);
+        showWarmupToast(`Auto-switch failed: ${formatWarmupError(err)}`, true);
+      } finally {
+        setSwitchingId(null);
+      }
+    };
+
+    void runAutoSwitch();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    accounts,
+    activeAccount,
+    checkProcesses,
+    closeCodexProcesses,
+    effectiveUsageAutomationSettings,
+    formatWarmupError,
+    priorityIndex,
+    processInfo?.count,
+    settingsLoaded,
+    showWarmupToast,
+    switchingId,
+    switchAccount,
+  ]);
 
   const sortedOtherAccounts = useMemo(() => {
     const getResetDeadline = (resetAt: number | null | undefined) =>
@@ -466,6 +849,19 @@ function App() {
           getRemainingPercent(a.usage?.primary_used_percent);
         if (remainingDiff !== 0) return remainingDiff;
 
+        const priorityDiff =
+          (priorityIndex.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+          (priorityIndex.get(b.id) ?? Number.MAX_SAFE_INTEGER);
+        if (priorityDiff !== 0) return priorityDiff;
+
+        return a.name.localeCompare(b.name);
+      }
+
+      if (otherAccountsSort === "priority") {
+        const priorityDiff =
+          (priorityIndex.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+          (priorityIndex.get(b.id) ?? Number.MAX_SAFE_INTEGER);
+        if (priorityDiff !== 0) return priorityDiff;
         return a.name.localeCompare(b.name);
       }
 
@@ -498,7 +894,7 @@ function App() {
       if (deadlineDiff !== 0) return deadlineDiff;
       return a.name.localeCompare(b.name);
     });
-  }, [otherAccounts, otherAccountsSort]);
+  }, [otherAccounts, otherAccountsSort, priorityIndex]);
 
   return (
     <div className="min-h-screen bg-gray-50 text-gray-900 dark:bg-gray-950 dark:text-gray-100">
@@ -630,6 +1026,24 @@ function App() {
                 <span className={isWarmingAll ? "animate-pulse" : ""}>⚡</span>
               </button>
               <button
+                onClick={openSettingsModal}
+                className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 shrink-0"
+                title="Usage automation settings"
+              >
+                <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+                  <path
+                    d="M12 15.5A3.5 3.5 0 1 0 12 8a3.5 3.5 0 0 0 0 7.5Z"
+                    strokeWidth="2"
+                  />
+                  <path
+                    d="M19.4 15a1.8 1.8 0 0 0 .36 1.98l.05.05a2.1 2.1 0 0 1-2.97 2.97l-.05-.05a1.8 1.8 0 0 0-1.98-.36 1.8 1.8 0 0 0-1.1 1.66V21a2.1 2.1 0 0 1-4.2 0v-.07a1.8 1.8 0 0 0-1.1-1.66 1.8 1.8 0 0 0-1.98.36l-.05.05a2.1 2.1 0 1 1-2.97-2.97l.05-.05A1.8 1.8 0 0 0 3.6 15a1.8 1.8 0 0 0-1.66-1.1H2a2.1 2.1 0 0 1 0-4.2h.07a1.8 1.8 0 0 0 1.66-1.1 1.8 1.8 0 0 0-.36-1.98l-.05-.05A2.1 2.1 0 1 1 6.3 3.6l.05.05a1.8 1.8 0 0 0 1.98.36 1.8 1.8 0 0 0 1.1-1.66V2a2.1 2.1 0 0 1 4.2 0v.07a1.8 1.8 0 0 0 1.1 1.66 1.8 1.8 0 0 0 1.98-.36l.05-.05a2.1 2.1 0 1 1 2.97 2.97l-.05.05a1.8 1.8 0 0 0-.36 1.98 1.8 1.8 0 0 0 1.66 1.1H22a2.1 2.1 0 0 1 0 4.2h-.07A1.8 1.8 0 0 0 19.4 15Z"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+              <button
                 onClick={() => setThemeMode((prev) => (prev === "dark" ? "light" : "dark"))}
                 className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 text-lg text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 shrink-0"
                 title={themeMode === "dark" ? "Switch to light mode" : "Switch to dark mode"}
@@ -741,6 +1155,14 @@ function App() {
                 <h2 className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
                   Active Account
                 </h2>
+                {usageWarningMessage && (
+                  <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/30 dark:text-amber-200">
+                    {usageWarningMessage}
+                    {effectiveUsageAutomationSettings.auto_switch_enabled
+                      ? " Auto-switch is enabled."
+                      : " Auto-switch is off."}
+                  </div>
+                )}
                 <AccountCard
                   account={activeAccount}
                   onSwitch={() => { }}
@@ -777,18 +1199,11 @@ function App() {
                         id="other-accounts-sort"
                         value={otherAccountsSort}
                         onChange={(e) =>
-                          setOtherAccountsSort(
-                            e.target.value as
-                              | "deadline_asc"
-                              | "deadline_desc"
-                              | "remaining_desc"
-                              | "remaining_asc"
-                              | "subscription_asc"
-                              | "subscription_desc"
-                          )
+                          setOtherAccountsSort(e.target.value as OtherAccountsSort)
                         }
                         className="appearance-none font-sans text-xs sm:text-sm font-medium pl-3 pr-9 py-2 rounded-xl border border-gray-300 dark:border-gray-700 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800 text-gray-700 dark:text-gray-200 shadow-sm hover:border-gray-400 dark:hover:border-gray-600 hover:shadow focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600 focus:border-gray-400 dark:focus:border-gray-600 transition-all"
                       >
+                        <option value="priority">Manual priority</option>
                         <option value="deadline_asc">Reset: earliest to latest</option>
                         <option value="deadline_desc">Reset: latest to earliest</option>
                         <option value="remaining_desc">
@@ -880,6 +1295,271 @@ function App() {
         onCompleteOAuth={completeOAuthLogin}
         onCancelOAuth={cancelOAuthLogin}
       />
+
+      {/* Usage Automation Settings Modal */}
+      {isSettingsModalOpen && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl w-full max-w-2xl mx-4 shadow-xl max-h-[88vh] overflow-hidden flex flex-col">
+            <div className="flex items-center justify-between p-5 border-b border-gray-100 dark:border-gray-800">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Usage Automation
+              </h2>
+              <button
+                onClick={() => setIsSettingsModalOpen(false)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="p-5 space-y-5 overflow-y-auto">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <label className="space-y-1">
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                    Warning threshold
+                  </span>
+                  <div className="relative">
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.1"
+                      value={settingsDraft.warning_remaining_percent}
+                      onChange={(event) =>
+                        updateSettingsDraftPercent(
+                          "warning_remaining_percent",
+                          event.target.value
+                        )
+                      }
+                      className="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 pr-9 text-sm text-gray-900 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-gray-500 dark:focus:ring-gray-500"
+                    />
+                    <span className="absolute inset-y-0 right-3 flex items-center text-sm text-gray-400">
+                      %
+                    </span>
+                  </div>
+                </label>
+
+                <label className="space-y-1">
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                    Auto-switch threshold
+                  </span>
+                  <div className="relative">
+                    <input
+                      type="number"
+                      min="0"
+                      max="100"
+                      step="0.1"
+                      value={settingsDraft.auto_switch_remaining_percent}
+                      onChange={(event) =>
+                        updateSettingsDraftPercent(
+                          "auto_switch_remaining_percent",
+                          event.target.value
+                        )
+                      }
+                      className="w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 pr-9 text-sm text-gray-900 focus:border-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-gray-500 dark:focus:ring-gray-500"
+                    />
+                    <span className="absolute inset-y-0 right-3 flex items-center text-sm text-gray-400">
+                      %
+                    </span>
+                  </div>
+                </label>
+              </div>
+
+              <div className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 px-4 py-3 dark:border-gray-700">
+                <div>
+                  <div className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                    Auto-switch
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {settingsDraft.auto_switch_enabled ? "Enabled" : "Disabled"}
+                  </div>
+                </div>
+                <button
+                  onClick={() =>
+                    setSettingsDraft((prev) => ({
+                      ...prev,
+                      auto_switch_enabled: !prev.auto_switch_enabled,
+                    }))
+                  }
+                  className={`relative h-7 w-12 rounded-full transition-colors ${
+                    settingsDraft.auto_switch_enabled
+                      ? "bg-emerald-500"
+                      : "bg-gray-300 dark:bg-gray-700"
+                  }`}
+                  aria-pressed={settingsDraft.auto_switch_enabled}
+                  title={
+                    settingsDraft.auto_switch_enabled
+                      ? "Disable auto-switch"
+                      : "Enable auto-switch"
+                  }
+                >
+                  <span
+                    className={`absolute left-1 top-1 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                      settingsDraft.auto_switch_enabled
+                        ? "translate-x-5"
+                        : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+
+              {settingsDraft.auto_switch_enabled ? (
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between gap-4 rounded-lg border border-gray-200 px-4 py-3 dark:border-gray-700">
+                    <div>
+                      <div className="text-sm font-medium text-gray-800 dark:text-gray-100">
+                        Close Codex before switching
+                      </div>
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        {settingsDraft.auto_close_codex_on_switch
+                          ? "Codex will be closed when it blocks auto-switch."
+                          : "Auto-switch pauses while Codex is running."}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() =>
+                        setSettingsDraft((prev) => ({
+                          ...prev,
+                          auto_close_codex_on_switch: !prev.auto_close_codex_on_switch,
+                        }))
+                      }
+                      className={`relative h-7 w-12 rounded-full transition-colors ${
+                        settingsDraft.auto_close_codex_on_switch
+                          ? "bg-amber-500"
+                          : "bg-gray-300 dark:bg-gray-700"
+                      }`}
+                      aria-pressed={settingsDraft.auto_close_codex_on_switch}
+                      title={
+                        settingsDraft.auto_close_codex_on_switch
+                          ? "Pause instead of closing Codex"
+                          : "Close Codex before auto-switching"
+                      }
+                    >
+                      <span
+                        className={`absolute left-1 top-1 h-5 w-5 rounded-full bg-white shadow transition-transform ${
+                          settingsDraft.auto_close_codex_on_switch
+                            ? "translate-x-5"
+                            : "translate-x-0"
+                        }`}
+                      />
+                    </button>
+                  </div>
+
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                    Auto-switch strategy
+                  </div>
+                  <div className="grid grid-cols-2 gap-2 rounded-lg bg-gray-100 p-1 dark:bg-gray-800">
+                    {(
+                      [
+                        ["remaining_desc", "Usage first"],
+                        ["reset_time_asc", "Reset first"],
+                      ] as Array<[AutoSwitchStrategy, string]>
+                    ).map(([strategy, label]) => (
+                      <button
+                        key={strategy}
+                        onClick={() =>
+                          setSettingsDraft((prev) => ({
+                            ...prev,
+                            auto_switch_strategy: strategy,
+                          }))
+                        }
+                        className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                          settingsDraft.auto_switch_strategy === strategy
+                            ? "bg-white text-gray-900 shadow-sm dark:bg-gray-950 dark:text-gray-100"
+                            : "text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-100"
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200">
+                    Manual priority
+                  </div>
+                  <div className="space-y-2">
+                    {settingsDraftPriorityAccountIds.length === 0 ? (
+                      <div className="rounded-lg border border-dashed border-gray-200 px-4 py-6 text-center text-sm text-gray-400 dark:border-gray-700 dark:text-gray-500">
+                        No accounts
+                      </div>
+                    ) : (
+                      settingsDraftPriorityAccountIds.map((accountId, index) => {
+                        const account = accountsById.get(accountId);
+                        if (!account) return null;
+
+                        return (
+                          <div
+                            key={accountId}
+                            className="flex items-center gap-3 rounded-lg border border-gray-200 px-3 py-2 dark:border-gray-700"
+                          >
+                            <div className="flex h-7 w-7 items-center justify-center rounded-md bg-gray-100 text-xs font-semibold text-gray-500 dark:bg-gray-800 dark:text-gray-300">
+                              {index + 1}
+                            </div>
+                            <div className="min-w-0 flex-1">
+                              <div className="truncate text-sm font-medium text-gray-800 dark:text-gray-100">
+                                {account.name}
+                              </div>
+                              {account.email && (
+                                <div className="truncate text-xs text-gray-500 dark:text-gray-400">
+                                  {account.email}
+                                </div>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-1">
+                              <button
+                                onClick={() => movePriorityAccount(accountId, -1)}
+                                disabled={index === 0}
+                                className="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 text-gray-600 transition-colors hover:bg-gray-200 disabled:opacity-40 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                                title="Move up"
+                              >
+                                ↑
+                              </button>
+                              <button
+                                onClick={() => movePriorityAccount(accountId, 1)}
+                                disabled={
+                                  index === settingsDraftPriorityAccountIds.length - 1
+                                }
+                                className="flex h-8 w-8 items-center justify-center rounded-md bg-gray-100 text-gray-600 transition-colors hover:bg-gray-200 disabled:opacity-40 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+                                title="Move down"
+                              >
+                                ↓
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {settingsError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600 dark:border-red-700 dark:bg-red-900/20 dark:text-red-300">
+                  {settingsError}
+                </div>
+              )}
+            </div>
+
+            <div className="flex gap-3 p-5 border-t border-gray-100 dark:border-gray-800">
+              <button
+                onClick={() => setIsSettingsModalOpen(false)}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors"
+              >
+                Close
+              </button>
+              <button
+                onClick={handleSaveSettings}
+                disabled={isSavingSettings}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 transition-colors disabled:opacity-50"
+              >
+                {isSavingSettings ? "Saving..." : "Save Settings"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Import/Export Config Modal */}
       {isConfigModalOpen && (

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -5,6 +5,7 @@ import type {
   AccountWithUsage,
   WarmupSummary,
   ImportAccountsSummary,
+  UsageAutomationSettings,
 } from "../types";
 import { invokeBackend, type FileSource } from "../lib/platform";
 
@@ -378,6 +379,18 @@ export function useAccounts() {
     }
   }, []);
 
+  const loadUsageAutomationSettings = useCallback(async () => {
+    return await invokeBackend<UsageAutomationSettings>("get_usage_automation_settings");
+  }, []);
+
+  const saveUsageAutomationSettings = useCallback(
+    async (settings: UsageAutomationSettings) => {
+      await invokeBackend("set_usage_automation_settings", { settings });
+      await loadAccounts(true);
+    },
+    [loadAccounts]
+  );
+
   useEffect(() => {
     loadAccounts().then((accountList) => refreshUsage(accountList));
     
@@ -411,5 +424,7 @@ export function useAccounts() {
     cancelOAuthLogin,
     loadMaskedAccountIds,
     saveMaskedAccountIds,
+    loadUsageAutomationSettings,
+    saveUsageAutomationSettings,
   };
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 // Types matching the Rust backend
 
 export type AuthMode = "api_key" | "chat_g_p_t";
+export type AutoSwitchStrategy = "remaining_desc" | "reset_time_asc";
 
 export interface AccountInfo {
   id: string;
@@ -37,6 +38,15 @@ export interface OAuthLoginInfo {
 export interface AccountWithUsage extends AccountInfo {
   usage?: UsageInfo;
   usageLoading?: boolean;
+}
+
+export interface UsageAutomationSettings {
+  warning_remaining_percent: number;
+  auto_switch_remaining_percent: number;
+  auto_switch_enabled: boolean;
+  auto_close_codex_on_switch: boolean;
+  auto_switch_strategy: AutoSwitchStrategy;
+  priority_account_ids: string[];
 }
 
 export interface CodexProcessInfo {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,6 +45,7 @@ export interface UsageAutomationSettings {
   auto_switch_remaining_percent: number;
   auto_switch_enabled: boolean;
   auto_close_codex_on_switch: boolean;
+  auto_reopen_codex_after_switch: boolean;
   auto_switch_strategy: AutoSwitchStrategy;
   priority_account_ids: string[];
 }


### PR DESCRIPTION
## Summary
- keeps the usage automation controls from PR #53
- fails closed when Codex process detection is unavailable
- adds an option to close Codex before auto-switching, then switch accounts safely
- adds an option to reopen Codex after the account switch succeeds

JSON account export is intentionally not included in this PR.

## Validation
- pnpm build
- cargo check --manifest-path src-tauri\Cargo.toml
- cargo test --manifest-path src-tauri\Cargo.toml

## Notes
This keeps the automation execution in the app runtime; it does not add a separate backend worker or OS-level scheduled runner.