### PR TITLE
Add timed warm-up scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The browser dashboard serves the same UI and backend actions through `/api/invok
 A warm-up sends one minimal request to an account so its current 5-hour usage
 window starts counting — handy for activating a window before you need it.
 
-- **Manual** – warm up a sinlge or all accounts, from the main window or tray menu.
+- **Manual** – warm up a single or all accounts, from the main window or tray menu.
 - **Automatic** – when enabled (per account or for all), the app warms an
   account each time its 5-hour window resets, as long as the weekly limit isn't
   exhausted.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - **Multi-Account Management** – Add, rename, mask, import, export, and manage multiple Codex accounts in one place
 - **Quick Switching** – Switch between accounts from the main window, native tray menu, or tray popup
-- **Automatic Warm-Up** – Warm up one account or all accounts manually, or keep accounts fresh with automatic warm-up scheduling
+- **Automatic Warm-Up** – Warm up one account or all accounts manually, or let scheduled auto warm-up activate each new 5-hour reset window for you
 - **System Tray Controls** – Use the tray popup to switch accounts, inspect quota, refresh usage, open the main window, or quit the app
 - **Tray Display Modes** – Choose between the app icon with session percentage or a text-only hourly/weekly percentage display
 - **Usage Monitoring** – View real-time 5-hour session and weekly usage, reset timing, credits, and subscription expiry
@@ -95,6 +95,28 @@ Optional environment variables:
 - `CODEX_SWITCHER_WEB_PORT` to override the port
 
 The browser dashboard serves the same UI and backend actions through `/api/invoke/*`, which makes it usable over LAN, Tailscale, or a remote host tunnel when you expose the chosen port safely.
+
+
+## Warm-Up
+
+A warm-up sends one minimal request to an account so its current 5-hour usage
+window starts counting — handy for activating a window before you need it.
+
+- **Manual** – warm up a sinlge or all accounts, from the main window or tray menu.
+- **Automatic** – when enabled (per account or for all), the app warms an
+  account each time its 5-hour window resets, as long as the weekly limit isn't
+  exhausted.
+- **Timed** – pick specific times of day (e.g. `08:00`, `13:00`, `18:00`) from
+  the **Timed** control in the main window. At each time the app warms all
+  accounts (skipping any whose weekly limit is exhausted), so you control when
+  your 5-hour windows start instead of letting them drift.
+
+On macOS you can keep the machine awake with the built-in `caffeinate` command,
+which stops automatically when the app quits:
+
+```bash
+caffeinate -i -w "$(pgrep -x 'Codex Switcher')"
+```
 
 ## Disclaimer
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -10,8 +10,7 @@ use tauri::{
 };
 
 use crate::{
-    api::usage::get_account_usage,
-    auth::{get_account, get_accounts_file, load_accounts, load_app_settings},
+    auth::{get_accounts_file, load_accounts, load_app_settings},
     commands::{
         is_codex_running_switch_block, restore_main_window, switch_account_by_id,
         window::TRAY_WINDOW,
@@ -73,7 +72,6 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
     refresh_menu(app);
 
     watch_accounts_file(app.clone());
-    poll_active_account_usage(app.clone());
     Ok(())
 }
 
@@ -438,27 +436,6 @@ fn watch_accounts_file<R: Runtime>(app: AppHandle<R>) {
                 let _ = app.emit(ACCOUNTS_CHANGED_EVENT, ()); // refresh the React UIs
             }
         }
-    });
-}
-
-/// Poll the active account's usage so the tray title stays fresh even when the
-/// main window's webview poller is hidden or suspended by the OS.
-fn poll_active_account_usage<R: Runtime>(app: AppHandle<R>) {
-    std::thread::spawn(move || loop {
-        let account = load_accounts()
-            .ok()
-            .and_then(|store| store.active_account_id)
-            .and_then(|id| get_account(&id).ok().flatten());
-
-        if let Some(account) = account {
-            match tauri::async_runtime::block_on(get_account_usage(&account)) {
-                // Keep the last known title on transient fetch errors.
-                Ok(usage) => ingest_usage(&app, vec![usage]),
-                Err(error) => eprintln!("Failed to poll usage for tray title: {error}"),
-            }
-        }
-
-        std::thread::sleep(Duration::from_secs(60));
     });
 }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -10,7 +10,8 @@ use tauri::{
 };
 
 use crate::{
-    auth::{get_accounts_file, load_accounts, load_app_settings},
+    api::usage::get_account_usage,
+    auth::{get_account, get_accounts_file, load_accounts, load_app_settings},
     commands::{
         is_codex_running_switch_block, restore_main_window, switch_account_by_id,
         window::TRAY_WINDOW,
@@ -72,6 +73,7 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
     refresh_menu(app);
 
     watch_accounts_file(app.clone());
+    poll_active_account_usage(app.clone());
     Ok(())
 }
 
@@ -443,6 +445,27 @@ fn modified_at(path: &std::path::Path) -> Option<std::time::SystemTime> {
     path.metadata()
         .and_then(|metadata| metadata.modified())
         .ok()
+}
+
+/// Poll the active account's usage so the tray title stays fresh even when the
+/// main window's webview poller is hidden or suspended by the OS.
+fn poll_active_account_usage<R: Runtime>(app: AppHandle<R>) {
+    std::thread::spawn(move || loop {
+        let account = load_accounts()
+            .ok()
+            .and_then(|store| store.active_account_id)
+            .and_then(|id| get_account(&id).ok().flatten());
+
+        if let Some(account) = account {
+            match tauri::async_runtime::block_on(get_account_usage(&account)) {
+                // Keep the last known title on transient fetch errors.
+                Ok(usage) => ingest_usage(&app, vec![usage]),
+                Err(error) => eprintln!("Failed to poll usage for tray title: {error}"),
+            }
+        }
+
+        std::thread::sleep(Duration::from_secs(60));
+    });
 }
 
 #[cfg(test)]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAccounts } from "./hooks/useAccounts";
 import { useForceCloseCodexProcesses } from "./hooks/useForceCloseCodexProcesses";
 import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
-import type { CodexProcessInfo, UsageInfo } from "./types";
+import type { AccountWithUsage, CodexProcessInfo, UsageInfo } from "./types";
 import {
   exportFullBackupFile,
   importFullBackupFile,
@@ -21,6 +21,7 @@ import {
   AUTO_WARMUP_ACCOUNTS_STORAGE_KEY,
   AUTO_WARMUP_ALL_CHANGED_EVENT,
   AUTO_WARMUP_LEDGER_STORAGE_KEY,
+  TIMED_WARMUP_LEDGER_STORAGE_KEY,
   normalizeTimedWarmupTimes,
   readAutoWarmupAllEnabled,
   readTimedWarmupEnabled,
@@ -88,8 +89,34 @@ function readStoredAutoWarmupLedger(): AutoWarmupLedger {
   }
 }
 
+function readStoredTimedWarmupLedger(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(TIMED_WARMUP_LEDGER_STORAGE_KEY) ?? "{}");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === "string" && typeof entry[1] === "string"
+      )
+    );
+  } catch {
+    return {};
+  }
+}
+
 function isLimitFull(usedPercent: number | null | undefined): boolean {
   return usedPercent !== null && usedPercent !== undefined && usedPercent >= LIMIT_FULL_THRESHOLD;
+}
+
+function getTimedWarmupTargets(accounts: AccountWithUsage[]): AccountWithUsage[] {
+  return accounts.filter(
+    (account) =>
+      account.usage &&
+      !account.usageLoading &&
+      !account.usage.error &&
+      !isLimitFull(account.usage.secondary_used_percent)
+  );
 }
 
 function getPrimaryWindowMinutes(usage: UsageInfo): number {
@@ -209,7 +236,7 @@ function App() {
   const timedWarmupRunningRef = useRef(timedWarmupRunning);
   // Tracks the last calendar date (YYYY-MM-DD) each scheduled time fired on,
   // so each time triggers at most once per day.
-  const timedWarmupLastFireRef = useRef<Record<string, string>>({});
+  const timedWarmupLastFireRef = useRef<Record<string, string>>(readStoredTimedWarmupLedger());
 
   useEffect(() => {
     accountsRef.current = accounts;
@@ -740,6 +767,18 @@ function App() {
       : "Auto: off";
   }, [autoWarmupAccountIds.size, autoWarmupAllEnabled, autoWarmupRunningIds]);
 
+  const timedWarmupTargetsReady = useMemo(
+    () =>
+      accounts.length > 0 &&
+      accounts.every((account) => account.usage && !account.usageLoading),
+    [accounts]
+  );
+
+  const timedWarmupTargetCount = useMemo(
+    () => getTimedWarmupTargets(accounts).length,
+    [accounts]
+  );
+
   const backOffAutoWarmupRetry = useCallback((accountId: string) => {
     autoWarmupRetryAfterRef.current[accountId] =
       Date.now() + AUTO_WARMUP_RETRY_BACKOFF_MS;
@@ -829,9 +868,7 @@ function App() {
   ]);
 
   const runTimedWarmup = useCallback(async () => {
-    const targets = accountsRef.current.filter(
-      (account) => !isLimitFull(account.usage?.secondary_used_percent)
-    );
+    const targets = getTimedWarmupTargets(accountsRef.current);
     if (targets.length === 0) return;
 
     setTimedWarmupRunning(true);
@@ -878,9 +915,18 @@ function App() {
       // asleep) is skipped rather than warmed late at the wrong moment.
       if (!timedWarmupTimes.includes(currentTime)) return;
       if (timedWarmupLastFireRef.current[currentTime] === todayKey) return;
+      if (!timedWarmupTargetsReady || timedWarmupTargetCount === 0) return;
 
       // Mark before running so a slow warm-up can't double-fire on the next tick.
       timedWarmupLastFireRef.current[currentTime] = todayKey;
+      try {
+        window.localStorage.setItem(
+          TIMED_WARMUP_LEDGER_STORAGE_KEY,
+          JSON.stringify(timedWarmupLastFireRef.current)
+        );
+      } catch {
+        // Ignore storage errors; timed warm-up still works for the current session.
+      }
       void runTimedWarmup();
     };
 
@@ -891,7 +937,13 @@ function App() {
     );
 
     return () => window.clearInterval(interval);
-  }, [timedWarmupEnabled, timedWarmupTimes, runTimedWarmup]);
+  }, [
+    timedWarmupEnabled,
+    timedWarmupTimes,
+    timedWarmupTargetsReady,
+    timedWarmupTargetCount,
+    runTimedWarmup,
+  ]);
 
   const handleAddTimedWarmupTime = useCallback(() => {
     const normalized = normalizeTimedWarmupTimes([timedWarmupDraft]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,13 @@ import {
   AUTO_WARMUP_ACCOUNTS_STORAGE_KEY,
   AUTO_WARMUP_ALL_CHANGED_EVENT,
   AUTO_WARMUP_LEDGER_STORAGE_KEY,
+  normalizeTimedWarmupTimes,
   readAutoWarmupAllEnabled,
+  readTimedWarmupEnabled,
+  readTimedWarmupTimes,
   writeAutoWarmupAllEnabled,
+  writeTimedWarmupEnabled,
+  writeTimedWarmupTimes,
 } from "./lib/autoWarmup";
 import "./App.css";
 
@@ -173,6 +178,15 @@ function App() {
   const [autoWarmupRunningIds, setAutoWarmupRunningIds] = useState<Set<string>>(
     new Set()
   );
+  const [timedWarmupEnabled, setTimedWarmupEnabled] = useState(() =>
+    readTimedWarmupEnabled()
+  );
+  const [timedWarmupTimes, setTimedWarmupTimes] = useState<string[]>(() =>
+    readTimedWarmupTimes()
+  );
+  const [isTimedWarmupOpen, setIsTimedWarmupOpen] = useState(false);
+  const [timedWarmupRunning, setTimedWarmupRunning] = useState(false);
+  const [timedWarmupDraft, setTimedWarmupDraft] = useState("");
   const [maskedAccounts, setMaskedAccounts] = useState<Set<string>>(new Set());
   const [otherAccountsSort, setOtherAccountsSort] = useState<
     | "deadline_asc"
@@ -184,6 +198,7 @@ function App() {
   >("deadline_asc");
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
+  const timedWarmupRef = useRef<HTMLDivElement | null>(null);
   const [themeMode, setThemeMode] = useState<ThemeMode>(readStoredTheme);
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
   const accountsRef = useRef(accounts);
@@ -191,6 +206,10 @@ function App() {
   const autoWarmupLedgerRef = useRef(autoWarmupLedger);
   const autoWarmupRunningIdsRef = useRef(autoWarmupRunningIds);
   const autoWarmupRetryAfterRef = useRef<Record<string, number>>({});
+  const timedWarmupRunningRef = useRef(timedWarmupRunning);
+  // Tracks the last calendar date (YYYY-MM-DD) each scheduled time fired on,
+  // so each time triggers at most once per day.
+  const timedWarmupLastFireRef = useRef<Record<string, string>>({});
 
   useEffect(() => {
     accountsRef.current = accounts;
@@ -203,6 +222,26 @@ function App() {
   useEffect(() => {
     autoWarmupRunningIdsRef.current = autoWarmupRunningIds;
   }, [autoWarmupRunningIds]);
+
+  useEffect(() => {
+    timedWarmupRunningRef.current = timedWarmupRunning;
+  }, [timedWarmupRunning]);
+
+  useEffect(() => {
+    try {
+      writeTimedWarmupEnabled(timedWarmupEnabled);
+    } catch {
+      // Ignore storage errors; timed warm-up still works for the current session.
+    }
+  }, [timedWarmupEnabled]);
+
+  useEffect(() => {
+    try {
+      writeTimedWarmupTimes(timedWarmupTimes);
+    } catch {
+      // Ignore storage errors; timed warm-up still works for the current session.
+    }
+  }, [timedWarmupTimes]);
 
   useEffect(() => {
     if (loading || error) return;
@@ -355,6 +394,20 @@ function App() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isActionsMenuOpen]);
+
+  useEffect(() => {
+    if (!isTimedWarmupOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!timedWarmupRef.current) return;
+      if (!timedWarmupRef.current.contains(event.target as Node)) {
+        setIsTimedWarmupOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isTimedWarmupOpen]);
 
   useEffect(() => {
     applyTheme(themeMode);
@@ -775,6 +828,97 @@ function App() {
     runAutoWarmupForAccount,
   ]);
 
+  const runTimedWarmup = useCallback(async () => {
+    const targets = accountsRef.current.filter(
+      (account) => !isLimitFull(account.usage?.secondary_used_percent)
+    );
+    if (targets.length === 0) return;
+
+    setTimedWarmupRunning(true);
+    try {
+      const warmedAt = Date.now();
+      let warmed = 0;
+      let failed = 0;
+      for (const account of targets) {
+        try {
+          await warmupAccount(account.id);
+          markSuccessfulWarmup(account.id, warmedAt);
+          warmed += 1;
+        } catch (err) {
+          console.error("Timed warm-up failed:", err);
+          failed += 1;
+        }
+      }
+
+      if (failed === 0) {
+        showWarmupToast(
+          `Timed warm-up sent for ${warmed} account${warmed === 1 ? "" : "s"}`
+        );
+      } else {
+        showWarmupToast(`Timed warm-up: ${warmed} ok, ${failed} failed`, true);
+      }
+    } finally {
+      setTimedWarmupRunning(false);
+    }
+  }, [markSuccessfulWarmup, showWarmupToast, warmupAccount]);
+
+  useEffect(() => {
+    if (!timedWarmupEnabled || timedWarmupTimes.length === 0) return;
+
+    const checkTimedWarmup = () => {
+      if (timedWarmupRunningRef.current) return;
+
+      const now = new Date();
+      const todayKey = `${now.getFullYear()}-${now.getMonth()}-${now.getDate()}`;
+      const currentTime = `${String(now.getHours()).padStart(2, "0")}:${String(
+        now.getMinutes()
+      ).padStart(2, "0")}`;
+
+      // Only fire during the scheduled minute itself; a missed time (e.g. while
+      // asleep) is skipped rather than warmed late at the wrong moment.
+      if (!timedWarmupTimes.includes(currentTime)) return;
+      if (timedWarmupLastFireRef.current[currentTime] === todayKey) return;
+
+      // Mark before running so a slow warm-up can't double-fire on the next tick.
+      timedWarmupLastFireRef.current[currentTime] = todayKey;
+      void runTimedWarmup();
+    };
+
+    checkTimedWarmup();
+    const interval = window.setInterval(
+      checkTimedWarmup,
+      AUTO_WARMUP_CHECK_INTERVAL_MS
+    );
+
+    return () => window.clearInterval(interval);
+  }, [timedWarmupEnabled, timedWarmupTimes, runTimedWarmup]);
+
+  const handleAddTimedWarmupTime = useCallback(() => {
+    const normalized = normalizeTimedWarmupTimes([timedWarmupDraft]);
+    if (normalized.length === 0) return;
+    setTimedWarmupTimes((prev) =>
+      normalizeTimedWarmupTimes([...prev, normalized[0]])
+    );
+    setTimedWarmupDraft("");
+  }, [timedWarmupDraft]);
+
+  const handleRemoveTimedWarmupTime = useCallback((time: string) => {
+    setTimedWarmupTimes((prev) => prev.filter((entry) => entry !== time));
+  }, []);
+
+  const timedWarmupLabel = useMemo(() => {
+    if (timedWarmupRunning) return "Timed warming...";
+    if (!timedWarmupEnabled || timedWarmupTimes.length === 0) return "Timed: off";
+
+    const now = new Date();
+    const nowMinutes = now.getHours() * 60 + now.getMinutes();
+    const upcoming = timedWarmupTimes.find((time) => {
+      const [hours, minutes] = time.split(":").map(Number);
+      return hours * 60 + minutes > nowMinutes;
+    });
+    return `Timed: ${upcoming ?? timedWarmupTimes[0]}`;
+  }, [timedWarmupEnabled, timedWarmupRunning, timedWarmupTimes]);
+
   const handleExportSlimText = async () => {
     setConfigModalMode("slim_export");
     setConfigModalError(null);
@@ -1145,6 +1289,76 @@ function App() {
               >
                 {headerAutoWarmupLabel}
               </button>
+              <div className="relative shrink-0" ref={timedWarmupRef}>
+                <button
+                  onClick={() => setIsTimedWarmupOpen((prev) => !prev)}
+                  className={`flex h-10 items-center justify-center rounded-lg px-3 text-xs font-semibold transition-colors whitespace-nowrap ${
+                    timedWarmupEnabled
+                      ? "bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:bg-emerald-900/20 dark:text-emerald-300 dark:hover:bg-emerald-900/30"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                  }`}
+                  title="Schedule warm-up at specific times of day for all accounts"
+                >
+                  {timedWarmupLabel} ▾
+                </button>
+                {isTimedWarmupOpen && (
+                  <div className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-900">
+                    <label className="flex items-center justify-between text-sm font-medium text-gray-800 dark:text-gray-100">
+                      <span>Timed warm-up</span>
+                      <input
+                        type="checkbox"
+                        checked={timedWarmupEnabled}
+                        onChange={(e) => setTimedWarmupEnabled(e.target.checked)}
+                        className="h-4 w-4 accent-emerald-600"
+                      />
+                    </label>
+                    <div className="mt-3 space-y-1">
+                      {timedWarmupTimes.length === 0 ? (
+                        <p className="text-xs italic text-gray-400 dark:text-gray-500">
+                          No times added yet.
+                        </p>
+                      ) : (
+                        timedWarmupTimes.map((time) => (
+                          <div
+                            key={time}
+                            className="flex items-center justify-between rounded-md bg-gray-50 px-2 py-1 text-sm dark:bg-gray-800"
+                          >
+                            <span className="font-mono text-gray-800 dark:text-gray-100">
+                              {time}
+                            </span>
+                            <button
+                              onClick={() => handleRemoveTimedWarmupTime(time)}
+                              className="text-gray-400 transition-colors hover:text-red-500"
+                              title={`Remove ${time}`}
+                            >
+                              ✕
+                            </button>
+                          </div>
+                        ))
+                      )}
+                    </div>
+
+                    <div className="mt-3 flex items-center gap-2">
+                      <input
+                        type="time"
+                        value={timedWarmupDraft}
+                        onChange={(e) => setTimedWarmupDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handleAddTimedWarmupTime();
+                        }}
+                        className="h-8 flex-1 rounded-md border border-gray-300 bg-white px-2 text-sm text-gray-800 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                      />
+                      <button
+                        onClick={handleAddTimedWarmupTime}
+                        disabled={!timedWarmupDraft}
+                        className="h-8 rounded-md bg-gray-900 px-3 text-xs font-semibold text-white transition-colors hover:bg-gray-800 disabled:opacity-50 dark:bg-black dark:hover:bg-neutral-900"
+                      >
+                        Add
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
               <button
                 onClick={() => setThemeMode((prev) => (prev === "dark" ? "light" : "dark"))}
                 className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 text-lg text-gray-700 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 shrink-0"

--- a/src/TrayMenu.tsx
+++ b/src/TrayMenu.tsx
@@ -167,10 +167,6 @@ function TrayMenu() {
     }
   }, [autoWarmupAllEnabled]);
 
-  useEffect(() => {
-    void load();
-  }, [load]);
-
   // Reload when the tray is reopened or accounts change elsewhere.
   useEffect(() => {
     if (!isTauriRuntime()) return;

--- a/src/lib/autoWarmup.ts
+++ b/src/lib/autoWarmup.ts
@@ -3,6 +3,10 @@ export const AUTO_WARMUP_ACCOUNTS_STORAGE_KEY = "codex-switcher-auto-warmup-acco
 export const AUTO_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-auto-warmup-last-success";
 export const AUTO_WARMUP_ALL_CHANGED_EVENT = "auto-warmup-all-changed";
 
+export const TIMED_WARMUP_ENABLED_STORAGE_KEY = "codex-switcher-timed-warmup-enabled";
+export const TIMED_WARMUP_TIMES_STORAGE_KEY = "codex-switcher-timed-warmup-times";
+export const TIMED_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-timed-warmup-last-fire";
+
 export function readAutoWarmupAllEnabled(): boolean {
   if (typeof window === "undefined") return false;
   try {
@@ -15,4 +19,56 @@ export function readAutoWarmupAllEnabled(): boolean {
 export function writeAutoWarmupAllEnabled(enabled: boolean): void {
   if (typeof window === "undefined") return;
   window.localStorage.setItem(AUTO_WARMUP_ALL_STORAGE_KEY, String(enabled));
+}
+
+/** Validate, normalize, dedupe and sort a list of "HH:MM" times. */
+export function normalizeTimedWarmupTimes(times: readonly string[]): string[] {
+  const valid = new Set<string>();
+  for (const raw of times) {
+    const match = /^(\d{1,2}):(\d{1,2})$/.exec(String(raw).trim());
+    if (!match) continue;
+    const hours = Number(match[1]);
+    const minutes = Number(match[2]);
+    if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) continue;
+    valid.add(
+      `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`
+    );
+  }
+  return Array.from(valid).sort();
+}
+
+export function readTimedWarmupEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return (
+      window.localStorage.getItem(TIMED_WARMUP_ENABLED_STORAGE_KEY) === "true"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function writeTimedWarmupEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(TIMED_WARMUP_ENABLED_STORAGE_KEY, String(enabled));
+}
+
+export function readTimedWarmupTimes(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const parsed = JSON.parse(
+      window.localStorage.getItem(TIMED_WARMUP_TIMES_STORAGE_KEY) ?? "[]"
+    );
+    return Array.isArray(parsed) ? normalizeTimedWarmupTimes(parsed) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeTimedWarmupTimes(times: readonly string[]): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(
+    TIMED_WARMUP_TIMES_STORAGE_KEY,
+    JSON.stringify(normalizeTimedWarmupTimes(times))
+  );
 }


### PR DESCRIPTION
This continues the timed warm-up work from #79 and fixes the scheduler so timed warm-up only records a fire after ready usage data has produced an eligible target set.

It also avoids duplicate usage polling on startup by keeping the main window as the single usage poller and loading tray popup usage only when the popup is opened.

Validated on Windows:
- pnpm build
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- git diff --check
- cargo test --manifest-path src-tauri/Cargo.toml --lib tray::tests
- pnpm tauri:win build reached installer generation; it only failed at updater signing because TAURI_SIGNING_PRIVATE_KEY is not set