### PR TITLE
Add system tray account switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 - **Multi-Account Management** – Add and manage multiple Codex accounts in one place
 - **Quick Switching** – Switch between accounts with a single click
+- **System Tray Switching** – Switch accounts directly from the menu bar or system tray
 - **Usage Monitoring** – View real-time usage for both 5-hour and weekly limits
 - **Dual Login Mode** – OAuth authentication or import existing `auth.json` files
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - .
+
 allowBuilds:
   esbuild: true

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2.10", features = [] }
+tauri = { version = "2.10", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2.6"
 tauri-plugin-process = "2"

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -126,6 +126,10 @@ pub async fn add_account_from_auth_json_text(
 /// Switch to a different account
 #[tauri::command]
 pub async fn switch_account(account_id: String) -> Result<(), String> {
+    switch_account_by_id(&account_id)
+}
+
+pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
     let store = load_accounts().map_err(|e| e.to_string())?;
 
     // Find the account
@@ -139,10 +143,10 @@ pub async fn switch_account(account_id: String) -> Result<(), String> {
     switch_to_account(account).map_err(|e| e.to_string())?;
 
     // Update the active account in our store
-    set_active_account(&account_id).map_err(|e| e.to_string())?;
+    set_active_account(account_id).map_err(|e| e.to_string())?;
 
     // Update last_used_at
-    touch_account(&account_id).map_err(|e| e.to_string())?;
+    touch_account(account_id).map_err(|e| e.to_string())?;
 
     // Restart Antigravity background process if it is running
     // This allows it to pick up the new authorization file seamlessly

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -7,6 +7,8 @@ use crate::auth::{
 };
 use crate::types::{AccountInfo, AccountsStore, AuthData, ImportAccountsSummary, StoredAccount};
 
+use super::process::ensure_codex_not_running;
+
 use anyhow::Context;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use chacha20poly1305::{
@@ -138,6 +140,8 @@ pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
         .iter()
         .find(|a| a.id == account_id)
         .ok_or_else(|| format!("Account not found: {account_id}"))?;
+
+    ensure_codex_not_running()?;
 
     // Write to ~/.codex/auth.json
     switch_to_account(account).map_err(|e| e.to_string())?;

--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -60,6 +60,8 @@ struct UnixProcessSnapshot {
     uid_by_pid: HashMap<u32, u32>,
 }
 
+const CODEX_RUNNING_SWITCH_BLOCKED_PREFIX: &str = "Cannot switch accounts while ";
+
 /// Check for running Codex processes
 #[tauri::command]
 pub async fn check_codex_processes() -> Result<CodexProcessInfo, String> {
@@ -82,10 +84,14 @@ pub(crate) fn ensure_codex_not_running() -> Result<(), String> {
     }
 
     Err(format!(
-        "Cannot switch accounts while {} Codex process{} running",
+        "{CODEX_RUNNING_SWITCH_BLOCKED_PREFIX}{} Codex process{} running",
         pids.len(),
         if pids.len() == 1 { " is" } else { "es are" }
     ))
+}
+
+pub(crate) fn is_codex_running_switch_block(error: &str) -> bool {
+    error.starts_with(CODEX_RUNNING_SWITCH_BLOCKED_PREFIX)
 }
 
 /// Force-close active Codex processes that currently block account switching.

--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -74,6 +74,20 @@ pub async fn check_codex_processes() -> Result<CodexProcessInfo, String> {
     })
 }
 
+pub(crate) fn ensure_codex_not_running() -> Result<(), String> {
+    let (pids, _) = find_codex_processes().map_err(|e| e.to_string())?;
+
+    if pids.is_empty() {
+        return Ok(());
+    }
+
+    Err(format!(
+        "Cannot switch accounts while {} Codex process{} running",
+        pids.len(),
+        if pids.len() == 1 { " is" } else { "es are" }
+    ))
+}
+
 /// Force-close active Codex processes that currently block account switching.
 #[tauri::command]
 pub async fn kill_codex_processes() -> Result<KillCodexProcessesResult, String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@
 pub mod api;
 pub mod auth;
 pub mod commands;
+#[cfg(desktop)]
+pub mod tray;
 pub mod types;
 pub mod web;
 
@@ -23,9 +25,21 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .setup(|app| {
             #[cfg(desktop)]
-            app.handle()
-                .plugin(tauri_plugin_updater::Builder::new().build())?;
+            {
+                app.handle()
+                    .plugin(tauri_plugin_updater::Builder::new().build())?;
+                tray::setup(app.handle())?;
+            }
             Ok(())
+        })
+        .on_window_event(|window, event| {
+            #[cfg(desktop)]
+            if window.label() == "main" {
+                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+            }
         })
         .invoke_handler(tauri::generate_handler![
             commands::open_codex_app,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,177 @@
+use std::time::{Duration, SystemTime};
+
+use tauri::{
+    menu::{CheckMenuItemBuilder, Menu, MenuItemBuilder, PredefinedMenuItem},
+    tray::TrayIconBuilder,
+    AppHandle, Emitter, Manager, Runtime,
+};
+
+use crate::{
+    auth::{get_accounts_file, load_accounts},
+    commands::switch_account_by_id,
+    types::AccountsStore,
+};
+
+const TRAY_ID: &str = "codex-switcher-tray";
+const ACCOUNT_ITEM_PREFIX: &str = "account:";
+const OPEN_ITEM_ID: &str = "open";
+const QUIT_ITEM_ID: &str = "quit";
+const ACCOUNTS_CHANGED_EVENT: &str = "accounts-changed";
+
+pub fn setup(app: &AppHandle) -> tauri::Result<()> {
+    let menu = build_menu(app, &load_accounts().unwrap_or_default())?;
+    let icon = app
+        .default_window_icon()
+        .cloned()
+        .expect("application icon should be configured");
+
+    TrayIconBuilder::with_id(TRAY_ID)
+        .icon(icon)
+        .tooltip("Codex Switcher")
+        .menu(&menu)
+        .show_menu_on_left_click(true)
+        .on_menu_event(handle_menu_event)
+        .build(app)?;
+
+    watch_accounts_file(app.clone());
+    Ok(())
+}
+
+fn build_menu<R: Runtime>(app: &AppHandle<R>, store: &AccountsStore) -> tauri::Result<Menu<R>> {
+    let menu = Menu::new(app)?;
+
+    if store.accounts.is_empty() {
+        menu.append(
+            &MenuItemBuilder::with_id("empty", "No accounts configured")
+                .enabled(false)
+                .build(app)?,
+        )?;
+    } else {
+        for account in &store.accounts {
+            let item = CheckMenuItemBuilder::with_id(
+                account_menu_id(&account.id),
+                menu_label(&account.name),
+            )
+            .checked(store.active_account_id.as_deref() == Some(&account.id))
+            .build(app)?;
+            menu.append(&item)?;
+        }
+    }
+
+    menu.append(&PredefinedMenuItem::separator(app)?)?;
+    menu.append(&MenuItemBuilder::with_id(OPEN_ITEM_ID, "Open Codex Switcher").build(app)?)?;
+    menu.append(&MenuItemBuilder::with_id(QUIT_ITEM_ID, "Quit").build(app)?)?;
+    Ok(menu)
+}
+
+fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    let item_id = event.id().as_ref();
+
+    match item_id {
+        OPEN_ITEM_ID => show_main_window(app),
+        QUIT_ITEM_ID => app.exit(0),
+        _ => {
+            let Some(account_id) = item_id.strip_prefix(ACCOUNT_ITEM_PREFIX) else {
+                return;
+            };
+
+            if load_accounts()
+                .ok()
+                .and_then(|store| store.active_account_id)
+                .as_deref()
+                == Some(account_id)
+            {
+                refresh_menu(app);
+                return;
+            }
+
+            if let Err(error) = switch_account_by_id(account_id) {
+                eprintln!("Failed to switch account from tray: {error}");
+                refresh_menu(app);
+                return;
+            }
+
+            refresh_menu(app);
+            let _ = app.emit(ACCOUNTS_CHANGED_EVENT, ());
+        }
+    }
+}
+
+fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+fn refresh_menu<R: Runtime>(app: &AppHandle<R>) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+
+    match load_accounts()
+        .map_err(|error| error.to_string())
+        .and_then(|store| build_menu(app, &store).map_err(|error| error.to_string()))
+    {
+        Ok(menu) => {
+            if let Err(error) = tray.set_menu(Some(menu)) {
+                eprintln!("Failed to refresh tray menu: {error}");
+            }
+        }
+        Err(error) => eprintln!("Failed to build tray menu: {error}"),
+    }
+}
+
+fn watch_accounts_file<R: Runtime>(app: AppHandle<R>) {
+    std::thread::spawn(move || {
+        let accounts_path = match get_accounts_file() {
+            Ok(path) => path,
+            Err(error) => {
+                eprintln!("Failed to resolve accounts file for tray: {error}");
+                return;
+            }
+        };
+        let mut last_modified = modified_at(&accounts_path);
+
+        loop {
+            std::thread::sleep(Duration::from_secs(1));
+            let modified = modified_at(&accounts_path);
+            if modified != last_modified {
+                last_modified = modified;
+                refresh_menu(&app);
+            }
+        }
+    });
+}
+
+fn modified_at(path: &std::path::Path) -> Option<SystemTime> {
+    path.metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok()
+}
+
+fn account_menu_id(account_id: &str) -> String {
+    format!("{ACCOUNT_ITEM_PREFIX}{account_id}")
+}
+
+fn menu_label(label: &str) -> String {
+    label.replace('&', "&&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn account_ids_are_namespaced_for_tray_events() {
+        assert_eq!(account_menu_id("abc-123"), "account:abc-123");
+    }
+
+    #[test]
+    fn menu_labels_escape_mnemonic_markers() {
+        assert_eq!(
+            menu_label("Research & Development"),
+            "Research && Development"
+        );
+    }
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -8,7 +8,7 @@ use tauri::{
 
 use crate::{
     auth::{get_accounts_file, load_accounts},
-    commands::switch_account_by_id,
+    commands::{is_codex_running_switch_block, switch_account_by_id},
     types::AccountsStore,
 };
 
@@ -17,6 +17,7 @@ const ACCOUNT_ITEM_PREFIX: &str = "account:";
 const OPEN_ITEM_ID: &str = "open";
 const QUIT_ITEM_ID: &str = "quit";
 const ACCOUNTS_CHANGED_EVENT: &str = "accounts-changed";
+const SWITCH_ACCOUNT_BLOCKED_EVENT: &str = "switch-account-blocked";
 
 pub fn setup(app: &AppHandle) -> tauri::Result<()> {
     let menu = build_menu(app, &load_accounts().unwrap_or_default())?;
@@ -88,6 +89,10 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
             if let Err(error) = switch_account_by_id(account_id) {
                 eprintln!("Failed to switch account from tray: {error}");
                 refresh_menu(app);
+                if is_codex_running_switch_block(&error) {
+                    show_main_window(app);
+                    let _ = app.emit(SWITCH_ACCOUNT_BLOCKED_EVENT, error);
+                }
                 return;
             }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ const AUTO_WARMUP_MIN_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
 const AUTO_WARMUP_FULL_WINDOW_SLACK_MINUTES = 5;
 const DEFAULT_PRIMARY_WINDOW_MINUTES = 300;
 const LIMIT_FULL_THRESHOLD = 99.5;
+const SWITCH_ACCOUNT_BLOCKED_EVENT = "switch-account-blocked";
 type ThemeMode = "light" | "dark";
 type AutoWarmupLedger = Record<
   string,
@@ -466,6 +467,27 @@ function App() {
     showToast: showWarmupToast,
     formatError: formatWarmupError,
   });
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    void (async () => {
+      if (!isTauriRuntime()) return;
+      const { listen } = await import("@tauri-apps/api/event");
+      unlisten = await listen<string>(SWITCH_ACCOUNT_BLOCKED_EVENT, async (event) => {
+        const latestProcessInfo = await checkProcesses();
+
+        if (latestProcessInfo && !latestProcessInfo.can_switch) {
+          setForceCloseConfirmOpen(true);
+          return;
+        }
+
+        showWarmupToast(event.payload || "Account switch was blocked.", true);
+      });
+    })();
+
+    return () => unlisten?.();
+  }, [checkProcesses, setForceCloseConfirmOpen, showWarmupToast]);
 
   const handleWarmupAccount = async (accountId: string, accountName: string) => {
     try {

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -390,6 +390,20 @@ export function useAccounts() {
     return () => clearInterval(interval);
   }, [loadAccounts, refreshUsage]);
 
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+
+    void (async () => {
+      if (!("__TAURI_INTERNALS__" in window)) return;
+      const { listen } = await import("@tauri-apps/api/event");
+      unlisten = await listen("accounts-changed", () => {
+        void loadAccounts(true);
+      });
+    })();
+
+    return () => unlisten?.();
+  }, [loadAccounts]);
+
   return {
     accounts,
     loading,


### PR DESCRIPTION
## Summary

Add a native system tray/menu bar icon that allows users to switch Codex accounts without opening the main application window.

## Changes

- List configured accounts in the system tray menu
- Mark the currently active account
- Switch accounts directly from the tray
- Actions to open Codex Switcher and quit the application
- Allow esbuild dependency scripts for pnpm 11

## Testing
- Manually tested tray behavior and account switching on macOS
- Verified closing and reopening the main window from the tray
- Ran Rust tests and checks
- Ran TypeScript type checking
- Ran Vite production build

Windows and Linux use Tauri's cross-platform tray API but have not been manually tested.

<img width="197" height="158" alt="Screenshot 2026-06-05 at 14 54 09" src="https://github.com/user-attachments/assets/cdbbf4e1-0e53-4b5a-83aa-31aa60edd74e" />
