### PR TITLE
Add account usage stats

### DIFF
--- a/src-tauri/src/commands/account_stats.rs
+++ b/src-tauri/src/commands/account_stats.rs
@@ -1,0 +1,372 @@
+//! Account-scoped usage statistics from the Codex profile endpoint.
+
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, USER_AGENT},
+    StatusCode,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::{ensure_chatgpt_tokens_fresh, load_accounts, refresh_chatgpt_tokens};
+use crate::types::{AuthData, AuthMode, StoredAccount};
+
+const CHATGPT_PROFILE_USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/profiles/me";
+const CODEX_USER_AGENT: &str = "codex-cli/1.0.0";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountUsageStats {
+    pub account_id: String,
+    pub available: bool,
+    pub source: String,
+    pub generated_at: Option<String>,
+    pub stats_as_of: Option<String>,
+    pub summary: AccountUsageSummary,
+    pub activity: AccountUsageActivity,
+    pub daily: Vec<AccountDailyUsage>,
+    pub top_invocations: Vec<AccountTopInvocation>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct AccountUsageSummary {
+    pub lifetime_tokens: Option<i64>,
+    pub peak_daily_tokens: Option<i64>,
+    pub longest_task_seconds: Option<i64>,
+    pub current_streak_days: Option<i64>,
+    pub longest_streak_days: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct AccountUsageActivity {
+    pub fast_mode_percent: Option<f64>,
+    pub reasoning_effort: Option<String>,
+    pub reasoning_effort_percent: Option<f64>,
+    pub skills_explored: Option<i64>,
+    pub total_skills_used: Option<i64>,
+    pub total_threads: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountDailyUsage {
+    pub date: String,
+    pub tokens: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountTopInvocation {
+    pub kind: String,
+    pub display_name: String,
+    pub usage_count: i64,
+    pub plugin_id: Option<String>,
+    pub plugin_name: Option<String>,
+    pub skill_id: Option<String>,
+    pub skill_name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProfileUsageResponse {
+    #[serde(default)]
+    stats: ProfileUsageStats,
+    #[serde(default)]
+    metadata: ProfileUsageMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ProfileUsageStats {
+    #[serde(default)]
+    lifetime_tokens: Option<i64>,
+    #[serde(default)]
+    peak_daily_tokens: Option<i64>,
+    #[serde(default)]
+    longest_running_turn_sec: Option<i64>,
+    #[serde(default)]
+    current_streak_days: Option<i64>,
+    #[serde(default)]
+    longest_streak_days: Option<i64>,
+    #[serde(default)]
+    daily_usage_buckets: Option<Vec<ProfileDailyUsageBucket>>,
+    #[serde(default)]
+    top_invocations: Option<Vec<ProfileTopInvocation>>,
+    #[serde(default)]
+    fast_mode_usage_percentage: Option<f64>,
+    #[serde(default)]
+    most_used_reasoning_effort: Option<String>,
+    #[serde(default)]
+    most_used_reasoning_effort_percentage: Option<f64>,
+    #[serde(default)]
+    unique_skills_used: Option<i64>,
+    #[serde(default)]
+    total_skills_used: Option<i64>,
+    #[serde(default)]
+    total_threads: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProfileDailyUsageBucket {
+    start_date: String,
+    tokens: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProfileTopInvocation {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    #[serde(default)]
+    plugin_id: Option<String>,
+    #[serde(default)]
+    plugin_name: Option<String>,
+    #[serde(default)]
+    skill_id: Option<String>,
+    #[serde(default)]
+    skill_name: Option<String>,
+    #[serde(default)]
+    usage_count: Option<i64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ProfileUsageMetadata {
+    #[serde(default)]
+    stats_as_of: Option<String>,
+    #[serde(default)]
+    generated_at: Option<String>,
+    #[serde(default)]
+    stats_error: Option<String>,
+}
+
+#[tauri::command]
+pub async fn get_account_usage_stats(account_id: String) -> Result<AccountUsageStats, String> {
+    let store = load_accounts().map_err(|e| e.to_string())?;
+    let account = store
+        .accounts
+        .iter()
+        .find(|account| account.id == account_id)
+        .ok_or_else(|| format!("Account not found: {account_id}"))?;
+
+    if account.auth_mode != AuthMode::ChatGPT {
+        return Ok(unavailable_stats(
+            account_id,
+            "Usage stats are available for ChatGPT accounts only.",
+        ));
+    }
+
+    fetch_profile_usage(account)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+async fn fetch_profile_usage(account: &StoredAccount) -> anyhow::Result<AccountUsageStats> {
+    let fresh_account = ensure_chatgpt_tokens_fresh(account).await?;
+    let mut response = send_profile_usage_request(&fresh_account).await?;
+
+    if response.status() == StatusCode::UNAUTHORIZED {
+        let refreshed_account = refresh_chatgpt_tokens(&fresh_account).await?;
+        response = send_profile_usage_request(&refreshed_account).await?;
+        return parse_profile_usage_response(&refreshed_account.id, response).await;
+    }
+
+    parse_profile_usage_response(&fresh_account.id, response).await
+}
+
+async fn send_profile_usage_request(account: &StoredAccount) -> anyhow::Result<reqwest::Response> {
+    let (access_token, chatgpt_account_id) = extract_chatgpt_auth(account)?;
+    let client = reqwest::Client::new();
+
+    Ok(client
+        .get(CHATGPT_PROFILE_USAGE_URL)
+        .headers(build_chatgpt_headers(access_token, chatgpt_account_id)?)
+        .send()
+        .await?)
+}
+
+async fn parse_profile_usage_response(
+    account_id: &str,
+    response: reqwest::Response,
+) -> anyhow::Result<AccountUsageStats> {
+    let status = response.status();
+    if !status.is_success() {
+        return Ok(unavailable_stats(
+            account_id.to_string(),
+            &format!("Usage stats request failed: {status}"),
+        ));
+    }
+
+    let payload: ProfileUsageResponse = response.json().await?;
+    Ok(map_profile_usage(account_id, payload))
+}
+
+fn map_profile_usage(account_id: &str, payload: ProfileUsageResponse) -> AccountUsageStats {
+    let stats_error = payload
+        .metadata
+        .stats_error
+        .filter(|value| !value.is_empty());
+    let available = stats_error.is_none();
+    let stats = payload.stats;
+
+    AccountUsageStats {
+        account_id: account_id.to_string(),
+        available,
+        source: "Codex usage stats via ChatGPT backend".to_string(),
+        generated_at: payload.metadata.generated_at,
+        stats_as_of: payload.metadata.stats_as_of,
+        summary: AccountUsageSummary {
+            lifetime_tokens: stats.lifetime_tokens,
+            peak_daily_tokens: stats.peak_daily_tokens,
+            longest_task_seconds: stats.longest_running_turn_sec,
+            current_streak_days: stats.current_streak_days,
+            longest_streak_days: stats.longest_streak_days,
+        },
+        activity: AccountUsageActivity {
+            fast_mode_percent: stats.fast_mode_usage_percentage,
+            reasoning_effort: stats.most_used_reasoning_effort,
+            reasoning_effort_percent: stats.most_used_reasoning_effort_percentage,
+            skills_explored: stats.unique_skills_used,
+            total_skills_used: stats.total_skills_used,
+            total_threads: stats.total_threads,
+        },
+        daily: stats
+            .daily_usage_buckets
+            .unwrap_or_default()
+            .into_iter()
+            .map(|bucket| AccountDailyUsage {
+                date: bucket.start_date,
+                tokens: bucket.tokens,
+            })
+            .collect(),
+        top_invocations: stats
+            .top_invocations
+            .unwrap_or_default()
+            .into_iter()
+            .map(map_top_invocation)
+            .collect(),
+        error: stats_error,
+    }
+}
+
+fn map_top_invocation(invocation: ProfileTopInvocation) -> AccountTopInvocation {
+    let kind = invocation.kind.unwrap_or_else(|| "unknown".to_string());
+    let display_name = invocation
+        .skill_name
+        .as_ref()
+        .or(invocation.plugin_name.as_ref())
+        .cloned()
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    AccountTopInvocation {
+        kind,
+        display_name,
+        usage_count: invocation.usage_count.unwrap_or(0),
+        plugin_id: invocation.plugin_id,
+        plugin_name: invocation.plugin_name,
+        skill_id: invocation.skill_id,
+        skill_name: invocation.skill_name,
+    }
+}
+
+fn unavailable_stats(account_id: String, message: &str) -> AccountUsageStats {
+    AccountUsageStats {
+        account_id,
+        available: false,
+        source: "Codex usage stats via ChatGPT backend".to_string(),
+        generated_at: None,
+        stats_as_of: None,
+        summary: AccountUsageSummary::default(),
+        activity: AccountUsageActivity::default(),
+        daily: Vec::new(),
+        top_invocations: Vec::new(),
+        error: Some(message.to_string()),
+    }
+}
+
+fn build_chatgpt_headers(
+    access_token: &str,
+    chatgpt_account_id: Option<&str>,
+) -> anyhow::Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    headers.insert(USER_AGENT, HeaderValue::from_static(CODEX_USER_AGENT));
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {access_token}"))?,
+    );
+
+    if let Some(account_id) = chatgpt_account_id {
+        headers.insert(
+            HeaderName::from_static("chatgpt-account-id"),
+            HeaderValue::from_str(account_id)?,
+        );
+    }
+
+    Ok(headers)
+}
+
+fn extract_chatgpt_auth(account: &StoredAccount) -> anyhow::Result<(&str, Option<&str>)> {
+    match &account.auth_data {
+        AuthData::ChatGPT {
+            access_token,
+            account_id,
+            ..
+        } => Ok((access_token.as_str(), account_id.as_deref())),
+        AuthData::ApiKey { .. } => anyhow::bail!("Account is not using ChatGPT OAuth"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn profile_usage_response_maps_profile_stats() {
+        let payload: ProfileUsageResponse = serde_json::from_value(serde_json::json!({
+            "stats": {
+                "lifetime_tokens": 1549926883,
+                "peak_daily_tokens": 135100741,
+                "longest_running_turn_sec": 10797,
+                "current_streak_days": 3,
+                "longest_streak_days": 10,
+                "daily_usage_buckets": [
+                    { "start_date": "2026-06-25", "tokens": 44880283 },
+                    { "start_date": "2026-06-26", "tokens": 29 }
+                ],
+                "top_invocations": [
+                    {
+                        "type": "skill",
+                        "skill_name": "dilekcebot-template-builder",
+                        "usage_count": 95
+                    },
+                    {
+                        "type": "plugin",
+                        "plugin_name": "github",
+                        "usage_count": 7
+                    }
+                ],
+                "fast_mode_usage_percentage": 1.09,
+                "most_used_reasoning_effort": "medium",
+                "most_used_reasoning_effort_percentage": 51.12,
+                "unique_skills_used": 12,
+                "total_skills_used": 191,
+                "total_threads": 500
+            },
+            "metadata": {
+                "stats_as_of": "2026-06-26",
+                "generated_at": "2026-06-26T14:56:19.430889Z",
+                "stats_error": null
+            }
+        }))
+        .unwrap();
+
+        let stats = map_profile_usage("account-1", payload);
+
+        assert!(stats.available);
+        assert_eq!(stats.account_id, "account-1");
+        assert_eq!(stats.summary.lifetime_tokens, Some(1_549_926_883));
+        assert_eq!(stats.summary.peak_daily_tokens, Some(135_100_741));
+        assert_eq!(stats.summary.longest_task_seconds, Some(10_797));
+        assert_eq!(stats.summary.current_streak_days, Some(3));
+        assert_eq!(stats.daily.len(), 2);
+        assert_eq!(stats.daily[1].tokens, 29);
+        assert_eq!(
+            stats.top_invocations[0].display_name,
+            "dilekcebot-template-builder"
+        );
+        assert_eq!(stats.top_invocations[1].display_name, "github");
+        assert_eq!(stats.activity.total_threads, Some(500));
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,12 +1,14 @@
 //! Tauri commands module
 
 pub mod account;
+pub mod account_stats;
 pub mod oauth;
 pub mod process;
 pub mod usage;
 pub mod window;
 
 pub use account::*;
+pub use account_stats::*;
 pub use oauth::*;
 pub use process::*;
 pub use usage::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,11 +12,12 @@ pub mod web;
 
 use commands::{
     add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,
-    export_accounts_full_encrypted_file, export_accounts_slim_text, get_active_account_info,
-    get_masked_account_ids, get_usage, hide_tray_window, import_accounts_full_encrypted_file,
-    import_accounts_slim_text, kill_codex_processes, list_accounts, open_main_window, quit_app,
-    refresh_account_metadata, refresh_all_accounts_usage, rename_account, report_usage,
-    set_masked_account_ids, start_login, switch_account, warmup_account, warmup_all_accounts,
+    export_accounts_full_encrypted_file, export_accounts_slim_text, get_account_usage_stats,
+    get_active_account_info, get_masked_account_ids, get_usage, hide_tray_window,
+    import_accounts_full_encrypted_file, import_accounts_slim_text, kill_codex_processes,
+    list_accounts, open_main_window, quit_app, refresh_account_metadata,
+    refresh_all_accounts_usage, rename_account, report_usage, set_masked_account_ids, start_login,
+    switch_account, warmup_account, warmup_all_accounts,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -72,6 +73,7 @@ pub fn run() {
             cancel_login,
             // Usage
             get_usage,
+            get_account_usage_stats,
             refresh_account_metadata,
             refresh_all_accounts_usage,
             warmup_account,

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -12,10 +12,11 @@ use tokio::runtime::Runtime;
 use crate::commands::{
     add_account_from_auth_json_text, add_account_from_file, cancel_login, check_codex_processes,
     complete_login, delete_account, export_accounts_full_encrypted_bytes,
-    export_accounts_slim_text, fetch_usage, get_active_account_info, get_masked_account_ids,
-    import_accounts_full_encrypted_bytes, import_accounts_slim_text, kill_codex_processes,
-    list_accounts, refresh_account_metadata, refresh_all_accounts_usage, rename_account,
-    set_masked_account_ids, start_login, switch_account, warmup_account, warmup_all_accounts,
+    export_accounts_slim_text, fetch_usage, get_account_usage_stats, get_active_account_info,
+    get_masked_account_ids, import_accounts_full_encrypted_bytes, import_accounts_slim_text,
+    kill_codex_processes, list_accounts, refresh_account_metadata, refresh_all_accounts_usage,
+    rename_account, set_masked_account_ids, start_login, switch_account, warmup_account,
+    warmup_all_accounts,
 };
 
 #[derive(Debug, Deserialize)]
@@ -140,6 +141,10 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         "get_usage" => {
             let args: AccountIdArgs = parse_args(payload)?;
             to_json(fetch_usage(&args.account_id).await?)
+        }
+        "get_account_usage_stats" => {
+            let args: AccountIdArgs = parse_args(payload)?;
+            to_json(get_account_usage_stats(args.account_id).await?)
         }
         "refresh_account_metadata" => {
             let args: AccountIdArgs = parse_args(payload)?;

--- a/src/TrayMenu.tsx
+++ b/src/TrayMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import type { AccountInfo, UsageInfo } from "./types";
+import type { AccountInfo, AccountUsageStats, UsageInfo } from "./types";
 import { invokeBackend, isTauriRuntime } from "./lib/platform";
 import {
   applyTheme,
@@ -70,6 +70,29 @@ function formatResetAt(resetAt: number | null | undefined): string | null {
   return `${Math.floor(diff / 86_400)}d ${Math.floor((diff % 86_400) / 3600)}h`;
 }
 
+function formatTokens(tokens: number | null | undefined): string {
+  if (tokens === null || tokens === undefined || !Number.isFinite(tokens)) return "--";
+  const abs = Math.abs(tokens);
+  if (abs >= 1_000_000_000) return `${(tokens / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
+  return `${tokens}`;
+}
+
+function dayKey(offset: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - offset);
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function sumDailyTokens(stats: AccountUsageStats, days: number): number {
+  const keys = new Set(Array.from({ length: days }, (_, index) => dayKey(index)));
+  return stats.daily.reduce((total, day) => (keys.has(day.date) ? total + day.tokens : total), 0);
+}
+
 function retainUsageForAccounts(
   usageById: Record<string, UsageInfo>,
   accounts: AccountInfo[]
@@ -87,6 +110,7 @@ function TrayMenu() {
   const [switchingId, setSwitchingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [usageById, setUsageById] = useState<Record<string, UsageInfo>>({});
+  const [statsById, setStatsById] = useState<Record<string, AccountUsageStats>>({});
   const [refreshing, setRefreshing] = useState(false);
   const [autoWarmupAllEnabled, setAutoWarmupAllEnabled] = useState(readAutoWarmupAllEnabled);
 
@@ -122,6 +146,47 @@ function TrayMenu() {
     );
   }, []);
 
+  const loadActiveStats = useCallback(async (list: AccountInfo[]) => {
+    const active = list.find((account) => account.is_active);
+    if (!active) return;
+
+    try {
+      const stats = await invokeBackend<AccountUsageStats>("get_account_usage_stats", {
+        accountId: active.id,
+      });
+      setStatsById((prev) => ({ ...prev, [active.id]: stats }));
+    } catch (err) {
+      setStatsById((prev) => ({
+        ...prev,
+        [active.id]: {
+          account_id: active.id,
+          available: false,
+          source: "Codex usage stats via ChatGPT backend",
+          generated_at: null,
+          stats_as_of: null,
+          summary: {
+            lifetime_tokens: null,
+            peak_daily_tokens: null,
+            longest_task_seconds: null,
+            current_streak_days: null,
+            longest_streak_days: null,
+          },
+          activity: {
+            fast_mode_percent: null,
+            reasoning_effort: null,
+            reasoning_effort_percent: null,
+            skills_explored: null,
+            total_skills_used: null,
+            total_threads: null,
+          },
+          daily: [],
+          top_invocations: [],
+          error: formatError(err),
+        },
+      }));
+    }
+  }, []);
+
   const load = useCallback(async () => {
     try {
       const list = await invokeBackend<AccountInfo[]>("list_accounts");
@@ -129,12 +194,13 @@ function TrayMenu() {
       setUsageById((prev) => retainUsageForAccounts(prev, list));
       setError(null);
       void loadUsage(list); // Don't block the list render on the usage calls.
+      void loadActiveStats(list);
     } catch (err) {
       setError(formatError(err));
     } finally {
       setLoading(false);
     }
-  }, [loadUsage]);
+  }, [loadActiveStats, loadUsage]);
 
   // Manual refresh: re-pull accounts and actively fetch fresh usage once.
   const handleRefresh = useCallback(async () => {
@@ -144,13 +210,13 @@ function TrayMenu() {
       setAccounts(list);
       setUsageById((prev) => retainUsageForAccounts(prev, list));
       setError(null);
-      await loadUsage(list);
+      await Promise.all([loadUsage(list), loadActiveStats(list)]);
     } catch (err) {
       setError(formatError(err));
     } finally {
       setRefreshing(false);
     }
-  }, [loadUsage]);
+  }, [loadActiveStats, loadUsage]);
 
   const handleAutoWarmupToggle = useCallback(async () => {
     const next = !autoWarmupAllEnabled;
@@ -286,6 +352,7 @@ function TrayMenu() {
           accounts.map((account) => {
             const plan = formatPlan(account.plan_type);
             const usage = usageById[account.id];
+            const stats = statsById[account.id];
             const windows =
               usage && !usage.error
                 ? ([
@@ -388,6 +455,22 @@ function TrayMenu() {
                       {account.email}
                     </span>
                   ) : null}
+                  {account.is_active && stats?.available && (
+                    <span className="mt-2 grid grid-cols-2 gap-1.5">
+                      <span className="rounded-md bg-white px-2 py-1 text-[11px] text-gray-600 shadow-sm dark:bg-gray-950 dark:text-gray-300">
+                        <span className="block font-medium text-gray-900 dark:text-gray-100">
+                          {formatTokens(sumDailyTokens(stats, 1))}
+                        </span>
+                        <span>today</span>
+                      </span>
+                      <span className="rounded-md bg-white px-2 py-1 text-[11px] text-gray-600 shadow-sm dark:bg-gray-950 dark:text-gray-300">
+                        <span className="block font-medium text-gray-900 dark:text-gray-100">
+                          {formatTokens(sumDailyTokens(stats, 7))}
+                        </span>
+                        <span>last 7 days</span>
+                      </span>
+                    </span>
+                  )}
                 </span>
                 {switchingId === account.id && (
                   <span className="shrink-0 text-xs text-gray-400">...</span>

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import type { AccountWithUsage } from "../types";
+import { AccountUsageStats } from "./AccountUsageStats";
 import { UsageBar } from "./UsageBar";
 
 interface AccountCardProps {
@@ -269,8 +270,14 @@ export function AccountCard({
         )}
       </div>
 
+      <AccountUsageStats
+        accountId={account.id}
+        enabled={account.auth_mode === "chat_g_p_t"}
+        defaultOpen={account.is_active}
+      />
+
       {/* Actions */}
-      <div className="flex gap-2">
+      <div className="flex gap-2 mt-3">
         {account.is_active ? (
           <button
             disabled

--- a/src/components/AccountUsageStats.tsx
+++ b/src/components/AccountUsageStats.tsx
@@ -1,0 +1,472 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  AccountDailyUsage,
+  AccountTopInvocation,
+  AccountUsageStats as AccountUsageStatsInfo,
+} from "../types";
+import { invokeBackend } from "../lib/platform";
+
+const PROFILE_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+interface AccountUsageStatsProps {
+  accountId: string;
+  enabled: boolean;
+  defaultOpen?: boolean;
+}
+
+function emptyStats(accountId: string, error: string): AccountUsageStatsInfo {
+  return {
+    account_id: accountId,
+    available: false,
+    source: "Codex usage stats via ChatGPT backend",
+    generated_at: null,
+    stats_as_of: null,
+    summary: {
+      lifetime_tokens: null,
+      peak_daily_tokens: null,
+      longest_task_seconds: null,
+      current_streak_days: null,
+      longest_streak_days: null,
+    },
+    activity: {
+      fast_mode_percent: null,
+      reasoning_effort: null,
+      reasoning_effort_percent: null,
+      skills_explored: null,
+      total_skills_used: null,
+      total_threads: null,
+    },
+    daily: [],
+    top_invocations: [],
+    error,
+  };
+}
+
+function formatTokens(tokens: number | null | undefined): string {
+  if (tokens === null || tokens === undefined || !Number.isFinite(tokens)) return "--";
+  const abs = Math.abs(tokens);
+  if (abs >= 1_000_000_000) return `${(tokens / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
+  return `${tokens}`;
+}
+
+function formatNumber(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "--";
+  return new Intl.NumberFormat().format(value);
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "--";
+  return `${Math.round(value)}%`;
+}
+
+function formatDuration(seconds: number | null | undefined): string {
+  if (seconds === null || seconds === undefined || !Number.isFinite(seconds)) return "--";
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+function formatDateLabel(date: string): string {
+  const parsed = new Date(`${date}T12:00:00`);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(parsed);
+}
+
+function formatGeneratedAt(value: string | null): string {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const diff = Date.now() - date.getTime();
+  if (diff < 60_000) return "just now";
+  if (diff < 60 * 60_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 24 * 60 * 60_000) return `${Math.floor(diff / (60 * 60_000))}h ago`;
+  return new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" }).format(date);
+}
+
+function dayKey(offset: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - offset);
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function sumDays(daily: AccountDailyUsage[], days: number): number {
+  const keys = new Set(Array.from({ length: days }, (_, index) => dayKey(index)));
+  return daily.reduce((total, day) => (keys.has(day.date) ? total + day.tokens : total), 0);
+}
+
+type ActivityRange = 30 | 90 | 180 | "all";
+
+const ACTIVITY_RANGE_OPTIONS: { value: ActivityRange; label: string }[] = [
+  { value: 30, label: "30d" },
+  { value: 90, label: "3 mo" },
+  { value: 180, label: "6 mo" },
+  { value: "all", label: "All" },
+];
+
+function activityRangeDays(range: ActivityRange, daily: AccountDailyUsage[]): number {
+  if (range !== "all") return range;
+  return Math.max(30, daily.length);
+}
+
+function activityRangeLabel(range: ActivityRange): string {
+  switch (range) {
+    case 30:
+      return "Last 30 days";
+    case 90:
+      return "Last 3 months";
+    case 180:
+      return "Last 6 months";
+    case "all":
+      return "All reported";
+  }
+}
+
+function recentDailyBars(daily: AccountDailyUsage[], range: ActivityRange): AccountDailyUsage[] {
+  if (range === "all") {
+    return [...daily].sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  const byDate = new Map(daily.map((day) => [day.date, day.tokens]));
+  return Array.from({ length: range }, (_, index) => {
+    const date = dayKey(range - index - 1);
+    return { date, tokens: byDate.get(date) ?? 0 };
+  });
+}
+
+function StatTile({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 dark:border-gray-800 dark:bg-gray-950/50">
+      <div className="truncate text-[11px] font-medium text-gray-500 dark:text-gray-400">
+        {label}
+      </div>
+      <div className="mt-1 truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+        {value}
+      </div>
+      {sub && (
+        <div className="mt-0.5 truncate text-[11px] text-gray-500 dark:text-gray-400">
+          {sub}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TokenActivity({ daily }: { daily: AccountDailyUsage[] }) {
+  const [range, setRange] = useState<ActivityRange>(30);
+  const [hoveredDate, setHoveredDate] = useState<string | null>(null);
+  const bars = useMemo(() => recentDailyBars(daily, range), [daily, range]);
+  const rangeDays = activityRangeDays(range, daily);
+  const maxTokens = Math.max(1, ...bars.map((day) => day.tokens));
+
+  if (bars.length === 0 || !bars.some((day) => day.tokens > 0)) {
+    return (
+      <div className="flex h-14 items-center justify-center rounded-lg border border-dashed border-gray-200 text-[11px] text-gray-400 dark:border-gray-800 dark:text-gray-500">
+        Daily activity unavailable
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white px-3 pb-3 pt-2 dark:border-gray-800 dark:bg-gray-950/40">
+      <div className="mb-2 flex items-center justify-between text-[11px]">
+        <span className="font-medium text-gray-600 dark:text-gray-300">Token activity</span>
+        <div className="flex items-center gap-2">
+          <span className="text-gray-400 dark:text-gray-500">{activityRangeLabel(range)}</span>
+          <select
+            value={range}
+            onChange={(event) => {
+              const value = event.target.value;
+              setRange(value === "all" ? "all" : (Number(value) as ActivityRange));
+            }}
+            className="h-6 rounded-md border border-gray-200 bg-gray-50 px-1.5 text-[11px] text-gray-600 outline-none dark:border-gray-800 dark:bg-gray-900 dark:text-gray-300"
+            aria-label="Token activity range"
+          >
+            {ACTIVITY_RANGE_OPTIONS.map((option) => (
+              <option key={option.label} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      <div
+        className="relative grid h-14 grid-flow-col auto-cols-fr items-end gap-px sm:gap-1"
+        onMouseLeave={() => setHoveredDate(null)}
+      >
+        {bars.map((day) => {
+          const height = day.tokens > 0 ? Math.max(8, Math.round((day.tokens / maxTokens) * 52)) : 3;
+          const isEmpty = day.tokens === 0;
+          const maxWidth = rangeDays > 90 ? "max-w-1.5" : rangeDays > 45 ? "max-w-2" : "max-w-3";
+          const isHovered = hoveredDate === day.date;
+          return (
+            <div
+              key={day.date}
+              className="relative flex h-14 items-end justify-center"
+              onMouseEnter={() => setHoveredDate(day.date)}
+            >
+              {isHovered && (
+                <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 min-w-max -translate-x-1/2 rounded-md bg-gray-950 px-2 py-1 text-[11px] text-white shadow-lg dark:bg-gray-100 dark:text-gray-950">
+                  {formatDateLabel(day.date)} · {formatTokens(day.tokens)}
+                </div>
+              )}
+              <div
+                className={`w-full ${maxWidth} rounded-t transition-colors ${
+                  isEmpty
+                    ? "bg-gray-200 dark:bg-gray-800"
+                    : "bg-blue-500 hover:bg-blue-400"
+                }`}
+                style={{ height }}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DetailPanel({
+  activity,
+  thirtyDayTokens,
+  summary,
+  topInvocations,
+}: {
+  activity: AccountUsageStatsInfo["activity"];
+  thirtyDayTokens: number | null;
+  summary: AccountUsageStatsInfo["summary"];
+  topInvocations: AccountTopInvocation[];
+}) {
+  const hasActivity =
+    activity.fast_mode_percent !== null ||
+    activity.reasoning_effort !== null ||
+    activity.skills_explored !== null ||
+    activity.total_threads !== null;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <details
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+      className="rounded-lg border border-gray-200 bg-gray-50 transition-colors dark:border-gray-800 dark:bg-gray-950/50"
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between rounded-lg px-3 py-2 text-[12px] font-semibold text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-900">
+        More usage details
+        <span className="flex h-6 w-6 items-center justify-center rounded-md bg-white text-gray-500 transition-colors dark:bg-gray-900 dark:text-gray-400">
+          <svg
+            className={`h-3.5 w-3.5 transition-transform ${open ? "rotate-180" : ""}`}
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </span>
+      </summary>
+      <div className="grid gap-3 border-t border-gray-200 p-3 dark:border-gray-800 sm:grid-cols-2">
+        <div className="grid grid-cols-3 gap-2 sm:col-span-2">
+          <StatTile label="Last 30 days" value={formatTokens(thirtyDayTokens)} sub="reported" />
+          <StatTile label="Longest task" value={formatDuration(summary.longest_task_seconds)} />
+          <StatTile label="Longest streak" value={`${formatNumber(summary.longest_streak_days)} days`} />
+        </div>
+
+        {hasActivity && (
+          <div className="space-y-1.5">
+            <div className="mb-1 text-[11px] font-semibold text-gray-600 dark:text-gray-300">
+              Activity insights
+            </div>
+            <div className="flex justify-between gap-2 text-[11px]">
+              <span className="text-gray-500 dark:text-gray-400">Fast mode</span>
+              <span className="text-gray-800 dark:text-gray-100">{formatPercent(activity.fast_mode_percent)}</span>
+            </div>
+            <div className="flex justify-between gap-2 text-[11px]">
+              <span className="text-gray-500 dark:text-gray-400">Reasoning</span>
+              <span className="text-gray-800 dark:text-gray-100">
+                {activity.reasoning_effort ?? "--"}
+                {activity.reasoning_effort_percent !== null && ` · ${formatPercent(activity.reasoning_effort_percent)}`}
+              </span>
+            </div>
+            <div className="flex justify-between gap-2 text-[11px]">
+              <span className="text-gray-500 dark:text-gray-400">Skills explored</span>
+              <span className="text-gray-800 dark:text-gray-100">{formatNumber(activity.skills_explored)}</span>
+            </div>
+            <div className="flex justify-between gap-2 text-[11px]">
+              <span className="text-gray-500 dark:text-gray-400">Total threads</span>
+              <span className="text-gray-800 dark:text-gray-100">{formatNumber(activity.total_threads)}</span>
+            </div>
+          </div>
+        )}
+
+        {topInvocations.length > 0 && (
+          <div className="space-y-1.5">
+            <div className="mb-1 text-[11px] font-semibold text-gray-600 dark:text-gray-300">
+              Most used plugins
+            </div>
+            {topInvocations.slice(0, 5).map((invocation) => (
+              <InvocationRow
+                key={`${invocation.kind}-${invocation.display_name}-${invocation.usage_count}`}
+                invocation={invocation}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}
+
+function InvocationRow({ invocation }: { invocation: AccountTopInvocation }) {
+  const prefix = invocation.kind === "plugin" ? "@" : "$";
+  return (
+    <div className="flex items-center justify-between gap-2 text-[11px]">
+      <span className="min-w-0 truncate text-gray-700 dark:text-gray-200">
+        {prefix}{invocation.display_name}
+      </span>
+      <span className="shrink-0 text-gray-500 dark:text-gray-400">
+        {formatNumber(invocation.usage_count)} runs
+      </span>
+    </div>
+  );
+}
+
+export function AccountUsageStats({ accountId, enabled, defaultOpen = false }: AccountUsageStatsProps) {
+  const [panelOpen, setPanelOpen] = useState(defaultOpen);
+  const [stats, setStats] = useState<AccountUsageStatsInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+  const requestSeq = useRef(0);
+
+  const loadStats = useCallback(async () => {
+    const requestId = ++requestSeq.current;
+
+    if (!enabled) {
+      setStats(emptyStats(accountId, "Usage stats are available for ChatGPT accounts only."));
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const next = await invokeBackend<AccountUsageStatsInfo>("get_account_usage_stats", {
+        accountId,
+      });
+      if (requestId !== requestSeq.current) return;
+      setStats(next);
+    } catch (err) {
+      if (requestId !== requestSeq.current) return;
+      setStats(emptyStats(accountId, err instanceof Error ? err.message : String(err)));
+    } finally {
+      if (requestId === requestSeq.current) {
+        setLoading(false);
+      }
+    }
+  }, [accountId, enabled]);
+
+  useEffect(() => {
+    requestSeq.current += 1;
+    setStats(null);
+    setLoading(false);
+    setPanelOpen(defaultOpen);
+  }, [accountId, defaultOpen]);
+
+  useEffect(() => {
+    if (!panelOpen) return;
+    void loadStats();
+  }, [loadStats, panelOpen]);
+
+  useEffect(() => {
+    if (!enabled || !panelOpen) return;
+    const timer = window.setInterval(() => {
+      void loadStats();
+    }, PROFILE_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [enabled, loadStats, panelOpen]);
+
+  const currentStats = stats?.account_id === accountId ? stats : null;
+  const generatedAt = currentStats ? formatGeneratedAt(currentStats.generated_at) : "";
+  const todayTokens = currentStats ? sumDays(currentStats.daily, 1) : null;
+  const sevenDayTokens = currentStats ? sumDays(currentStats.daily, 7) : null;
+  const thirtyDayTokens = currentStats ? sumDays(currentStats.daily, 30) : null;
+
+  return (
+    <details
+      open={panelOpen}
+      onToggle={(event) => setPanelOpen(event.currentTarget.open)}
+      className="group mt-4 border-t border-gray-200 pt-3 dark:border-gray-800"
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 rounded-lg px-1 py-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
+        <span className="flex min-w-0 items-center gap-2">
+            <svg className="h-4 w-4 text-gray-500 dark:text-gray-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M4 19V5" strokeLinecap="round" />
+              <path d="M4 19h16" strokeLinecap="round" />
+              <path d="M8 15l3-4 3 2 4-6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          <span className="truncate">Usage Stats</span>
+          {generatedAt && (
+            <span className="truncate text-[11px] font-normal text-gray-500 dark:text-gray-400">
+              updated {generatedAt}
+            </span>
+          )}
+        </span>
+        <span className="text-gray-400 transition-transform group-open:rotate-180">⌄</span>
+      </summary>
+
+      <div className="pt-3">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <p className="truncate text-[11px] text-gray-500 dark:text-gray-400">
+            {currentStats?.stats_as_of ? `Stats as of ${currentStats.stats_as_of}` : currentStats?.source ?? "ChatGPT backend"}
+            {generatedAt && ` · updated ${generatedAt}`}
+          </p>
+          <button
+            onClick={() => void loadStats()}
+            disabled={loading || !enabled}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-600 transition-colors hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            title="Refresh usage stats"
+          >
+            <span className={loading ? "inline-block animate-spin" : ""}>↻</span>
+          </button>
+        </div>
+
+        {loading && !currentStats ? (
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+            {[0, 1, 2, 3, 4].map((item) => (
+              <div key={item} className="h-16 animate-pulse rounded-lg bg-gray-100 dark:bg-gray-800" />
+            ))}
+          </div>
+        ) : currentStats?.available ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+              <StatTile label="Lifetime" value={formatTokens(currentStats.summary.lifetime_tokens)} sub="tokens" />
+              <StatTile label="Today" value={formatTokens(todayTokens)} sub="reported" />
+              <StatTile label="Last 7 days" value={formatTokens(sevenDayTokens)} sub="reported" />
+              <StatTile label="Current streak" value={`${formatNumber(currentStats.summary.current_streak_days)} days`} />
+              <StatTile label="Peak day" value={formatTokens(currentStats.summary.peak_daily_tokens)} sub="tokens" />
+            </div>
+
+            <TokenActivity daily={currentStats.daily} />
+
+            <DetailPanel
+              activity={currentStats.activity}
+              thirtyDayTokens={thirtyDayTokens}
+              summary={currentStats.summary}
+              topInvocations={currentStats.top_invocations}
+            />
+          </div>
+        ) : (
+          <div className="rounded-lg border border-dashed border-gray-200 px-3 py-3 text-xs text-gray-500 dark:border-gray-800 dark:text-gray-400">
+            {currentStats?.error ?? "Usage stats unavailable."}
+          </div>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export { AccountCard } from "./AccountCard";
 export { UsageBar } from "./UsageBar";
 export { AddAccountModal } from "./AddAccountModal";
+export { AccountUsageStats } from "./AccountUsageStats";
 export { UpdateChecker } from "./UpdateChecker";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,51 @@ export interface UsageInfo {
   error: string | null;
 }
 
+export interface AccountUsageSummary {
+  lifetime_tokens: number | null;
+  peak_daily_tokens: number | null;
+  longest_task_seconds: number | null;
+  current_streak_days: number | null;
+  longest_streak_days: number | null;
+}
+
+export interface AccountUsageActivity {
+  fast_mode_percent: number | null;
+  reasoning_effort: string | null;
+  reasoning_effort_percent: number | null;
+  skills_explored: number | null;
+  total_skills_used: number | null;
+  total_threads: number | null;
+}
+
+export interface AccountDailyUsage {
+  date: string;
+  tokens: number;
+}
+
+export interface AccountTopInvocation {
+  kind: string;
+  display_name: string;
+  usage_count: number;
+  plugin_id: string | null;
+  plugin_name: string | null;
+  skill_id: string | null;
+  skill_name: string | null;
+}
+
+export interface AccountUsageStats {
+  account_id: string;
+  available: boolean;
+  source: string;
+  generated_at: string | null;
+  stats_as_of: string | null;
+  summary: AccountUsageSummary;
+  activity: AccountUsageActivity;
+  daily: AccountDailyUsage[];
+  top_invocations: AccountTopInvocation[];
+  error: string | null;
+}
+
 export interface OAuthLoginInfo {
   auth_url: string;
   callback_port: number;


### PR DESCRIPTION
Fetch account-scoped usage stats from the subscription profile endpoint for OAuth. Map lifetime totals, streaks, daily buckets, top integrations, and activity metadata into a typed backend command exposed through both desktop and web surfaces.

Add an isolated Usage Stats panel that loads only when opened except for the active account by default, refreshes on a conservative interval, ignores stale async responses during account switches, and keeps detailed fields behind a secondary disclosure.

Show compact active-account stats in the tray using today and last 7 days from daily buckets while preserving the existing rate-limit usage flow and manual refresh behavior.

Include parser coverage for representative profile payloads and keep API-key accounts returning a non-fatal unavailable state.