### PR TITLE
Add hidden tray display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **Quick Switching** – Switch between accounts from the main window, native tray menu, or tray popup
 - **Automatic Warm-Up** – Warm up one account or all accounts manually, or keep accounts fresh with automatic warm-up scheduling
 - **System Tray Controls** – Use the tray popup to switch accounts, inspect quota, refresh usage, open the main window, or quit the app
-- **Tray Display Modes** – Choose between the app icon with session percentage or a text-only hourly/weekly percentage display
+- **Tray Display Modes** – Choose between the app icon with session percentage, a text-only hourly/weekly percentage display, or a hidden tray icon
 - **Usage Monitoring** – View real-time 5-hour session and weekly usage, reset timing, credits, and subscription expiry
 - **Blocked Switch Recovery** – Detect running Codex sessions and offer a force-close flow before retrying the account switch
 - **Dual Login Mode** – Authenticate with ChatGPT OAuth or import existing `auth.json` files

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -12,6 +12,7 @@ use crate::{
 
 const TRAY_ICON_AND_SESSION_ID: &str = "tray-display-icon-and-session";
 const TRAY_ACTIVE_USAGE_TEXT_ID: &str = "tray-display-active-usage-text";
+const TRAY_HIDDEN_ID: &str = "tray-display-hidden";
 
 pub fn setup(app: &AppHandle) -> tauri::Result<()> {
     refresh(app)?;
@@ -30,6 +31,7 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
     let mode = match event.id().as_ref() {
         TRAY_ICON_AND_SESSION_ID => TrayDisplayMode::IconAndSession,
         TRAY_ACTIVE_USAGE_TEXT_ID => TrayDisplayMode::ActiveUsageText,
+        TRAY_HIDDEN_ID => TrayDisplayMode::Hidden,
         _ => return,
     };
 
@@ -87,6 +89,14 @@ fn build_menu<R: Runtime>(
                 "Hourly + Weekly",
                 true,
                 tray_display_mode == TrayDisplayMode::ActiveUsageText,
+                None::<&str>,
+            )?,
+            &CheckMenuItem::with_id(
+                app,
+                TRAY_HIDDEN_ID,
+                "Hidden",
+                true,
+                tray_display_mode == TrayDisplayMode::Hidden,
                 None::<&str>,
             )?,
         ],

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -291,6 +291,9 @@ fn refresh_tray_display<R: Runtime>(
 ) {
     match mode {
         TrayDisplayMode::IconAndSession => {
+            if let Err(error) = tray.set_visible(true) {
+                eprintln!("Failed to show tray icon: {error}");
+            }
             #[cfg(not(target_os = "linux"))]
             {
                 if let Err(error) = tray.set_icon(Some(TRAY_ICON)) {
@@ -305,12 +308,23 @@ fn refresh_tray_display<R: Runtime>(
             }
         }
         TrayDisplayMode::ActiveUsageText => {
+            if let Err(error) = tray.set_visible(true) {
+                eprintln!("Failed to show tray icon: {error}");
+            }
             #[cfg(not(target_os = "linux"))]
             if let Err(error) = tray.set_icon(None) {
                 eprintln!("Failed to hide tray icon: {error}");
             }
             if let Err(error) = tray.set_title(title) {
                 eprintln!("Failed to refresh tray title: {error}");
+            }
+        }
+        TrayDisplayMode::Hidden => {
+            if let Err(error) = tray.set_title(None::<&str>) {
+                eprintln!("Failed to clear tray title: {error}");
+            }
+            if let Err(error) = tray.set_visible(false) {
+                eprintln!("Failed to hide tray icon: {error}");
             }
         }
     }
@@ -332,6 +346,7 @@ fn active_tray_title(active_account_id: Option<&str>, mode: TrayDisplayMode) -> 
     match mode {
         TrayDisplayMode::IconAndSession => active_session_title(active_account_id),
         TrayDisplayMode::ActiveUsageText => Some(active_usage_title(active_account_id)),
+        TrayDisplayMode::Hidden => None,
     }
 }
 
@@ -540,5 +555,13 @@ mod tests {
     fn active_usage_title_falls_back_when_usage_is_missing() {
         assert_eq!(active_usage_title(Some("missing")), "H:-- W:--");
         assert_eq!(active_usage_title(None), "Codex");
+    }
+
+    #[test]
+    fn hidden_tray_mode_has_no_title() {
+        assert_eq!(
+            active_tray_title(Some("active"), TrayDisplayMode::Hidden),
+            None
+        );
     }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -25,6 +25,7 @@ pub enum TrayDisplayMode {
     IconAndSession,
     #[default]
     ActiveUsageText,
+    Hidden,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Summary

Adds a third tray display mode, `Hidden`, under Settings > Tray so users can hide the system tray icon while keeping the setting reversible from the app menu.

The tray icon is kept alive and toggled with `set_visible(false)` instead of being removed, which keeps the existing tray refresh lifecycle simple and lets users switch back to Icon + Session or Hourly + Weekly later.

Closes #76.

## Validation

- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo test --manifest-path src-tauri/Cargo.toml
- pnpm build
- Manual dev app smoke test via `pnpm tauri dev`