### PR TITLE
Fix weekly-only rate limit handling

### DIFF
--- a/src-tauri/src/api/usage.rs
+++ b/src-tauri/src/api/usage.rs
@@ -23,6 +23,8 @@ const CHATGPT_ACCOUNTS_CHECK_API: &str =
 const CHATGPT_CODEX_RESPONSES_API: &str = "https://chatgpt.com/backend-api/codex/responses";
 const OPENAI_API: &str = "https://api.openai.com/v1";
 const CODEX_USER_AGENT: &str = "codex-cli/1.0.0";
+const SESSION_WINDOW_SECONDS: i32 = 5 * 60 * 60;
+const WEEKLY_WINDOW_SECONDS: i32 = 7 * 24 * 60 * 60;
 
 #[derive(Debug, Clone)]
 pub struct ChatGptAccountMetadata {
@@ -479,10 +481,31 @@ fn convert_payload_to_usage_info(account_id: &str, payload: RateLimitStatusPaylo
 fn extract_rate_limits(
     rate_limit: Option<RateLimitDetails>,
 ) -> (Option<RateLimitWindow>, Option<RateLimitWindow>) {
-    match rate_limit {
-        Some(details) => (details.primary_window, details.secondary_window),
-        None => (None, None),
+    let Some(details) = rate_limit else {
+        return (None, None);
+    };
+
+    match (details.primary_window, details.secondary_window) {
+        // The backend can temporarily omit the 5-hour window and promote the
+        // weekly window into primary_window. Keep UsageInfo semantic so every
+        // consumer still treats primary as session and secondary as weekly.
+        (Some(primary), None) if is_weekly_window(&primary) => (None, Some(primary)),
+        (None, Some(secondary)) if is_session_window(&secondary) => (Some(secondary), None),
+        (Some(primary), Some(secondary))
+            if is_weekly_window(&primary) && is_session_window(&secondary) =>
+        {
+            (Some(secondary), Some(primary))
+        }
+        (primary, secondary) => (primary, secondary),
     }
+}
+
+fn is_session_window(window: &RateLimitWindow) -> bool {
+    window.limit_window_seconds == Some(SESSION_WINDOW_SECONDS)
+}
+
+fn is_weekly_window(window: &RateLimitWindow) -> bool {
+    window.limit_window_seconds == Some(WEEKLY_WINDOW_SECONDS)
 }
 
 fn extract_credits(credits: Option<CreditStatusDetails>) -> Option<CreditStatusDetails> {
@@ -510,4 +533,67 @@ pub async fn refresh_all_usage(accounts: &[StoredAccount]) -> Vec<UsageInfo> {
 
     println!("[Usage] Refresh complete");
     results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rate_limit_window(used_percent: f64, window_seconds: i32) -> RateLimitWindow {
+        RateLimitWindow {
+            used_percent,
+            limit_window_seconds: Some(window_seconds),
+            reset_at: Some(1_800_000_000),
+        }
+    }
+
+    #[test]
+    fn keeps_legacy_session_and_weekly_windows_in_place() {
+        let (session, weekly) = extract_rate_limits(Some(RateLimitDetails {
+            primary_window: Some(rate_limit_window(27.0, SESSION_WINDOW_SECONDS)),
+            secondary_window: Some(rate_limit_window(82.0, WEEKLY_WINDOW_SECONDS)),
+        }));
+
+        assert_eq!(
+            session.and_then(|window| window.limit_window_seconds),
+            Some(SESSION_WINDOW_SECONDS)
+        );
+        assert_eq!(
+            weekly.and_then(|window| window.limit_window_seconds),
+            Some(WEEKLY_WINDOW_SECONDS)
+        );
+    }
+
+    #[test]
+    fn moves_weekly_only_primary_window_to_weekly_slot() {
+        let (session, weekly) = extract_rate_limits(Some(RateLimitDetails {
+            primary_window: Some(rate_limit_window(35.0, WEEKLY_WINDOW_SECONDS)),
+            secondary_window: None,
+        }));
+
+        assert!(session.is_none());
+        assert_eq!(weekly.map(|window| window.used_percent), Some(35.0));
+    }
+
+    #[test]
+    fn restores_semantic_order_if_backend_reverses_windows() {
+        let (session, weekly) = extract_rate_limits(Some(RateLimitDetails {
+            primary_window: Some(rate_limit_window(82.0, WEEKLY_WINDOW_SECONDS)),
+            secondary_window: Some(rate_limit_window(27.0, SESSION_WINDOW_SECONDS)),
+        }));
+
+        assert_eq!(session.map(|window| window.used_percent), Some(27.0));
+        assert_eq!(weekly.map(|window| window.used_percent), Some(82.0));
+    }
+
+    #[test]
+    fn preserves_unknown_windows_by_backend_position() {
+        let (primary, secondary) = extract_rate_limits(Some(RateLimitDetails {
+            primary_window: Some(rate_limit_window(11.0, 60 * 60)),
+            secondary_window: Some(rate_limit_window(22.0, 30 * 24 * 60 * 60)),
+        }));
+
+        assert_eq!(primary.map(|window| window.used_percent), Some(11.0));
+        assert_eq!(secondary.map(|window| window.used_percent), Some(22.0));
+    }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -378,7 +378,10 @@ fn active_session_title(active_account_id: Option<&str>) -> Option<String> {
     let active_account_id = active_account_id?;
     let cache = TRAY_USAGE.lock().ok()?;
     let usage = cache.get(active_account_id)?;
-    session_remaining_title(usage.primary_used_percent, usage.error.is_some())
+    session_remaining_title(
+        usage.primary_used_percent.or(usage.secondary_used_percent),
+        usage.error.is_some(),
+    )
 }
 
 fn active_tray_title(active_account_id: Option<&str>, mode: TrayDisplayMode) -> Option<String> {
@@ -399,19 +402,28 @@ fn active_usage_title(active_account_id: Option<&str>) -> String {
         .ok()
         .and_then(|cache| cache.get(active_account_id).cloned());
 
-    let (primary, secondary) = match usage {
-        Some(usage) if usage.error.is_none() => (
-            remaining_percent_label(usage.primary_used_percent),
-            remaining_percent_label(usage.secondary_used_percent),
-        ),
-        _ => (None, None),
-    };
+    match usage {
+        Some(usage) if usage.error.is_none() => {
+            usage_title(usage.primary_used_percent, usage.secondary_used_percent)
+        }
+        _ => "H:-- W:--".to_string(),
+    }
+}
 
-    format!(
-        "H:{} W:{}",
-        primary.as_deref().unwrap_or("--"),
-        secondary.as_deref().unwrap_or("--")
-    )
+fn usage_title(primary_used_percent: Option<f64>, secondary_used_percent: Option<f64>) -> String {
+    let mut parts = Vec::new();
+    if let Some(remaining) = remaining_percent_label(primary_used_percent) {
+        parts.push(format!("H:{remaining}"));
+    }
+    if let Some(remaining) = remaining_percent_label(secondary_used_percent) {
+        parts.push(format!("W:{remaining}"));
+    }
+
+    if parts.is_empty() {
+        "H:-- W:--".to_string()
+    } else {
+        parts.join(" ")
+    }
 }
 
 fn session_remaining_title(used_percent: Option<f64>, has_error: bool) -> Option<String> {
@@ -588,6 +600,14 @@ mod tests {
             session_remaining_title(Some(105.0), false),
             Some("0%".to_string())
         );
+    }
+
+    #[test]
+    fn usage_title_omits_missing_windows() {
+        assert_eq!(usage_title(Some(27.0), Some(82.0)), "H:73% W:18%");
+        assert_eq!(usage_title(None, Some(35.0)), "W:65%");
+        assert_eq!(usage_title(Some(27.0), None), "H:73%");
+        assert_eq!(usage_title(None, None), "H:-- W:--");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,6 +113,14 @@ function isLimitFull(usedPercent: number | null | undefined): boolean {
   return usedPercent !== null && usedPercent !== undefined && usedPercent >= LIMIT_FULL_THRESHOLD;
 }
 
+function getPreferredUsedPercent(usage: UsageInfo | undefined): number | null | undefined {
+  return usage?.primary_used_percent ?? usage?.secondary_used_percent;
+}
+
+function getPreferredResetsAt(usage: UsageInfo | undefined): number | null | undefined {
+  return usage?.primary_resets_at ?? usage?.secondary_resets_at;
+}
+
 function getTimedWarmupTargets(accounts: AccountWithUsage[]): AccountWithUsage[] {
   return accounts.filter(
     (account) =>
@@ -1167,13 +1175,13 @@ function App() {
         if (subscriptionDiff !== 0) return subscriptionDiff;
 
         const deadlineDiff =
-          getResetDeadline(a.usage?.primary_resets_at) -
-          getResetDeadline(b.usage?.primary_resets_at);
+          getResetDeadline(getPreferredResetsAt(a.usage)) -
+          getResetDeadline(getPreferredResetsAt(b.usage));
         if (deadlineDiff !== 0) return deadlineDiff;
 
         const remainingDiff =
-          getRemainingPercent(b.usage?.primary_used_percent) -
-          getRemainingPercent(a.usage?.primary_used_percent);
+          getRemainingPercent(getPreferredUsedPercent(b.usage)) -
+          getRemainingPercent(getPreferredUsedPercent(a.usage));
         if (remainingDiff !== 0) return remainingDiff;
 
         return a.name.localeCompare(b.name);
@@ -1181,21 +1189,21 @@ function App() {
 
       if (otherAccountsSort === "deadline_asc" || otherAccountsSort === "deadline_desc") {
         const deadlineDiff =
-          getResetDeadline(a.usage?.primary_resets_at) -
-          getResetDeadline(b.usage?.primary_resets_at);
+          getResetDeadline(getPreferredResetsAt(a.usage)) -
+          getResetDeadline(getPreferredResetsAt(b.usage));
         if (deadlineDiff !== 0) {
           return otherAccountsSort === "deadline_asc" ? deadlineDiff : -deadlineDiff;
         }
         const remainingDiff =
-          getRemainingPercent(b.usage?.primary_used_percent) -
-          getRemainingPercent(a.usage?.primary_used_percent);
+          getRemainingPercent(getPreferredUsedPercent(b.usage)) -
+          getRemainingPercent(getPreferredUsedPercent(a.usage));
         if (remainingDiff !== 0) return remainingDiff;
         return a.name.localeCompare(b.name);
       }
 
       const remainingDiff =
-        getRemainingPercent(b.usage?.primary_used_percent) -
-        getRemainingPercent(a.usage?.primary_used_percent);
+        getRemainingPercent(getPreferredUsedPercent(b.usage)) -
+        getRemainingPercent(getPreferredUsedPercent(a.usage));
       if (otherAccountsSort === "remaining_desc" && remainingDiff !== 0) {
         return remainingDiff;
       }
@@ -1203,8 +1211,8 @@ function App() {
         return -remainingDiff;
       }
       const deadlineDiff =
-        getResetDeadline(a.usage?.primary_resets_at) -
-        getResetDeadline(b.usage?.primary_resets_at);
+        getResetDeadline(getPreferredResetsAt(a.usage)) -
+        getResetDeadline(getPreferredResetsAt(b.usage));
       if (deadlineDiff !== 0) return deadlineDiff;
       return a.name.localeCompare(b.name);
     });


### PR DESCRIPTION
## Summary
- normalize rate-limit windows by duration when only the weekly window is returned
- preserve the existing 5-hour and weekly behavior when both windows are available
- keep shared desktop UI sorting and native tray labels correct across platforms

## Testing
- `pnpm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`