### PR TITLE
Add manual reset credit badges

### DIFF
--- a/src-tauri/src/commands/account_stats.rs
+++ b/src-tauri/src/commands/account_stats.rs
@@ -1,7 +1,8 @@
 //! Account-scoped usage statistics from the Codex profile endpoint.
 
+use chrono::{DateTime, Utc};
 use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, USER_AGENT},
+    header::{HeaderMap, HeaderName, HeaderValue, ACCEPT, AUTHORIZATION, USER_AGENT},
     StatusCode,
 };
 use serde::{Deserialize, Serialize};
@@ -10,6 +11,8 @@ use crate::auth::{ensure_chatgpt_tokens_fresh, load_accounts, refresh_chatgpt_to
 use crate::types::{AuthData, AuthMode, StoredAccount};
 
 const CHATGPT_PROFILE_USAGE_URL: &str = "https://chatgpt.com/backend-api/wham/profiles/me";
+const CHATGPT_RESET_CREDITS_URL: &str =
+    "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits";
 const CODEX_USER_AGENT: &str = "codex-cli/1.0.0";
 
 #[derive(Debug, Clone, Serialize)]
@@ -23,6 +26,7 @@ pub struct AccountUsageStats {
     pub activity: AccountUsageActivity,
     pub daily: Vec<AccountDailyUsage>,
     pub top_invocations: Vec<AccountTopInvocation>,
+    pub reset_credits: Option<AccountResetCredits>,
     pub error: Option<String>,
 }
 
@@ -60,6 +64,26 @@ pub struct AccountTopInvocation {
     pub plugin_name: Option<String>,
     pub skill_id: Option<String>,
     pub skill_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountResetCredits {
+    pub available_count: i64,
+    pub next_expires_at: Option<String>,
+    pub credits: Vec<AccountResetCredit>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountResetCredit {
+    pub id: String,
+    pub reset_type: String,
+    pub status: String,
+    pub granted_at: Option<String>,
+    pub expires_at: Option<String>,
+    pub redeem_started_at: Option<String>,
+    pub redeemed_at: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -132,6 +156,33 @@ struct ProfileUsageMetadata {
     stats_error: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct ResetCreditsResponse {
+    #[serde(default)]
+    credits: Vec<ResetCredit>,
+    #[serde(default)]
+    available_count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResetCredit {
+    id: String,
+    reset_type: String,
+    status: String,
+    #[serde(default)]
+    granted_at: Option<String>,
+    #[serde(default)]
+    expires_at: Option<String>,
+    #[serde(default)]
+    redeem_started_at: Option<String>,
+    #[serde(default)]
+    redeemed_at: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
 #[tauri::command]
 pub async fn get_account_usage_stats(account_id: String) -> Result<AccountUsageStats, String> {
     let store = load_accounts().map_err(|e| e.to_string())?;
@@ -160,10 +211,10 @@ async fn fetch_profile_usage(account: &StoredAccount) -> anyhow::Result<AccountU
     if response.status() == StatusCode::UNAUTHORIZED {
         let refreshed_account = refresh_chatgpt_tokens(&fresh_account).await?;
         response = send_profile_usage_request(&refreshed_account).await?;
-        return parse_profile_usage_response(&refreshed_account.id, response).await;
+        return parse_profile_usage_with_reset_credits(&refreshed_account, response).await;
     }
 
-    parse_profile_usage_response(&fresh_account.id, response).await
+    parse_profile_usage_with_reset_credits(&fresh_account, response).await
 }
 
 async fn send_profile_usage_request(account: &StoredAccount) -> anyhow::Result<reqwest::Response> {
@@ -175,6 +226,19 @@ async fn send_profile_usage_request(account: &StoredAccount) -> anyhow::Result<r
         .headers(build_chatgpt_headers(access_token, chatgpt_account_id)?)
         .send()
         .await?)
+}
+
+async fn parse_profile_usage_with_reset_credits(
+    account: &StoredAccount,
+    response: reqwest::Response,
+) -> anyhow::Result<AccountUsageStats> {
+    let mut stats = parse_profile_usage_response(&account.id, response).await?;
+
+    if stats.available {
+        stats.reset_credits = fetch_reset_credits(account).await.ok();
+    }
+
+    Ok(stats)
 }
 
 async fn parse_profile_usage_response(
@@ -191,6 +255,27 @@ async fn parse_profile_usage_response(
 
     let payload: ProfileUsageResponse = response.json().await?;
     Ok(map_profile_usage(account_id, payload))
+}
+
+async fn fetch_reset_credits(account: &StoredAccount) -> anyhow::Result<AccountResetCredits> {
+    let (access_token, chatgpt_account_id) = extract_chatgpt_auth(account)?;
+    let client = reqwest::Client::new();
+    let response = client
+        .get(CHATGPT_RESET_CREDITS_URL)
+        .headers(build_reset_credits_headers(
+            access_token,
+            chatgpt_account_id,
+        )?)
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        anyhow::bail!("Reset credits request failed: {status}");
+    }
+
+    let payload: ResetCreditsResponse = response.json().await?;
+    Ok(map_reset_credits(payload, Utc::now()))
 }
 
 fn map_profile_usage(account_id: &str, payload: ProfileUsageResponse) -> AccountUsageStats {
@@ -237,7 +322,45 @@ fn map_profile_usage(account_id: &str, payload: ProfileUsageResponse) -> Account
             .into_iter()
             .map(map_top_invocation)
             .collect(),
+        reset_credits: None,
         error: stats_error,
+    }
+}
+
+fn map_reset_credits(payload: ResetCreditsResponse, now: DateTime<Utc>) -> AccountResetCredits {
+    let next_expires_at = payload
+        .credits
+        .iter()
+        .filter(|credit| credit.status == "available")
+        .filter_map(|credit| {
+            credit
+                .expires_at
+                .as_ref()
+                .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+                .map(|value| value.with_timezone(&Utc))
+                .filter(|value| *value > now)
+                .map(|value| value.to_rfc3339())
+        })
+        .min();
+
+    AccountResetCredits {
+        available_count: payload.available_count.max(0),
+        next_expires_at,
+        credits: payload.credits.into_iter().map(map_reset_credit).collect(),
+    }
+}
+
+fn map_reset_credit(credit: ResetCredit) -> AccountResetCredit {
+    AccountResetCredit {
+        id: credit.id,
+        reset_type: credit.reset_type,
+        status: credit.status,
+        granted_at: credit.granted_at,
+        expires_at: credit.expires_at,
+        redeem_started_at: credit.redeem_started_at,
+        redeemed_at: credit.redeemed_at,
+        title: credit.title,
+        description: credit.description,
     }
 }
 
@@ -272,6 +395,7 @@ fn unavailable_stats(account_id: String, message: &str) -> AccountUsageStats {
         activity: AccountUsageActivity::default(),
         daily: Vec::new(),
         top_invocations: Vec::new(),
+        reset_credits: None,
         error: Some(message.to_string()),
     }
 }
@@ -294,6 +418,23 @@ fn build_chatgpt_headers(
         );
     }
 
+    Ok(headers)
+}
+
+fn build_reset_credits_headers(
+    access_token: &str,
+    chatgpt_account_id: Option<&str>,
+) -> anyhow::Result<HeaderMap> {
+    let mut headers = build_chatgpt_headers(access_token, chatgpt_account_id)?;
+    headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+    headers.insert(
+        HeaderName::from_static("openai-beta"),
+        HeaderValue::from_static("codex-1"),
+    );
+    headers.insert(
+        HeaderName::from_static("originator"),
+        HeaderValue::from_static("Codex Desktop"),
+    );
     Ok(headers)
 }
 
@@ -368,5 +509,60 @@ mod tests {
         );
         assert_eq!(stats.top_invocations[1].display_name, "github");
         assert_eq!(stats.activity.total_threads, Some(500));
+    }
+
+    #[test]
+    fn reset_credits_response_maps_available_count_and_next_expiry() {
+        let payload: ResetCreditsResponse = serde_json::from_value(serde_json::json!({
+            "credits": [
+                {
+                    "id": "expired-available",
+                    "reset_type": "codex_rate_limits",
+                    "status": "available",
+                    "granted_at": "2026-05-18T00:39:53Z",
+                    "expires_at": "2026-06-17T00:39:53Z"
+                },
+                {
+                    "id": "later",
+                    "reset_type": "codex_rate_limits",
+                    "status": "available",
+                    "granted_at": "2026-06-18T00:39:53.731630Z",
+                    "expires_at": "2026-07-18T00:39:53.731630Z"
+                },
+                {
+                    "id": "earlier",
+                    "reset_type": "codex_rate_limits",
+                    "status": "available",
+                    "granted_at": "2026-06-12T04:03:43.263391Z",
+                    "expires_at": "2026-07-12T04:03:43.263391Z",
+                    "title": "One free rate limit reset"
+                },
+                {
+                    "id": "redeemed",
+                    "reset_type": "codex_rate_limits",
+                    "status": "redeemed",
+                    "granted_at": "2026-06-12T04:03:43Z",
+                    "expires_at": "2026-07-10T04:03:43Z"
+                }
+            ],
+            "available_count": 2
+        }))
+        .unwrap();
+
+        let now = DateTime::parse_from_rfc3339("2026-06-26T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let stats = map_reset_credits(payload, now);
+
+        assert_eq!(stats.available_count, 2);
+        assert_eq!(stats.credits.len(), 4);
+        assert_eq!(
+            stats.next_expires_at.as_deref(),
+            Some("2026-07-12T04:03:43.263391+00:00")
+        );
+        assert_eq!(
+            stats.credits[2].title.as_deref(),
+            Some("One free rate limit reset")
+        );
     }
 }

--- a/src/TrayMenu.tsx
+++ b/src/TrayMenu.tsx
@@ -181,6 +181,7 @@ function TrayMenu() {
           },
           daily: [],
           top_invocations: [],
+          reset_credits: null,
           error: formatError(err),
         },
       }));

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -1,7 +1,10 @@
-import { useState, useRef, useEffect } from "react";
-import type { AccountWithUsage } from "../types";
+import { useCallback, useState, useRef, useEffect } from "react";
+import type { AccountResetCredits, AccountUsageStats as AccountUsageStatsInfo, AccountWithUsage } from "../types";
+import { invokeBackend } from "../lib/platform";
 import { AccountUsageStats } from "./AccountUsageStats";
 import { UsageBar } from "./UsageBar";
+
+const RESET_CREDITS_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 interface AccountCardProps {
   account: AccountWithUsage;
@@ -78,6 +81,64 @@ function getSubscriptionStatus(timestamp: string | null | undefined): {
   };
 }
 
+function formatResetCreditsCount(resetCredits: AccountResetCredits | null): string | null {
+  if (!resetCredits) return null;
+  const count = resetCredits.available_count;
+  if (count <= 0) return null;
+  return count === 1 ? "1 reset" : `${count} resets`;
+}
+
+function formatResetCreditsExpiry(resetCredits: AccountResetCredits | null): string | null {
+  if (!resetCredits?.next_expires_at) return null;
+
+  const expiry = new Date(resetCredits.next_expires_at);
+  if (Number.isNaN(expiry.getTime())) return null;
+
+  return `closest expires ${new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(expiry)}`;
+}
+
+function getResetCreditsTone(resetCredits: AccountResetCredits | null): {
+  container: string;
+  badge: string;
+  text: string;
+} {
+  const fallback = {
+    container: "border-sky-200 bg-sky-50/70 dark:border-sky-800 dark:bg-sky-950/30",
+    badge: "border-sky-200 bg-sky-100 text-sky-700 dark:border-sky-700 dark:bg-sky-900/50 dark:text-sky-300",
+    text: "text-sky-700/80 dark:text-sky-300/80",
+  };
+
+  if (!resetCredits?.next_expires_at) return fallback;
+
+  const expiry = new Date(resetCredits.next_expires_at);
+  if (Number.isNaN(expiry.getTime())) return fallback;
+
+  const remainingMs = expiry.getTime() - Date.now();
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  if (remainingMs <= 3 * dayMs) {
+    return {
+      container: "border-red-200 bg-red-50/70 dark:border-red-800 dark:bg-red-950/30",
+      badge: "border-red-200 bg-red-100 text-red-700 dark:border-red-700 dark:bg-red-900/50 dark:text-red-300",
+      text: "text-red-700/80 dark:text-red-300/80",
+    };
+  }
+
+  if (remainingMs <= 10 * dayMs) {
+    return {
+      container: "border-amber-200 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/30",
+      badge: "border-amber-200 bg-amber-100 text-amber-700 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-300",
+      text: "text-amber-700/80 dark:text-amber-300/80",
+    };
+  }
+
+  return fallback;
+}
+
 function BlurredText({ children, blur }: { children: React.ReactNode; blur: boolean }) {
   return (
     <span
@@ -112,7 +173,9 @@ export function AccountCard({
   );
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(account.name);
+  const [resetCredits, setResetCredits] = useState<AccountResetCredits | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const resetRequestSeq = useRef(0);
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -173,6 +236,50 @@ export function AccountCard({
   const planColorClass = planColors[planKey] || planColors.free;
   const showSubscriptionStatus = account.auth_mode === "chat_g_p_t";
   const subscriptionStatus = getSubscriptionStatus(account.subscription_expires_at);
+  const resetCreditsCount = formatResetCreditsCount(resetCredits);
+  const resetCreditsExpiry = formatResetCreditsExpiry(resetCredits);
+  const resetCreditsTone = getResetCreditsTone(resetCredits);
+
+  const loadResetCredits = useCallback(async () => {
+    const requestId = ++resetRequestSeq.current;
+
+    if (account.auth_mode !== "chat_g_p_t") {
+      setResetCredits(null);
+      return;
+    }
+
+    try {
+      const stats = await invokeBackend<AccountUsageStatsInfo>("get_account_usage_stats", {
+        accountId: account.id,
+      });
+      if (requestId !== resetRequestSeq.current) return;
+      setResetCredits(stats.account_id === account.id ? stats.reset_credits : null);
+    } catch {
+      if (requestId !== resetRequestSeq.current) return;
+      setResetCredits(null);
+    }
+  }, [account.auth_mode, account.id]);
+
+  const handleStatsLoaded = useCallback(
+    (stats: AccountUsageStatsInfo | null) => {
+      setResetCredits(stats?.account_id === account.id ? stats.reset_credits : null);
+    },
+    [account.id]
+  );
+
+  useEffect(() => {
+    setResetCredits(null);
+
+    void loadResetCredits();
+    const timer = window.setInterval(() => {
+      void loadResetCredits();
+    }, RESET_CREDITS_REFRESH_INTERVAL_MS);
+
+    return () => {
+      resetRequestSeq.current += 1;
+      window.clearInterval(timer);
+    };
+  }, [loadResetCredits]);
 
 
   return (
@@ -224,7 +331,7 @@ export function AccountCard({
           )}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex max-w-[60%] flex-wrap items-center justify-end gap-2">
           {/* Eye toggle */}
           {onToggleMask && (
             <button
@@ -250,6 +357,20 @@ export function AccountCard({
           >
             {planDisplay}
           </span>
+          {resetCreditsCount && (
+            <div
+              className={`flex max-w-full items-center gap-2 rounded-lg border px-2 py-1.5 text-xs ${resetCreditsTone.container}`}
+            >
+              <span className={`rounded-full border px-2.5 py-0.5 font-medium ${resetCreditsTone.badge}`}>
+                {resetCreditsCount}
+              </span>
+              {resetCreditsExpiry && (
+                <span className={`truncate ${resetCreditsTone.text}`}>
+                  {resetCreditsExpiry}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
@@ -274,6 +395,7 @@ export function AccountCard({
         accountId={account.id}
         enabled={account.auth_mode === "chat_g_p_t"}
         defaultOpen={account.is_active}
+        onStatsLoaded={handleStatsLoaded}
       />
 
       {/* Actions */}

--- a/src/components/AccountUsageStats.tsx
+++ b/src/components/AccountUsageStats.tsx
@@ -12,6 +12,7 @@ interface AccountUsageStatsProps {
   accountId: string;
   enabled: boolean;
   defaultOpen?: boolean;
+  onStatsLoaded?: (stats: AccountUsageStatsInfo | null) => void;
 }
 
 function emptyStats(accountId: string, error: string): AccountUsageStatsInfo {
@@ -38,6 +39,7 @@ function emptyStats(accountId: string, error: string): AccountUsageStatsInfo {
     },
     daily: [],
     top_invocations: [],
+    reset_credits: null,
     error,
   };
 }
@@ -339,7 +341,12 @@ function InvocationRow({ invocation }: { invocation: AccountTopInvocation }) {
   );
 }
 
-export function AccountUsageStats({ accountId, enabled, defaultOpen = false }: AccountUsageStatsProps) {
+export function AccountUsageStats({
+  accountId,
+  enabled,
+  defaultOpen = false,
+  onStatsLoaded,
+}: AccountUsageStatsProps) {
   const [panelOpen, setPanelOpen] = useState(defaultOpen);
   const [stats, setStats] = useState<AccountUsageStatsInfo | null>(null);
   const [loading, setLoading] = useState(false);
@@ -349,7 +356,9 @@ export function AccountUsageStats({ accountId, enabled, defaultOpen = false }: A
     const requestId = ++requestSeq.current;
 
     if (!enabled) {
-      setStats(emptyStats(accountId, "Usage stats are available for ChatGPT accounts only."));
+      const next = emptyStats(accountId, "Usage stats are available for ChatGPT accounts only.");
+      setStats(next);
+      onStatsLoaded?.(next);
       setLoading(false);
       return;
     }
@@ -361,22 +370,26 @@ export function AccountUsageStats({ accountId, enabled, defaultOpen = false }: A
       });
       if (requestId !== requestSeq.current) return;
       setStats(next);
+      onStatsLoaded?.(next);
     } catch (err) {
       if (requestId !== requestSeq.current) return;
-      setStats(emptyStats(accountId, err instanceof Error ? err.message : String(err)));
+      const next = emptyStats(accountId, err instanceof Error ? err.message : String(err));
+      setStats(next);
+      onStatsLoaded?.(next);
     } finally {
       if (requestId === requestSeq.current) {
         setLoading(false);
       }
     }
-  }, [accountId, enabled]);
+  }, [accountId, enabled, onStatsLoaded]);
 
   useEffect(() => {
     requestSeq.current += 1;
     setStats(null);
+    onStatsLoaded?.(null);
     setLoading(false);
     setPanelOpen(defaultOpen);
-  }, [accountId, defaultOpen]);
+  }, [accountId, defaultOpen, onStatsLoaded]);
 
   useEffect(() => {
     if (!panelOpen) return;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -61,6 +61,24 @@ export interface AccountTopInvocation {
   skill_name: string | null;
 }
 
+export interface AccountResetCredit {
+  id: string;
+  reset_type: string;
+  status: string;
+  granted_at: string | null;
+  expires_at: string | null;
+  redeem_started_at: string | null;
+  redeemed_at: string | null;
+  title: string | null;
+  description: string | null;
+}
+
+export interface AccountResetCredits {
+  available_count: number;
+  next_expires_at: string | null;
+  credits: AccountResetCredit[];
+}
+
 export interface AccountUsageStats {
   account_id: string;
   available: boolean;
@@ -71,6 +89,7 @@ export interface AccountUsageStats {
   activity: AccountUsageActivity;
   daily: AccountDailyUsage[];
   top_invocations: AccountTopInvocation[];
+  reset_credits: AccountResetCredits | null;
   error: string | null;
 }
 


### PR DESCRIPTION
## Summary

Adds account-scoped manual reset credit visibility for ChatGPT OAuth accounts.

The app now fetches the ChatGPT backend reset-credit endpoint alongside the existing profile usage stats, maps the available reset count and closest expiry, and surfaces that information directly on each account card next to the plan badge.

## User-facing behavior

- Shows a compact reset credit panel beside the plan badge, for example `2 resets - closest expires Jul 12, 2026`.
- Hides the panel when no reset credits are available.
- Colors the reset panel by urgency when an expiry date is reported:
  - neutral/blue by default
  - amber within 10 days
  - red within 3 days
- Keeps reset credit failures isolated so normal usage stats still render.

## Implementation notes

- Uses `GET /backend-api/wham/rate-limit-reset-credits` for ChatGPT OAuth accounts.
- Carries reset credit data through the existing account usage stats response shape.
- Guards async account-card reset fetches against stale responses when the active account changes quickly.
- Adds TypeScript types for reset credit snapshots and a Rust unit test for mapping available counts and closest available expiry.

## Validation

- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
