### PR TITLE
Adapt auto warm-up to weekly-only limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,15 @@ Dock mode.
 
 ## Warm-Up
 
-A warm-up sends one minimal request to an account so its current 5-hour usage
-window starts counting — handy for activating a window before you need it.
+A warm-up sends one minimal request to an account so its current usage window
+has activity before you need it.
 
 - **Manual** – warm up a single or all accounts, from the main window or tray menu.
-- **Automatic** – when enabled (per account or for all), the app warms an
-  account each time its 5-hour window resets, as long as the weekly limit isn't
-  exhausted.
+- **Automatic** – when enabled (per account or for all), the app tracks the
+  5-hour window when available and warms it after each reset, as long as the
+  weekly limit isn't exhausted. If only the weekly window is available, it
+  warms once after the weekly reset and automatically returns to the 5-hour
+  schedule if that window reappears.
 - **Timed** – pick specific times of day (e.g. `08:00`, `13:00`, `18:00`) from
   the **Timed** control in the main window. At each time the app warms all
   accounts (skipping any whose weekly limit is exhausted), so you control when

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,13 +30,17 @@ import {
   writeTimedWarmupEnabled,
   writeTimedWarmupTimes,
 } from "./lib/autoWarmup";
+import {
+  getAutoWarmupWindowKey,
+  getAutoWarmupWindowKind,
+  getDueAutoWarmupWindow,
+  type AutoWarmupWindow,
+  type AutoWarmupWindowKind,
+} from "./lib/autoWarmupPolicy";
 import "./App.css";
 
 const AUTO_WARMUP_CHECK_INTERVAL_MS = 30 * 1000;
-const AUTO_WARMUP_RETRY_BACKOFF_MS = 5 * 60 * 1000;
-const AUTO_WARMUP_MIN_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
-const AUTO_WARMUP_FULL_WINDOW_SLACK_MINUTES = 5;
-const DEFAULT_PRIMARY_WINDOW_MINUTES = 300;
+const AUTO_WARMUP_RETRY_BACKOFF_MS = 60 * 1000;
 const LIMIT_FULL_THRESHOLD = 99.5;
 const SWITCH_ACCOUNT_BLOCKED_EVENT = "switch-account-blocked";
 const CLOSE_BEHAVIOR_REQUESTED_EVENT = "close-behavior-requested";
@@ -51,6 +55,8 @@ type AutoWarmupLedger = Record<
   string,
   {
     lastSuccessfulWarmupAt?: number;
+    lastAutoWindowKey?: string;
+    lastAutoWindowKind?: AutoWarmupWindowKind;
   }
 >;
 const appWindow = getCurrentWindow();
@@ -74,20 +80,30 @@ function readStoredAutoWarmupLedger(): AutoWarmupLedger {
     const parsed = JSON.parse(window.localStorage.getItem(AUTO_WARMUP_LEDGER_STORAGE_KEY) ?? "{}");
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
 
-    return Object.fromEntries(
-      Object.entries(parsed)
-        .map(([accountId, value]) => {
-          const timestamp =
-            value &&
-            typeof value === "object" &&
-            "lastSuccessfulWarmupAt" in value &&
-            typeof value.lastSuccessfulWarmupAt === "number"
-              ? value.lastSuccessfulWarmupAt
-              : undefined;
-          return timestamp ? [accountId, { lastSuccessfulWarmupAt: timestamp }] : null;
-        })
-        .filter((entry): entry is [string, { lastSuccessfulWarmupAt: number }] => Boolean(entry))
-    );
+    const entries: Array<[string, AutoWarmupLedger[string]]> = [];
+    for (const [accountId, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+
+      const entry: AutoWarmupLedger[string] = {};
+      if (
+        "lastSuccessfulWarmupAt" in value &&
+        typeof value.lastSuccessfulWarmupAt === "number"
+      ) {
+        entry.lastSuccessfulWarmupAt = value.lastSuccessfulWarmupAt;
+      }
+      if ("lastAutoWindowKey" in value && typeof value.lastAutoWindowKey === "string") {
+        entry.lastAutoWindowKey = value.lastAutoWindowKey;
+      }
+      if (
+        "lastAutoWindowKind" in value &&
+        (value.lastAutoWindowKind === "session" || value.lastAutoWindowKind === "weekly")
+      ) {
+        entry.lastAutoWindowKind = value.lastAutoWindowKind;
+      }
+
+      if (Object.keys(entry).length > 0) entries.push([accountId, entry]);
+    }
+    return Object.fromEntries(entries);
   } catch {
     return {};
   }
@@ -129,33 +145,6 @@ function getTimedWarmupTargets(accounts: AccountWithUsage[]): AccountWithUsage[]
       !account.usage.error &&
       !isLimitFull(account.usage.secondary_used_percent)
   );
-}
-
-function getPrimaryWindowMinutes(usage: UsageInfo): number {
-  return usage.primary_window_minutes ?? DEFAULT_PRIMARY_WINDOW_MINUTES;
-}
-
-function getPrimaryRemainingMs(usage: UsageInfo): number | null {
-  if (!usage.primary_resets_at) return null;
-  return usage.primary_resets_at * 1000 - Date.now();
-}
-
-function isPrimaryFullWindow(usage: UsageInfo): boolean {
-  const remainingMs = getPrimaryRemainingMs(usage);
-  if (remainingMs === null) return false;
-
-  const thresholdMinutes = Math.max(
-    0,
-    getPrimaryWindowMinutes(usage) - AUTO_WARMUP_FULL_WINDOW_SLACK_MINUTES
-  );
-  return remainingMs >= thresholdMinutes * 60 * 1000;
-}
-
-function getLastSuccessfulWarmupAt(
-  ledger: AutoWarmupLedger,
-  accountId: string
-): number | undefined {
-  return ledger[accountId]?.lastSuccessfulWarmupAt;
 }
 
 function App() {
@@ -557,12 +546,24 @@ function App() {
     }
   }, []);
 
-  const markSuccessfulWarmup = useCallback((accountId: string, timestamp = Date.now()) => {
-    setAutoWarmupLedger((prev) => ({
-      ...prev,
-      [accountId]: { lastSuccessfulWarmupAt: timestamp },
-    }));
-  }, []);
+  const markSuccessfulWarmup = useCallback(
+    (accountId: string, timestamp = Date.now(), window?: AutoWarmupWindow) => {
+      delete autoWarmupRetryAfterRef.current[accountId];
+      setAutoWarmupLedger((prev) => ({
+        ...prev,
+        [accountId]: {
+          lastSuccessfulWarmupAt: timestamp,
+          ...(window
+            ? {
+                lastAutoWindowKey: getAutoWarmupWindowKey(window),
+                lastAutoWindowKind: window.kind,
+              }
+            : {}),
+        },
+      }));
+    },
+    []
+  );
 
   const {
     forceCloseConfirmOpen,
@@ -766,24 +767,9 @@ function App() {
     });
   };
 
-  const isAutoWarmupDue = useCallback(
+  const getDueAutoWarmupForAccount = useCallback(
     (accountId: string, usage: UsageInfo | undefined) => {
-      if (!usage || usage.error || !usage.primary_resets_at) return false;
-      if (isLimitFull(usage.secondary_used_percent)) return false;
-      if (!isPrimaryFullWindow(usage)) return false;
-
-      const lastSuccessfulWarmupAt = getLastSuccessfulWarmupAt(
-        autoWarmupLedgerRef.current,
-        accountId
-      );
-      if (
-        lastSuccessfulWarmupAt &&
-        Date.now() - lastSuccessfulWarmupAt < AUTO_WARMUP_MIN_SUCCESS_INTERVAL_MS
-      ) {
-        return false;
-      }
-
-      return true;
+      return getDueAutoWarmupWindow(usage, autoWarmupLedgerRef.current[accountId]);
     },
     []
   );
@@ -796,11 +782,14 @@ function App() {
     ) => {
       if (isRunning) return "Warming...";
       if (!isEnabled) return "Auto: off";
-      if (!usage || usage.error || !usage.primary_resets_at) return "Auto: on";
+      if (!usage || usage.error) return "Auto: on";
 
-      if (isLimitFull(usage.secondary_used_percent)) {
+      const windowKind = getAutoWarmupWindowKind(usage);
+      if (windowKind === "session" && isLimitFull(usage.secondary_used_percent)) {
         return "Waiting weekly reset";
       }
+      if (windowKind === "session") return "Auto: 5h";
+      if (windowKind === "weekly") return "Auto: weekly";
 
       return "Auto: on";
     },
@@ -845,17 +834,13 @@ function App() {
           return;
         }
 
-        if (freshUsage.error || !freshUsage.primary_resets_at) {
-          backOffAutoWarmupRetry(accountId);
-          return;
-        }
-        if (!isAutoWarmupDue(accountId, freshUsage)) {
-          return;
-        }
+        const window = getDueAutoWarmupForAccount(accountId, freshUsage);
+        if (!window) return;
 
         await warmupAccount(accountId);
-        markSuccessfulWarmup(accountId);
-        showWarmupToast(`Auto warm-up sent for ${accountName}`);
+        markSuccessfulWarmup(accountId, Date.now(), window);
+        const modeLabel = window.kind === "session" ? "5h" : "weekly";
+        showWarmupToast(`Auto ${modeLabel} warm-up sent for ${accountName}`);
       } catch (err) {
         console.error("Auto warm-up failed:", err);
         backOffAutoWarmupRetry(accountId);
@@ -874,7 +859,7 @@ function App() {
     [
       backOffAutoWarmupRetry,
       formatWarmupError,
-      isAutoWarmupDue,
+      getDueAutoWarmupForAccount,
       markSuccessfulWarmup,
       refreshSingleUsage,
       showWarmupToast,
@@ -894,7 +879,7 @@ function App() {
         const retryAfter = autoWarmupRetryAfterRef.current[account.id];
         if (retryAfter && Date.now() < retryAfter) continue;
 
-        if (!isAutoWarmupDue(account.id, account.usage)) continue;
+        if (!getDueAutoWarmupForAccount(account.id, account.usage)) continue;
 
         void runAutoWarmupForAccount(account.id, account.name);
       }
@@ -910,7 +895,7 @@ function App() {
   }, [
     autoWarmupAccountIds.size,
     autoWarmupAllEnabled,
-    isAutoWarmupDue,
+    getDueAutoWarmupForAccount,
     runAutoWarmupForAccount,
   ]);
 

--- a/src/lib/autoWarmupPolicy.ts
+++ b/src/lib/autoWarmupPolicy.ts
@@ -1,0 +1,121 @@
+import type { UsageInfo } from "../types";
+
+const DEFAULT_SESSION_WINDOW_MINUTES = 5 * 60;
+const DEFAULT_WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
+const FULL_WINDOW_SLACK_MINUTES = 5;
+const LIMIT_FULL_THRESHOLD = 99.5;
+const MIN_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
+
+export type AutoWarmupWindowKind = "session" | "weekly";
+
+export interface AutoWarmupWindow {
+  kind: AutoWarmupWindowKind;
+  windowMinutes: number;
+  resetsAt: number;
+}
+
+export interface AutoWarmupHistory {
+  lastSuccessfulWarmupAt?: number;
+  lastAutoWindowKey?: string;
+  lastAutoWindowKind?: AutoWarmupWindowKind;
+}
+
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+function hasPrimaryWindow(usage: UsageInfo): boolean {
+  return (
+    isPresent(usage.primary_used_percent) ||
+    isPresent(usage.primary_window_minutes) ||
+    isPresent(usage.primary_resets_at)
+  );
+}
+
+function hasSecondaryWindow(usage: UsageInfo): boolean {
+  return (
+    isPresent(usage.secondary_used_percent) ||
+    isPresent(usage.secondary_window_minutes) ||
+    isPresent(usage.secondary_resets_at)
+  );
+}
+
+export function getAutoWarmupWindowKind(
+  usage: UsageInfo | undefined
+): AutoWarmupWindowKind | null {
+  if (!usage || usage.error) return null;
+  if (hasPrimaryWindow(usage)) return "session";
+  if (hasSecondaryWindow(usage)) return "weekly";
+  return null;
+}
+
+export function getAutoWarmupWindow(
+  usage: UsageInfo | undefined
+): AutoWarmupWindow | null {
+  const kind = getAutoWarmupWindowKind(usage);
+  if (!usage || !kind) return null;
+
+  if (kind === "session") {
+    if (!isPresent(usage.primary_resets_at)) return null;
+    return {
+      kind,
+      windowMinutes: usage.primary_window_minutes ?? DEFAULT_SESSION_WINDOW_MINUTES,
+      resetsAt: usage.primary_resets_at,
+    };
+  }
+
+  if (!isPresent(usage.secondary_resets_at)) return null;
+  return {
+    kind,
+    windowMinutes: usage.secondary_window_minutes ?? DEFAULT_WEEKLY_WINDOW_MINUTES,
+    resetsAt: usage.secondary_resets_at,
+  };
+}
+
+export function getAutoWarmupWindowKey(window: AutoWarmupWindow): string {
+  return `${window.kind}:${window.windowMinutes}:${window.resetsAt}`;
+}
+
+export function isAutoWarmupWindowFresh(
+  window: AutoWarmupWindow,
+  nowMs = Date.now()
+): boolean {
+  if (!Number.isFinite(window.windowMinutes) || window.windowMinutes <= 0) return false;
+  if (!Number.isFinite(window.resetsAt) || window.resetsAt <= 0) return false;
+
+  const remainingMs = window.resetsAt * 1000 - nowMs;
+  const thresholdMinutes = Math.max(0, window.windowMinutes - FULL_WINDOW_SLACK_MINUTES);
+  return remainingMs >= thresholdMinutes * 60 * 1000;
+}
+
+export function getDueAutoWarmupWindow(
+  usage: UsageInfo | undefined,
+  history: AutoWarmupHistory | undefined,
+  nowMs = Date.now()
+): AutoWarmupWindow | null {
+  const window = getAutoWarmupWindow(usage);
+  if (!window) return null;
+  const weeklyUsedPercent = usage?.secondary_used_percent;
+  if (
+    window.kind === "session" &&
+    isPresent(weeklyUsedPercent) &&
+    weeklyUsedPercent >= LIMIT_FULL_THRESHOLD
+  ) {
+    return null;
+  }
+  if (!isAutoWarmupWindowFresh(window, nowMs)) return null;
+
+  const windowKey = getAutoWarmupWindowKey(window);
+  if (history?.lastAutoWindowKey === windowKey) return null;
+
+  const lastSuccessfulWarmupAt = history?.lastSuccessfulWarmupAt;
+  if (
+    lastSuccessfulWarmupAt &&
+    nowMs - lastSuccessfulWarmupAt < MIN_SUCCESS_INTERVAL_MS &&
+    (!history.lastAutoWindowKind || history.lastAutoWindowKind === window.kind)
+  ) {
+    return null;
+  }
+
+  return window;
+}


### PR DESCRIPTION
## Summary
- keep the existing 5-hour auto warm-up behavior whenever that window is available
- fall back to one warm-up after a fresh weekly reset when only the weekly window exists
- switch modes automatically per account and persist window identity to prevent duplicate requests
- show the selected mode on account cards and retry transient failures within the existing five-minute reset window
- document the adaptive behavior

## Testing
- exercised dual-window, weekly-only, mode-switch, full-weekly, duplicate-window, legacy-ledger, error, missing-reset, default-duration, and reset-boundary policy scenarios
- `pnpm run build`
- `cargo test --manifest-path src-tauri/Cargo.toml` (28 passed)
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`

## Runtime note
The scheduling and compatibility paths are covered locally. The effect of the warm-up request on a real weekly reset will be observed at the next available account reset.