### PR TITLE
Add macOS Dock display preference

### DIFF
--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -5,16 +5,24 @@ use tauri::{
     AppHandle, Runtime,
 };
 
+#[cfg(target_os = "macos")]
+pub(crate) use crate::types::DockDisplayMode;
 use crate::{
     auth::{load_app_settings, save_app_settings},
-    types::TrayDisplayMode,
+    types::{AppSettings, TrayDisplayMode},
 };
 
 const TRAY_ICON_AND_SESSION_ID: &str = "tray-display-icon-and-session";
 const TRAY_ACTIVE_USAGE_TEXT_ID: &str = "tray-display-active-usage-text";
 const TRAY_HIDDEN_ID: &str = "tray-display-hidden";
+#[cfg(target_os = "macos")]
+pub(crate) const DOCK_SHOW_IN_DOCK_ID: &str = "dock-display-show-in-dock";
+#[cfg(target_os = "macos")]
+pub(crate) const DOCK_MENU_BAR_ONLY_ID: &str = "dock-display-menu-bar-only";
 
 pub fn setup(app: &AppHandle) -> tauri::Result<()> {
+    #[cfg(target_os = "macos")]
+    apply_saved_dock_display_mode(app);
     refresh(app)?;
     app.on_menu_event(handle_menu_event);
     Ok(())
@@ -22,40 +30,152 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
 
 pub fn refresh<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let settings = load_app_settings().unwrap_or_default();
-    let menu = build_menu(app, settings.tray_display_mode)?;
+    let menu = build_menu(app, &settings)?;
     app.set_menu(menu)?;
     Ok(())
 }
 
 fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
-    let mode = match event.id().as_ref() {
+    let item_id = event.id();
+
+    if let Some(mode) = tray_display_mode_for_item(item_id.as_ref()) {
+        update_tray_display_mode(app, mode);
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    if let Some(mode) = dock_display_mode_for_item(item_id.as_ref()) {
+        update_dock_display_mode(app, mode);
+    }
+}
+
+fn tray_display_mode_for_item(item_id: &str) -> Option<TrayDisplayMode> {
+    Some(match item_id {
         TRAY_ICON_AND_SESSION_ID => TrayDisplayMode::IconAndSession,
         TRAY_ACTIVE_USAGE_TEXT_ID => TrayDisplayMode::ActiveUsageText,
         TRAY_HIDDEN_ID => TrayDisplayMode::Hidden,
-        _ => return,
-    };
+        _ => return None,
+    })
+}
 
+pub(crate) fn update_tray_display_mode(app: &AppHandle, mode: TrayDisplayMode) {
     let mut settings = load_app_settings().unwrap_or_default();
     if settings.tray_display_mode == mode {
         return;
     }
 
     settings.tray_display_mode = mode;
+    #[cfg(target_os = "macos")]
+    let dock_mode_changed = ensure_dock_entry_for_tray_mode(&mut settings);
     if let Err(error) = save_app_settings(&settings) {
         eprintln!("Failed to save app settings: {error}");
         return;
     }
 
+    #[cfg(target_os = "macos")]
+    if dock_mode_changed {
+        apply_dock_display_mode(app, settings.dock_display_mode);
+    }
     if let Err(error) = refresh(app) {
         eprintln!("Failed to refresh app menu: {error}");
     }
     crate::tray::refresh(app);
 }
 
-fn build_menu<R: Runtime>(
+#[cfg(target_os = "macos")]
+pub(crate) fn dock_display_mode_for_item(item_id: &str) -> Option<DockDisplayMode> {
+    Some(match item_id {
+        DOCK_SHOW_IN_DOCK_ID => DockDisplayMode::ShowInDock,
+        DOCK_MENU_BAR_ONLY_ID => DockDisplayMode::MenuBarOnly,
+        _ => return None,
+    })
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn update_dock_display_mode(app: &AppHandle, mode: DockDisplayMode) {
+    if let Err(error) = set_dock_display_mode(app, mode) {
+        eprintln!("Failed to update Dock display mode: {error}");
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn set_dock_display_mode<R: Runtime>(
     app: &AppHandle<R>,
-    tray_display_mode: TrayDisplayMode,
-) -> tauri::Result<Menu<R>> {
+    mode: DockDisplayMode,
+) -> anyhow::Result<AppSettings> {
+    let mut settings = load_app_settings().unwrap_or_default();
+    if settings.dock_display_mode == mode {
+        let changed = ensure_menu_bar_entry_for_dock_mode(&mut settings);
+        if changed {
+            save_app_settings(&settings)?;
+        }
+        apply_dock_display_mode(app, mode);
+        if changed {
+            if let Err(error) = refresh(app) {
+                eprintln!("Failed to refresh app menu: {error}");
+            }
+            crate::tray::refresh(app);
+        }
+        return Ok(settings);
+    }
+
+    settings.dock_display_mode = mode;
+    ensure_menu_bar_entry_for_dock_mode(&mut settings);
+    save_app_settings(&settings)?;
+    apply_dock_display_mode(app, mode);
+
+    if let Err(error) = refresh(app) {
+        eprintln!("Failed to refresh app menu: {error}");
+    }
+    crate::tray::refresh(app);
+    Ok(settings)
+}
+
+#[cfg(target_os = "macos")]
+fn apply_saved_dock_display_mode<R: Runtime>(app: &AppHandle<R>) {
+    let mut settings = load_app_settings().unwrap_or_default();
+    let changed = ensure_menu_bar_entry_for_dock_mode(&mut settings);
+    if changed {
+        if let Err(error) = save_app_settings(&settings) {
+            eprintln!("Failed to save app settings: {error}");
+        }
+    }
+    apply_dock_display_mode(app, settings.dock_display_mode);
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_menu_bar_entry_for_dock_mode(settings: &mut AppSettings) -> bool {
+    if settings.dock_display_mode == DockDisplayMode::MenuBarOnly
+        && settings.tray_display_mode == TrayDisplayMode::Hidden
+    {
+        settings.tray_display_mode = TrayDisplayMode::ActiveUsageText;
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_dock_entry_for_tray_mode(settings: &mut AppSettings) -> bool {
+    if settings.tray_display_mode == TrayDisplayMode::Hidden
+        && settings.dock_display_mode == DockDisplayMode::MenuBarOnly
+    {
+        settings.dock_display_mode = DockDisplayMode::ShowInDock;
+        true
+    } else {
+        false
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn apply_dock_display_mode<R: Runtime>(app: &AppHandle<R>, mode: DockDisplayMode) {
+    let visible = mode == DockDisplayMode::ShowInDock;
+    if let Err(error) = app.set_dock_visibility(visible) {
+        eprintln!("Failed to update Dock visibility: {error}");
+    }
+}
+
+fn build_menu<R: Runtime>(app: &AppHandle<R>, settings: &AppSettings) -> tauri::Result<Menu<R>> {
     let pkg_info = app.package_info();
     let config = app.config();
     let about_metadata = AboutMetadata {
@@ -80,7 +200,7 @@ fn build_menu<R: Runtime>(
                 TRAY_ICON_AND_SESSION_ID,
                 "Icon + Session",
                 true,
-                tray_display_mode == TrayDisplayMode::IconAndSession,
+                settings.tray_display_mode == TrayDisplayMode::IconAndSession,
                 None::<&str>,
             )?,
             &CheckMenuItem::with_id(
@@ -88,7 +208,7 @@ fn build_menu<R: Runtime>(
                 TRAY_ACTIVE_USAGE_TEXT_ID,
                 "Hourly + Weekly",
                 true,
-                tray_display_mode == TrayDisplayMode::ActiveUsageText,
+                settings.tray_display_mode == TrayDisplayMode::ActiveUsageText,
                 None::<&str>,
             )?,
             &CheckMenuItem::with_id(
@@ -96,12 +216,42 @@ fn build_menu<R: Runtime>(
                 TRAY_HIDDEN_ID,
                 "Hidden",
                 true,
-                tray_display_mode == TrayDisplayMode::Hidden,
+                settings.tray_display_mode == TrayDisplayMode::Hidden,
                 None::<&str>,
             )?,
         ],
     )?;
 
+    #[cfg(target_os = "macos")]
+    let dock_settings = Submenu::with_items(
+        app,
+        "Dock Icon",
+        true,
+        &[
+            &CheckMenuItem::with_id(
+                app,
+                DOCK_SHOW_IN_DOCK_ID,
+                "Show in Dock",
+                true,
+                settings.dock_display_mode == DockDisplayMode::ShowInDock,
+                None::<&str>,
+            )?,
+            &CheckMenuItem::with_id(
+                app,
+                DOCK_MENU_BAR_ONLY_ID,
+                "Menu Bar Only",
+                true,
+                settings.dock_display_mode == DockDisplayMode::MenuBarOnly,
+                None::<&str>,
+            )?,
+        ],
+    )?;
+
+    #[cfg(target_os = "macos")]
+    let settings_menu =
+        Submenu::with_items(app, "Settings", true, &[&tray_settings, &dock_settings])?;
+
+    #[cfg(not(target_os = "macos"))]
     let settings_menu = Submenu::with_items(app, "Settings", true, &[&tray_settings])?;
 
     let window_menu = Submenu::with_items(
@@ -182,4 +332,36 @@ fn build_menu<R: Runtime>(
             &help_menu,
         ],
     )
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::{ensure_dock_entry_for_tray_mode, ensure_menu_bar_entry_for_dock_mode};
+    use crate::types::{AppSettings, DockDisplayMode, TrayDisplayMode};
+
+    #[test]
+    fn menu_bar_only_dock_mode_keeps_a_visible_tray_entry() {
+        let mut settings = AppSettings {
+            tray_display_mode: TrayDisplayMode::Hidden,
+            dock_display_mode: DockDisplayMode::MenuBarOnly,
+            ..Default::default()
+        };
+
+        assert!(ensure_menu_bar_entry_for_dock_mode(&mut settings));
+        assert_eq!(settings.tray_display_mode, TrayDisplayMode::ActiveUsageText);
+        assert_eq!(settings.dock_display_mode, DockDisplayMode::MenuBarOnly);
+    }
+
+    #[test]
+    fn hidden_tray_mode_keeps_a_visible_dock_entry() {
+        let mut settings = AppSettings {
+            tray_display_mode: TrayDisplayMode::Hidden,
+            dock_display_mode: DockDisplayMode::MenuBarOnly,
+            ..Default::default()
+        };
+
+        assert!(ensure_dock_entry_for_tray_mode(&mut settings));
+        assert_eq!(settings.tray_display_mode, TrayDisplayMode::Hidden);
+        assert_eq!(settings.dock_display_mode, DockDisplayMode::ShowInDock);
+    }
 }

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -1,11 +1,29 @@
 //! Window and tray popup management commands.
 
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
 use tauri::{AppHandle, Manager, Runtime};
 
-use crate::types::UsageInfo;
+use crate::{
+    auth::{load_app_settings, save_app_settings},
+    types::{DockDisplayMode, UsageInfo},
+};
 
 /// Label of the borderless tray popup window.
 pub const TRAY_WINDOW: &str = "tray";
+pub const CLOSE_BEHAVIOR_REQUESTED_EVENT: &str = "close-behavior-requested";
+
+static CLOSE_BEHAVIOR_PROMPT_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static CLOSE_BEHAVIOR_PROMPT_ACKED: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloseBehaviorRequestedPayload {
+    pub request_id: u64,
+}
 
 /// Receive the main app's polled usage so the tray menu can show remaining quota
 /// without doing its own fetching. The main window is the single usage poller.
@@ -31,6 +49,38 @@ pub fn open_main_window(app: AppHandle) {
     restore_main_window(&app);
 }
 
+pub fn hide_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.hide();
+    }
+    #[cfg(target_os = "macos")]
+    let _ = app.hide();
+}
+
+#[cfg(target_os = "macos")]
+pub fn next_close_behavior_prompt_payload() -> CloseBehaviorRequestedPayload {
+    CloseBehaviorRequestedPayload {
+        request_id: CLOSE_BEHAVIOR_PROMPT_SEQUENCE.fetch_add(1, Ordering::Relaxed) + 1,
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn schedule_close_behavior_prompt_fallback<R: Runtime>(app: AppHandle<R>, request_id: u64) {
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(750));
+        if CLOSE_BEHAVIOR_PROMPT_ACKED.load(Ordering::SeqCst) >= request_id {
+            return;
+        }
+
+        let app_handle = app.clone();
+        if let Err(error) = app.run_on_main_thread(move || {
+            hide_main_window(&app_handle);
+        }) {
+            eprintln!("Failed to schedule close prompt fallback: {error}");
+        }
+    });
+}
+
 /// Bring the main window to the foreground and hide the tray popup.
 pub fn restore_main_window<R: Runtime>(app: &AppHandle<R>) {
     if let Some(tray) = app.get_webview_window(TRAY_WINDOW) {
@@ -47,4 +97,81 @@ pub fn restore_main_window<R: Runtime>(app: &AppHandle<R>) {
 #[tauri::command]
 pub fn quit_app(app: AppHandle) {
     app.exit(0);
+}
+
+#[tauri::command]
+pub fn get_dock_display_mode() -> Option<DockDisplayMode> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(
+            crate::auth::load_app_settings()
+                .unwrap_or_default()
+                .dock_display_mode,
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+#[tauri::command]
+pub fn set_dock_display_mode(
+    app: AppHandle,
+    mode: DockDisplayMode,
+) -> Result<Option<DockDisplayMode>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        crate::app_menu::set_dock_display_mode(&app, mode)
+            .map(|settings| Some(settings.dock_display_mode))
+            .map_err(|error| error.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, mode);
+        Ok(None)
+    }
+}
+
+#[tauri::command]
+pub fn complete_close_behavior(
+    app: AppHandle,
+    mode: DockDisplayMode,
+    dont_ask_again: bool,
+) -> Result<Option<DockDisplayMode>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut settings = crate::app_menu::set_dock_display_mode(&app, mode)
+            .map_err(|error| error.to_string())?;
+        if dont_ask_again {
+            settings.close_behavior_prompt_enabled = false;
+            save_app_settings(&settings).map_err(|error| error.to_string())?;
+        }
+        hide_main_window(&app);
+        Ok(Some(settings.dock_display_mode))
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (mode, dont_ask_again);
+        hide_main_window(&app);
+        Ok(None)
+    }
+}
+
+#[tauri::command]
+pub fn ack_close_behavior_prompt(request_id: u64) {
+    CLOSE_BEHAVIOR_PROMPT_ACKED.fetch_max(request_id, Ordering::SeqCst);
+}
+
+pub fn should_prompt_for_close_behavior() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        load_app_settings()
+            .unwrap_or_default()
+            .close_behavior_prompt_enabled
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,14 +11,16 @@ pub mod types;
 pub mod web;
 
 use commands::{
-    add_account_from_file, cancel_login, check_codex_processes, complete_login, delete_account,
-    export_accounts_full_encrypted_file, export_accounts_slim_text, get_account_usage_stats,
-    get_active_account_info, get_masked_account_ids, get_usage, hide_tray_window,
+    ack_close_behavior_prompt, add_account_from_file, cancel_login, check_codex_processes,
+    complete_close_behavior, complete_login, delete_account, export_accounts_full_encrypted_file,
+    export_accounts_slim_text, get_account_usage_stats, get_active_account_info,
+    get_dock_display_mode, get_masked_account_ids, get_usage, hide_tray_window,
     import_accounts_full_encrypted_file, import_accounts_slim_text, kill_codex_processes,
     list_accounts, open_main_window, quit_app, refresh_account_metadata,
-    refresh_all_accounts_usage, rename_account, report_usage, set_masked_account_ids, start_login,
-    switch_account, warmup_account, warmup_all_accounts,
+    refresh_all_accounts_usage, rename_account, report_usage, set_dock_display_mode,
+    set_masked_account_ids, start_login, switch_account, warmup_account, warmup_all_accounts,
 };
+use tauri::Emitter;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -41,13 +43,19 @@ pub fn run() {
             if window.label() == "main" {
                 if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                     api.prevent_close();
-                    // Order the window out before NSApp.hide so AppKit won't
-                    // restore it on the next activation (e.g. tray popup focus);
-                    // hiding the app deactivates it so a later Dock click is a
-                    // real re-activation and reliably emits RunEvent::Reopen.
-                    let _ = window.hide();
                     #[cfg(target_os = "macos")]
-                    let _ = tauri::Manager::app_handle(window).hide();
+                    if commands::should_prompt_for_close_behavior() {
+                        let payload = commands::window::next_close_behavior_prompt_payload();
+                        let app_handle = tauri::Manager::app_handle(window);
+                        commands::window::schedule_close_behavior_prompt_fallback(
+                            app_handle.clone(),
+                            payload.request_id,
+                        );
+                        let _ =
+                            window.emit(commands::window::CLOSE_BEHAVIOR_REQUESTED_EVENT, payload);
+                        return;
+                    }
+                    commands::hide_main_window(&tauri::Manager::app_handle(window));
                 }
             }
         })
@@ -86,6 +94,10 @@ pub fn run() {
             open_main_window,
             quit_app,
             report_usage,
+            get_dock_display_mode,
+            set_dock_display_mode,
+            complete_close_behavior,
+            ack_close_behavior_prompt,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -3,7 +3,7 @@ use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use tauri::{
-    menu::{CheckMenuItemBuilder, Menu, MenuItemBuilder, PredefinedMenuItem},
+    menu::{CheckMenuItemBuilder, Menu, MenuItemBuilder, PredefinedMenuItem, Submenu},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Emitter, Manager, PhysicalPosition, Runtime, WebviewUrl, WebviewWindowBuilder,
     WindowEvent,
@@ -201,13 +201,45 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>, store: &AccountsStore) -> tauri::R
     }
 
     menu.append(&PredefinedMenuItem::separator(app)?)?;
+    #[cfg(target_os = "macos")]
+    append_dock_settings_menu(app, &menu)?;
+    #[cfg(target_os = "macos")]
+    menu.append(&PredefinedMenuItem::separator(app)?)?;
     menu.append(&MenuItemBuilder::with_id(OPEN_ITEM_ID, "Open Codex Switcher").build(app)?)?;
     menu.append(&MenuItemBuilder::with_id(QUIT_ITEM_ID, "Quit").build(app)?)?;
     Ok(menu)
 }
 
+#[cfg(target_os = "macos")]
+fn append_dock_settings_menu<R: Runtime>(app: &AppHandle<R>, menu: &Menu<R>) -> tauri::Result<()> {
+    let settings = load_app_settings().unwrap_or_default();
+    let dock_settings = Submenu::with_items(
+        app,
+        "Dock Icon",
+        true,
+        &[
+            &CheckMenuItemBuilder::with_id(crate::app_menu::DOCK_SHOW_IN_DOCK_ID, "Show in Dock")
+                .checked(settings.dock_display_mode == crate::app_menu::DockDisplayMode::ShowInDock)
+                .build(app)?,
+            &CheckMenuItemBuilder::with_id(crate::app_menu::DOCK_MENU_BAR_ONLY_ID, "Menu Bar Only")
+                .checked(
+                    settings.dock_display_mode == crate::app_menu::DockDisplayMode::MenuBarOnly,
+                )
+                .build(app)?,
+        ],
+    )?;
+    menu.append(&dock_settings)?;
+    Ok(())
+}
+
 fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
     let item_id = event.id().as_ref();
+
+    #[cfg(target_os = "macos")]
+    if let Some(mode) = crate::app_menu::dock_display_mode_for_item(item_id) {
+        crate::app_menu::update_dock_display_mode(app, mode);
+        return;
+    }
 
     match item_id {
         OPEN_ITEM_ID => show_main_window(app),

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -28,10 +28,35 @@ pub enum TrayDisplayMode {
     Hidden,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DockDisplayMode {
+    #[default]
+    ShowInDock,
+    MenuBarOnly,
+}
+
+fn default_close_behavior_prompt_enabled() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AppSettings {
     pub tray_display_mode: TrayDisplayMode,
+    pub dock_display_mode: DockDisplayMode,
+    #[serde(default = "default_close_behavior_prompt_enabled")]
+    pub close_behavior_prompt_enabled: bool,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            tray_display_mode: TrayDisplayMode::default(),
+            dock_display_mode: DockDisplayMode::default(),
+            close_behavior_prompt_enabled: true,
+        }
+    }
 }
 
 impl Default for AccountsStore {
@@ -383,7 +408,7 @@ pub struct CreditStatusDetails {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_chatgpt_id_token_claims;
+    use super::{parse_chatgpt_id_token_claims, AppSettings, DockDisplayMode, TrayDisplayMode};
     use base64::Engine;
 
     #[test]
@@ -403,5 +428,15 @@ mod tests {
                 .map(|value| value.to_rfc3339()),
             Some("2026-04-23T05:03:38+00:00".to_string())
         );
+    }
+
+    #[test]
+    fn app_settings_default_missing_dock_display_mode_to_show_in_dock() {
+        let settings: AppSettings =
+            serde_json::from_str(r#"{"tray_display_mode":"active_usage_text"}"#).unwrap();
+
+        assert_eq!(settings.tray_display_mode, TrayDisplayMode::ActiveUsageText);
+        assert_eq!(settings.dock_display_mode, DockDisplayMode::ShowInDock);
+        assert!(settings.close_behavior_prompt_enabled);
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAccounts } from "./hooks/useAccounts";
 import { useForceCloseCodexProcesses } from "./hooks/useForceCloseCodexProcesses";
 import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
-import type { AccountWithUsage, CodexProcessInfo, UsageInfo } from "./types";
+import type { AccountWithUsage, CodexProcessInfo, DockDisplayMode, UsageInfo } from "./types";
 import {
   exportFullBackupFile,
   importFullBackupFile,
@@ -39,9 +39,13 @@ const AUTO_WARMUP_FULL_WINDOW_SLACK_MINUTES = 5;
 const DEFAULT_PRIMARY_WINDOW_MINUTES = 300;
 const LIMIT_FULL_THRESHOLD = 99.5;
 const SWITCH_ACCOUNT_BLOCKED_EVENT = "switch-account-blocked";
+const CLOSE_BEHAVIOR_REQUESTED_EVENT = "close-behavior-requested";
 interface SwitchAccountBlockedPayload {
   accountId?: string;
   error?: string;
+}
+interface CloseBehaviorRequestedPayload {
+  requestId?: number;
 }
 type AutoWarmupLedger = Record<
   string,
@@ -228,6 +232,9 @@ function App() {
   const timedWarmupRef = useRef<HTMLDivElement | null>(null);
   const [themeMode, setThemeMode] = useState<ThemeMode>(readStoredTheme);
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
+  const [closeBehaviorPromptOpen, setCloseBehaviorPromptOpen] = useState(false);
+  const [closeBehaviorDontAskAgain, setCloseBehaviorDontAskAgain] = useState(false);
+  const [isCompletingCloseBehavior, setIsCompletingCloseBehavior] = useState(false);
   const accountsRef = useRef(accounts);
   const autoWarmupAccountIdsRef = useRef(autoWarmupAccountIds);
   const autoWarmupLedgerRef = useRef(autoWarmupLedger);
@@ -564,6 +571,7 @@ function App() {
   useEffect(() => {
     let unlisten: (() => void) | undefined;
     let unlistenAutoWarmup: (() => void) | undefined;
+    let unlistenCloseBehavior: (() => void) | undefined;
 
     void (async () => {
       if (!isTauriRuntime()) return;
@@ -609,13 +617,44 @@ function App() {
           }
         }
       );
+      unlistenCloseBehavior = await listen<CloseBehaviorRequestedPayload>(
+        CLOSE_BEHAVIOR_REQUESTED_EVENT,
+        ({ payload }) => {
+          const requestId = payload?.requestId;
+          if (typeof requestId === "number") {
+            void invokeBackend("ack_close_behavior_prompt", { requestId });
+          }
+          setCloseBehaviorDontAskAgain(false);
+          setCloseBehaviorPromptOpen(true);
+        }
+      );
     })();
 
     return () => {
       unlisten?.();
       unlistenAutoWarmup?.();
+      unlistenCloseBehavior?.();
     };
   }, [checkProcesses, formatWarmupError, setForceCloseConfirmOpen, showWarmupToast, switchAccount]);
+
+  const handleCloseBehaviorChoice = useCallback(
+    async (mode: DockDisplayMode) => {
+      try {
+        setIsCompletingCloseBehavior(true);
+        await invokeBackend("complete_close_behavior", {
+          mode,
+          dontAskAgain: closeBehaviorDontAskAgain,
+        });
+        setCloseBehaviorPromptOpen(false);
+      } catch (err) {
+        console.error("Failed to complete close behavior:", err);
+        showWarmupToast(`Close failed: ${formatWarmupError(err)}`, true);
+      } finally {
+        setIsCompletingCloseBehavior(false);
+      }
+    },
+    [closeBehaviorDontAskAgain, formatWarmupError, showWarmupToast]
+  );
 
   const handleForceCloseConfirm = useCallback(async () => {
     const accountId = pendingTraySwitchAccountId;
@@ -1723,6 +1762,58 @@ function App() {
                 {isForceClosingCodex
                   ? "Force closing..."
                   : forceCloseConfirmLabel}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {closeBehaviorPromptOpen && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl w-full max-w-md mx-4 shadow-xl">
+            <div className="p-5 border-b border-gray-100 dark:border-gray-800">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Keep Codex Switcher in the Dock?
+              </h2>
+            </div>
+            <div className="p-5 space-y-4">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                When the window is closed, Codex Switcher can stay in the Dock or live only in the menu bar.
+              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                You can always change this later from the tray popup.
+              </p>
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
+                <input
+                  type="checkbox"
+                  checked={closeBehaviorDontAskAgain}
+                  onChange={(event) => setCloseBehaviorDontAskAgain(event.target.checked)}
+                  className="h-4 w-4 accent-gray-900 dark:accent-gray-100"
+                />
+                <span>Don't ask again</span>
+              </label>
+            </div>
+            <div className="flex flex-col gap-2 p-5 border-t border-gray-100 dark:border-gray-800 sm:flex-row sm:justify-end">
+              <button
+                onClick={() => setCloseBehaviorPromptOpen(false)}
+                disabled={isCompletingCloseBehavior}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => void handleCloseBehaviorChoice("show_in_dock")}
+                disabled={isCompletingCloseBehavior}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors disabled:opacity-50"
+              >
+                Keep in Dock
+              </button>
+              <button
+                onClick={() => void handleCloseBehaviorChoice("menu_bar_only")}
+                disabled={isCompletingCloseBehavior}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 transition-colors disabled:opacity-50"
+              >
+                Menu Bar Only
               </button>
             </div>
           </div>

--- a/src/TrayMenu.tsx
+++ b/src/TrayMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import type { AccountInfo, AccountUsageStats, UsageInfo } from "./types";
+import type { AccountInfo, AccountUsageStats, DockDisplayMode, UsageInfo } from "./types";
 import { invokeBackend, isTauriRuntime } from "./lib/platform";
 import {
   applyTheme,
@@ -113,6 +113,7 @@ function TrayMenu() {
   const [statsById, setStatsById] = useState<Record<string, AccountUsageStats>>({});
   const [refreshing, setRefreshing] = useState(false);
   const [autoWarmupAllEnabled, setAutoWarmupAllEnabled] = useState(readAutoWarmupAllEnabled);
+  const [dockDisplayMode, setDockDisplayMode] = useState<DockDisplayMode | null>(null);
 
   // Fetch each account's rate-limit usage in parallel; rows fill in as they land.
   const loadUsage = useCallback(async (list: AccountInfo[]) => {
@@ -188,8 +189,18 @@ function TrayMenu() {
     }
   }, []);
 
+  const loadDockDisplayMode = useCallback(async () => {
+    try {
+      const mode = await invokeBackend<DockDisplayMode | null>("get_dock_display_mode");
+      setDockDisplayMode(mode);
+    } catch {
+      setDockDisplayMode(null);
+    }
+  }, []);
+
   const load = useCallback(async () => {
     try {
+      void loadDockDisplayMode();
       const list = await invokeBackend<AccountInfo[]>("list_accounts");
       setAccounts(list);
       setUsageById((prev) => retainUsageForAccounts(prev, list));
@@ -201,7 +212,7 @@ function TrayMenu() {
     } finally {
       setLoading(false);
     }
-  }, [loadActiveStats, loadUsage]);
+  }, [loadActiveStats, loadDockDisplayMode, loadUsage]);
 
   // Manual refresh: re-pull accounts and actively fetch fresh usage once.
   const handleRefresh = useCallback(async () => {
@@ -233,6 +244,23 @@ function TrayMenu() {
       setError(formatError(err));
     }
   }, [autoWarmupAllEnabled]);
+
+  const handleDockDisplayMode = useCallback(
+    async (mode: DockDisplayMode) => {
+      const previous = dockDisplayMode;
+      setDockDisplayMode(mode);
+      try {
+        const next = await invokeBackend<DockDisplayMode | null>("set_dock_display_mode", {
+          mode,
+        });
+        setDockDisplayMode(next);
+      } catch (err) {
+        setDockDisplayMode(previous);
+        setError(formatError(err));
+      }
+    },
+    [dockDisplayMode]
+  );
 
   // Reload when the tray is reopened or accounts change elsewhere.
   useEffect(() => {
@@ -485,6 +513,34 @@ function TrayMenu() {
       {error && (
         <div className="border-t border-gray-100 px-3 py-2 text-xs text-red-600 dark:border-gray-800 dark:text-red-400">
           {error}
+        </div>
+      )}
+
+      {dockDisplayMode && (
+        <div className="flex items-center gap-1 border-t border-gray-100 px-1.5 py-1.5 dark:border-gray-800">
+          <span className="px-1.5 text-[11px] font-medium text-gray-500 dark:text-gray-400">
+            Dock
+          </span>
+          <button
+            onClick={() => void handleDockDisplayMode("show_in_dock")}
+            className={`rounded-md px-2 py-1 text-[11px] font-semibold transition-colors ${
+              dockDisplayMode === "show_in_dock"
+                ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            }`}
+          >
+            Show
+          </button>
+          <button
+            onClick={() => void handleDockDisplayMode("menu_bar_only")}
+            className={`rounded-md px-2 py-1 text-[11px] font-semibold transition-colors ${
+              dockDisplayMode === "menu_bar_only"
+                ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+            }`}
+          >
+            Menu Bar
+          </button>
         </div>
       )}
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 // Types matching the Rust backend
 
 export type AuthMode = "api_key" | "chat_g_p_t";
+export type DockDisplayMode = "show_in_dock" | "menu_bar_only";
 
 export interface AccountInfo {
   id: string;


### PR DESCRIPTION
## Summary
- Add a macOS-only Dock display preference so Codex Switcher can either stay visible in the Dock or run as a menu-bar-only app.
- Add a first-close prompt with Keep in Dock, Menu Bar Only, Cancel, and Don't ask again options.
- Add Dock Icon controls to the macOS app menu, native tray menu, and tray popup so users can recover even when menu-bar-only mode hides the normal macOS app menu.

## Why
macOS users expect menu-bar-capable apps to offer a clear choice between Dock visibility and menu-bar-only behavior. The app previously hid the main window on close without a dedicated preference flow, and a frontend-only close prompt could be missed during startup, reload, or transient webview issues. That could leave the close request prevented with no visible fallback.

## Implementation details
- Persist DockDisplayMode and close_behavior_prompt_enabled in AppSettings, with backwards-compatible defaults for existing settings files.
- Add macOS-only commands for reading and updating Dock display mode, completing close behavior, and acknowledging close-prompt delivery.
- Route close requests through a tokenized close-behavior-requested event. The frontend acknowledges receipt before showing the modal. If no ack arrives within 750 ms, the backend falls back to hiding the main window.
- Keep Dock and tray states safe: switching to Menu Bar Only forces a visible tray item, and hiding the tray while menu-bar-only is active restores Dock visibility.
- Keep non-macOS behavior untouched by gating Dock-specific behavior behind macOS cfg blocks.

## Validation
- npm run build
- cargo test --manifest-path src-tauri/Cargo.toml
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- git diff --check