### PR TITLE
Add native tray display settings

### DIFF
--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -1,0 +1,175 @@
+//! Native application menu management.
+
+use tauri::{
+    menu::{AboutMetadata, CheckMenuItem, Menu, PredefinedMenuItem, Submenu},
+    AppHandle, Runtime,
+};
+
+use crate::{
+    auth::{load_app_settings, save_app_settings},
+    types::TrayDisplayMode,
+};
+
+const TRAY_ICON_AND_SESSION_ID: &str = "tray-display-icon-and-session";
+const TRAY_ACTIVE_USAGE_TEXT_ID: &str = "tray-display-active-usage-text";
+
+pub fn setup(app: &AppHandle) -> tauri::Result<()> {
+    refresh(app)?;
+    app.on_menu_event(handle_menu_event);
+    Ok(())
+}
+
+pub fn refresh<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    let settings = load_app_settings().unwrap_or_default();
+    let menu = build_menu(app, settings.tray_display_mode)?;
+    app.set_menu(menu)?;
+    Ok(())
+}
+
+fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
+    let mode = match event.id().as_ref() {
+        TRAY_ICON_AND_SESSION_ID => TrayDisplayMode::IconAndSession,
+        TRAY_ACTIVE_USAGE_TEXT_ID => TrayDisplayMode::ActiveUsageText,
+        _ => return,
+    };
+
+    let mut settings = load_app_settings().unwrap_or_default();
+    if settings.tray_display_mode == mode {
+        return;
+    }
+
+    settings.tray_display_mode = mode;
+    if let Err(error) = save_app_settings(&settings) {
+        eprintln!("Failed to save app settings: {error}");
+        return;
+    }
+
+    if let Err(error) = refresh(app) {
+        eprintln!("Failed to refresh app menu: {error}");
+    }
+    crate::tray::refresh(app);
+}
+
+fn build_menu<R: Runtime>(
+    app: &AppHandle<R>,
+    tray_display_mode: TrayDisplayMode,
+) -> tauri::Result<Menu<R>> {
+    let pkg_info = app.package_info();
+    let config = app.config();
+    let about_metadata = AboutMetadata {
+        name: Some(pkg_info.name.clone()),
+        version: Some(pkg_info.version.to_string()),
+        copyright: config.bundle.copyright.clone(),
+        authors: config
+            .bundle
+            .publisher
+            .clone()
+            .map(|publisher| vec![publisher]),
+        ..Default::default()
+    };
+
+    let tray_settings = Submenu::with_items(
+        app,
+        "Tray",
+        true,
+        &[
+            &CheckMenuItem::with_id(
+                app,
+                TRAY_ICON_AND_SESSION_ID,
+                "Icon + Session",
+                true,
+                tray_display_mode == TrayDisplayMode::IconAndSession,
+                None::<&str>,
+            )?,
+            &CheckMenuItem::with_id(
+                app,
+                TRAY_ACTIVE_USAGE_TEXT_ID,
+                "Hourly + Weekly",
+                true,
+                tray_display_mode == TrayDisplayMode::ActiveUsageText,
+                None::<&str>,
+            )?,
+        ],
+    )?;
+
+    let settings_menu = Submenu::with_items(app, "Settings", true, &[&tray_settings])?;
+
+    let window_menu = Submenu::with_items(
+        app,
+        "Window",
+        true,
+        &[
+            &PredefinedMenuItem::minimize(app, None)?,
+            &PredefinedMenuItem::maximize(app, None)?,
+            #[cfg(target_os = "macos")]
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::close_window(app, None)?,
+        ],
+    )?;
+
+    let help_menu = Submenu::with_items(app, "Help", true, &[])?;
+
+    Menu::with_items(
+        app,
+        &[
+            #[cfg(target_os = "macos")]
+            &Submenu::with_items(
+                app,
+                pkg_info.name.clone(),
+                true,
+                &[
+                    &PredefinedMenuItem::about(app, None, Some(about_metadata))?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &settings_menu,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::services(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::hide(app, None)?,
+                    &PredefinedMenuItem::hide_others(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::quit(app, None)?,
+                ],
+            )?,
+            #[cfg(not(any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )))]
+            &Submenu::with_items(
+                app,
+                "File",
+                true,
+                &[
+                    &PredefinedMenuItem::close_window(app, None)?,
+                    #[cfg(not(target_os = "macos"))]
+                    &PredefinedMenuItem::quit(app, None)?,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(app, None)?,
+                    &PredefinedMenuItem::redo(app, None)?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &PredefinedMenuItem::cut(app, None)?,
+                    &PredefinedMenuItem::copy(app, None)?,
+                    &PredefinedMenuItem::paste(app, None)?,
+                    &PredefinedMenuItem::select_all(app, None)?,
+                ],
+            )?,
+            #[cfg(target_os = "macos")]
+            &Submenu::with_items(
+                app,
+                "View",
+                true,
+                &[&PredefinedMenuItem::fullscreen(app, None)?],
+            )?,
+            &window_menu,
+            &help_menu,
+        ],
+    )
+}

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 
-use crate::types::{AccountsStore, AuthData, StoredAccount};
+use crate::types::{AccountsStore, AppSettings, AuthData, StoredAccount};
 
 /// Get the path to the codex-switcher config directory
 pub fn get_config_dir() -> Result<PathBuf> {
@@ -17,6 +17,10 @@ pub fn get_config_dir() -> Result<PathBuf> {
 /// Get the path to accounts.json
 pub fn get_accounts_file() -> Result<PathBuf> {
     Ok(get_config_dir()?.join("accounts.json"))
+}
+
+pub fn get_settings_file() -> Result<PathBuf> {
+    Ok(get_config_dir()?.join("settings.json"))
 }
 
 /// Load the accounts store from disk
@@ -34,6 +38,44 @@ pub fn load_accounts() -> Result<AccountsStore> {
         .with_context(|| format!("Failed to parse accounts file: {}", path.display()))?;
 
     Ok(store)
+}
+
+pub fn load_app_settings() -> Result<AppSettings> {
+    let path = get_settings_file()?;
+
+    if !path.exists() {
+        return Ok(AppSettings::default());
+    }
+
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read settings file: {}", path.display()))?;
+
+    let settings: AppSettings = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse settings file: {}", path.display()))?;
+
+    Ok(settings)
+}
+
+pub fn save_app_settings(settings: &AppSettings) -> Result<()> {
+    let path = get_settings_file()?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
+    }
+
+    let content = serde_json::to_string_pretty(settings).context("Failed to serialize settings")?;
+    fs::write(&path, content)
+        .with_context(|| format!("Failed to write settings file: {}", path.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o600);
+        fs::set_permissions(&path, perms)?;
+    }
+
+    Ok(())
 }
 
 /// Save the accounts store to disk

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 //! Codex Switcher - Multi-account manager for Codex CLI
 
 pub mod api;
+#[cfg(desktop)]
+pub mod app_menu;
 pub mod auth;
 pub mod commands;
 #[cfg(desktop)]
@@ -28,6 +30,7 @@ pub fn run() {
             {
                 app.handle()
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
+                app_menu::setup(app.handle())?;
                 tray::setup(app.handle())?;
             }
             Ok(())

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -11,12 +11,12 @@ use tauri::{
 
 use crate::{
     api::usage::get_account_usage,
-    auth::{get_account, get_accounts_file, load_accounts},
+    auth::{get_account, get_accounts_file, load_accounts, load_app_settings},
     commands::{
         is_codex_running_switch_block, restore_main_window, switch_account_by_id,
         window::TRAY_WINDOW,
     },
-    types::{AccountsStore, UsageInfo},
+    types::{AccountsStore, TrayDisplayMode, UsageInfo},
 };
 
 static TRAY_USAGE: LazyLock<Mutex<HashMap<String, UsageInfo>>> =
@@ -70,10 +70,15 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         .show_menu_on_left_click(false);
 
     builder.build(app)?;
+    refresh_menu(app);
 
     watch_accounts_file(app.clone());
     poll_active_account_usage(app.clone());
     Ok(())
+}
+
+pub fn refresh<R: Runtime>(app: &AppHandle<R>) {
+    refresh_menu(app);
 }
 
 /// Store usage reported by the main app and refresh the native menu labels.
@@ -252,19 +257,53 @@ fn refresh_menu<R: Runtime>(app: &AppHandle<R>) {
     match load_accounts()
         .map_err(|error| error.to_string())
         .and_then(|store| {
-            let title = active_session_title(store.active_account_id.as_deref());
+            let settings = load_app_settings().unwrap_or_default();
+            let title = active_tray_title(
+                store.active_account_id.as_deref(),
+                settings.tray_display_mode,
+            );
             let menu = build_menu(app, &store).map_err(|error| error.to_string())?;
-            Ok((menu, title))
+            Ok((menu, title, settings.tray_display_mode))
         }) {
-        Ok((menu, title)) => {
+        Ok((menu, title, mode)) => {
             if let Err(error) = tray.set_menu(Some(menu)) {
                 eprintln!("Failed to refresh tray menu: {error}");
             }
-            if let Err(error) = tray.set_title(title.as_deref()) {
+            refresh_tray_display(&tray, mode, title.as_deref());
+        }
+        Err(error) => eprintln!("Failed to build tray menu: {error}"),
+    }
+}
+
+fn refresh_tray_display<R: Runtime>(
+    tray: &tauri::tray::TrayIcon<R>,
+    mode: TrayDisplayMode,
+    title: Option<&str>,
+) {
+    match mode {
+        TrayDisplayMode::IconAndSession => {
+            #[cfg(not(target_os = "linux"))]
+            {
+                if let Err(error) = tray.set_icon(Some(TRAY_ICON)) {
+                    eprintln!("Failed to refresh tray icon: {error}");
+                }
+                if let Err(error) = tray.set_icon_as_template(true) {
+                    eprintln!("Failed to refresh tray icon template mode: {error}");
+                }
+            }
+            if let Err(error) = tray.set_title(title) {
                 eprintln!("Failed to refresh tray title: {error}");
             }
         }
-        Err(error) => eprintln!("Failed to build tray menu: {error}"),
+        TrayDisplayMode::ActiveUsageText => {
+            #[cfg(not(target_os = "linux"))]
+            if let Err(error) = tray.set_icon(None) {
+                eprintln!("Failed to hide tray icon: {error}");
+            }
+            if let Err(error) = tray.set_title(title) {
+                eprintln!("Failed to refresh tray title: {error}");
+            }
+        }
     }
 }
 
@@ -280,11 +319,47 @@ fn active_session_title(active_account_id: Option<&str>) -> Option<String> {
     session_remaining_title(usage.primary_used_percent, usage.error.is_some())
 }
 
+fn active_tray_title(active_account_id: Option<&str>, mode: TrayDisplayMode) -> Option<String> {
+    match mode {
+        TrayDisplayMode::IconAndSession => active_session_title(active_account_id),
+        TrayDisplayMode::ActiveUsageText => Some(active_usage_title(active_account_id)),
+    }
+}
+
+fn active_usage_title(active_account_id: Option<&str>) -> String {
+    let Some(active_account_id) = active_account_id else {
+        return "Codex".to_string();
+    };
+
+    let usage = TRAY_USAGE
+        .lock()
+        .ok()
+        .and_then(|cache| cache.get(active_account_id).cloned());
+
+    let (primary, secondary) = match usage {
+        Some(usage) if usage.error.is_none() => (
+            remaining_percent_label(usage.primary_used_percent),
+            remaining_percent_label(usage.secondary_used_percent),
+        ),
+        _ => (None, None),
+    };
+
+    format!(
+        "H:{} W:{}",
+        primary.as_deref().unwrap_or("--"),
+        secondary.as_deref().unwrap_or("--")
+    )
+}
+
 fn session_remaining_title(used_percent: Option<f64>, has_error: bool) -> Option<String> {
     if has_error {
         return None;
     }
 
+    remaining_percent_label(used_percent)
+}
+
+fn remaining_percent_label(used_percent: Option<f64>) -> Option<String> {
     let used_percent = used_percent?;
     if !used_percent.is_finite() {
         return None;
@@ -450,5 +525,11 @@ mod tests {
             session_remaining_title(Some(105.0), false),
             Some("0%".to_string())
         );
+    }
+
+    #[test]
+    fn active_usage_title_falls_back_when_usage_is_missing() {
+        assert_eq!(active_usage_title(Some("missing")), "H:-- W:--");
+        assert_eq!(active_usage_title(None), "Codex");
     }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -19,6 +19,20 @@ pub struct AccountsStore {
     pub masked_account_ids: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrayDisplayMode {
+    IconAndSession,
+    #[default]
+    ActiveUsageText,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct AppSettings {
+    pub tray_display_mode: TrayDisplayMode,
+}
+
 impl Default for AccountsStore {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
## Summary
- add a native macOS app menu Settings section for tray display preferences
- persist the tray display mode in the local app settings file
- support a text-only tray mode that shows the active account's hourly and weekly remaining usage percentages, and make it the default

## Validation
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- cargo test --manifest-path src-tauri/Cargo.toml
- pnpm build
- git diff --check
- pnpm tauri build --no-bundle

## Notes
`cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` still fails on existing repository warnings outside this change, but the new tray settings code does not introduce an additional warning.
