### PR TITLE
Add tray auto warm-up toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,15 @@ import {
   THEME_STORAGE_KEY,
   type ThemeMode,
 } from "./lib/theme";
+import {
+  AUTO_WARMUP_ACCOUNTS_STORAGE_KEY,
+  AUTO_WARMUP_ALL_CHANGED_EVENT,
+  AUTO_WARMUP_LEDGER_STORAGE_KEY,
+  readAutoWarmupAllEnabled,
+  writeAutoWarmupAllEnabled,
+} from "./lib/autoWarmup";
 import "./App.css";
 
-const AUTO_WARMUP_ALL_STORAGE_KEY = "codex-switcher-auto-warmup-all";
-const AUTO_WARMUP_ACCOUNTS_STORAGE_KEY = "codex-switcher-auto-warmup-accounts";
-const AUTO_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-auto-warmup-last-success";
 const AUTO_WARMUP_CHECK_INTERVAL_MS = 30 * 1000;
 const AUTO_WARMUP_RETRY_BACKOFF_MS = 5 * 60 * 1000;
 const AUTO_WARMUP_MIN_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
@@ -159,8 +163,7 @@ function App() {
     isError: boolean;
   } | null>(null);
   const [autoWarmupAllEnabled, setAutoWarmupAllEnabled] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(AUTO_WARMUP_ALL_STORAGE_KEY) === "true";
+    return readAutoWarmupAllEnabled();
   });
   const [autoWarmupAccountIds, setAutoWarmupAccountIds] = useState<Set<string>>(
     () => new Set(readStoredStringArray(AUTO_WARMUP_ACCOUNTS_STORAGE_KEY))
@@ -239,12 +242,15 @@ function App() {
 
   useEffect(() => {
     try {
-      window.localStorage.setItem(
-        AUTO_WARMUP_ALL_STORAGE_KEY,
-        String(autoWarmupAllEnabled)
-      );
+      writeAutoWarmupAllEnabled(autoWarmupAllEnabled);
     } catch {
       // Ignore storage errors; auto warm-up still works for the current session.
+    }
+
+    if (isTauriRuntime()) {
+      void import("@tauri-apps/api/event")
+        .then(({ emit }) => emit(AUTO_WARMUP_ALL_CHANGED_EVENT, autoWarmupAllEnabled))
+        .catch((err) => console.error("Failed to sync tray auto warm-up:", err));
     }
   }, [autoWarmupAllEnabled]);
 
@@ -477,6 +483,7 @@ function App() {
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;
+    let unlistenAutoWarmup: (() => void) | undefined;
 
     void (async () => {
       if (!isTauriRuntime()) return;
@@ -514,9 +521,20 @@ function App() {
           );
         }
       );
+      unlistenAutoWarmup = await listen<boolean>(
+        AUTO_WARMUP_ALL_CHANGED_EVENT,
+        ({ payload }) => {
+          if (typeof payload === "boolean") {
+            setAutoWarmupAllEnabled(payload);
+          }
+        }
+      );
     })();
 
-    return () => unlisten?.();
+    return () => {
+      unlisten?.();
+      unlistenAutoWarmup?.();
+    };
   }, [checkProcesses, formatWarmupError, setForceCloseConfirmOpen, showWarmupToast, switchAccount]);
 
   const handleForceCloseConfirm = useCallback(async () => {

--- a/src/TrayMenu.tsx
+++ b/src/TrayMenu.tsx
@@ -7,6 +7,11 @@ import {
   THEME_CHANGED_EVENT,
   type ThemeMode,
 } from "./lib/theme";
+import {
+  AUTO_WARMUP_ALL_CHANGED_EVENT,
+  readAutoWarmupAllEnabled,
+  writeAutoWarmupAllEnabled,
+} from "./lib/autoWarmup";
 
 const TRAY_REFRESH_EVENT = "tray-refresh";
 const ACCOUNTS_CHANGED_EVENT = "accounts-changed";
@@ -83,6 +88,7 @@ function TrayMenu() {
   const [error, setError] = useState<string | null>(null);
   const [usageById, setUsageById] = useState<Record<string, UsageInfo>>({});
   const [refreshing, setRefreshing] = useState(false);
+  const [autoWarmupAllEnabled, setAutoWarmupAllEnabled] = useState(readAutoWarmupAllEnabled);
 
   // Fetch each account's rate-limit usage in parallel; rows fill in as they land.
   const loadUsage = useCallback(async (list: AccountInfo[]) => {
@@ -146,6 +152,21 @@ function TrayMenu() {
     }
   }, [loadUsage]);
 
+  const handleAutoWarmupToggle = useCallback(async () => {
+    const next = !autoWarmupAllEnabled;
+    setAutoWarmupAllEnabled(next);
+    try {
+      writeAutoWarmupAllEnabled(next);
+      if (isTauriRuntime()) {
+        const { emit } = await import("@tauri-apps/api/event");
+        await emit(AUTO_WARMUP_ALL_CHANGED_EVENT, next);
+      }
+    } catch (err) {
+      setAutoWarmupAllEnabled(!next);
+      setError(formatError(err));
+    }
+  }, [autoWarmupAllEnabled]);
+
   useEffect(() => {
     void load();
   }, [load]);
@@ -156,11 +177,13 @@ function TrayMenu() {
     let unlistenRefresh: (() => void) | undefined;
     let unlistenChanged: (() => void) | undefined;
     let unlistenTheme: (() => void) | undefined;
+    let unlistenAutoWarmup: (() => void) | undefined;
 
     void (async () => {
       const { listen } = await import("@tauri-apps/api/event");
       unlistenRefresh = await listen(TRAY_REFRESH_EVENT, () => {
         syncThemeFromStorage();
+        setAutoWarmupAllEnabled(readAutoWarmupAllEnabled());
         void load();
       });
       unlistenChanged = await listen(ACCOUNTS_CHANGED_EVENT, () => void load());
@@ -169,12 +192,21 @@ function TrayMenu() {
           applyTheme(payload);
         }
       });
+      unlistenAutoWarmup = await listen<boolean>(
+        AUTO_WARMUP_ALL_CHANGED_EVENT,
+        ({ payload }) => {
+          if (typeof payload === "boolean") {
+            setAutoWarmupAllEnabled(payload);
+          }
+        }
+      );
     })();
 
     return () => {
       unlistenRefresh?.();
       unlistenChanged?.();
       unlistenTheme?.();
+      unlistenAutoWarmup?.();
     };
   }, [load]);
 
@@ -218,10 +250,26 @@ function TrayMenu() {
         </div>
         <span className="text-sm font-semibold">Codex Switcher</span>
         <button
+          onClick={() => void handleAutoWarmupToggle()}
+          disabled={accounts.length === 0}
+          title={
+            autoWarmupAllEnabled
+              ? "Disable auto warm-up for all accounts"
+              : "Enable auto warm-up for all accounts"
+          }
+          className={`ml-auto rounded-md px-2 py-1 text-[11px] font-semibold transition-colors disabled:opacity-50 ${
+            autoWarmupAllEnabled
+              ? "bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-900/20 dark:text-emerald-300 dark:hover:bg-emerald-900/30"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          }`}
+        >
+          Auto: {autoWarmupAllEnabled ? "on" : "off"}
+        </button>
+        <button
           onClick={() => void handleRefresh()}
           disabled={refreshing}
           title="Refresh usage"
-          className="ml-auto flex h-6 w-6 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+          className="flex h-6 w-6 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
         >
           <span className={`text-base leading-none ${refreshing ? "inline-block animate-spin" : ""}`}>
             ↻

--- a/src/lib/autoWarmup.ts
+++ b/src/lib/autoWarmup.ts
@@ -1,0 +1,18 @@
+export const AUTO_WARMUP_ALL_STORAGE_KEY = "codex-switcher-auto-warmup-all";
+export const AUTO_WARMUP_ACCOUNTS_STORAGE_KEY = "codex-switcher-auto-warmup-accounts";
+export const AUTO_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-auto-warmup-last-success";
+export const AUTO_WARMUP_ALL_CHANGED_EVENT = "auto-warmup-all-changed";
+
+export function readAutoWarmupAllEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(AUTO_WARMUP_ALL_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function writeAutoWarmupAllEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(AUTO_WARMUP_ALL_STORAGE_KEY, String(enabled));
+}


### PR DESCRIPTION
## Summary

Adds a global auto warm-up toggle to the tray popup and keeps it synchronized with the main window toggle.

## Details

- Moves auto warm-up storage keys into a shared frontend helper.
- Adds a tray header toggle for the existing global auto warm-up setting.
- Uses a Tauri event to sync auto warm-up changes between the tray popup and the main window immediately.

## Validation

- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- Ran the Tauri dev app and checked runtime logs for errors.
