### PR TITLE
Show reset credit expiry details

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test:reset-credits": "node --experimental-strip-types --test tests/resetCredits.test.ts",
     "preview": "vite preview",
     "tauri": "sh ./scripts/tauri.sh",
     "tauri:win": "tauri",

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState, useRef, useEffect } from "react";
 import type { AccountResetCredits, AccountUsageStats as AccountUsageStatsInfo, AccountWithUsage } from "../types";
 import { invokeBackend } from "../lib/platform";
 import { AccountUsageStats } from "./AccountUsageStats";
+import { ResetCreditsMenu } from "./ResetCreditsMenu";
 import { UsageBar } from "./UsageBar";
 
 const RESET_CREDITS_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
@@ -79,69 +80,6 @@ function getSubscriptionStatus(timestamp: string | null | undefined): {
     label: `Until ${formattedDate}`,
     className: "text-gray-400 dark:text-gray-500",
   };
-}
-
-function formatResetCreditsCount(resetCredits: AccountResetCredits | null): string | null {
-  if (!resetCredits) return null;
-  const count = resetCredits.available_count;
-  if (count <= 0) return null;
-  return count === 1 ? "1 reset" : `${count} resets`;
-}
-
-function formatResetCreditsExpiry(
-  resetCredits: AccountResetCredits | null,
-  compact = false,
-): string | null {
-  if (!resetCredits?.next_expires_at) return null;
-
-  const expiry = new Date(resetCredits.next_expires_at);
-  if (Number.isNaN(expiry.getTime())) return null;
-
-  const formattedDate = new Intl.DateTimeFormat(undefined, {
-    month: "short",
-    day: "numeric",
-    ...(compact ? {} : { year: "numeric" }),
-  }).format(expiry);
-
-  return compact ? `closest ${formattedDate}` : `closest expires ${formattedDate}`;
-}
-
-function getResetCreditsTone(resetCredits: AccountResetCredits | null): {
-  container: string;
-  badge: string;
-  text: string;
-} {
-  const fallback = {
-    container: "border-sky-200 bg-sky-50/70 dark:border-sky-800 dark:bg-sky-950/30",
-    badge: "border-sky-200 bg-sky-100 text-sky-700 dark:border-sky-700 dark:bg-sky-900/50 dark:text-sky-300",
-    text: "text-sky-700/80 dark:text-sky-300/80",
-  };
-
-  if (!resetCredits?.next_expires_at) return fallback;
-
-  const expiry = new Date(resetCredits.next_expires_at);
-  if (Number.isNaN(expiry.getTime())) return fallback;
-
-  const remainingMs = expiry.getTime() - Date.now();
-  const dayMs = 24 * 60 * 60 * 1000;
-
-  if (remainingMs <= 3 * dayMs) {
-    return {
-      container: "border-red-200 bg-red-50/70 dark:border-red-800 dark:bg-red-950/30",
-      badge: "border-red-200 bg-red-100 text-red-700 dark:border-red-700 dark:bg-red-900/50 dark:text-red-300",
-      text: "text-red-700/80 dark:text-red-300/80",
-    };
-  }
-
-  if (remainingMs <= 10 * dayMs) {
-    return {
-      container: "border-amber-200 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/30",
-      badge: "border-amber-200 bg-amber-100 text-amber-700 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-300",
-      text: "text-amber-700/80 dark:text-amber-300/80",
-    };
-  }
-
-  return fallback;
 }
 
 function BlurredText({ children, blur }: { children: React.ReactNode; blur: boolean }) {
@@ -241,10 +179,7 @@ export function AccountCard({
   const planColorClass = planColors[planKey] || planColors.free;
   const showSubscriptionStatus = account.auth_mode === "chat_g_p_t";
   const subscriptionStatus = getSubscriptionStatus(account.subscription_expires_at);
-  const resetCreditsCount = formatResetCreditsCount(resetCredits);
   const compactResetCredits = !account.is_active;
-  const resetCreditsExpiry = formatResetCreditsExpiry(resetCredits, compactResetCredits);
-  const resetCreditsTone = getResetCreditsTone(resetCredits);
 
   const loadResetCredits = useCallback(async () => {
     const requestId = ++resetRequestSeq.current;
@@ -363,35 +298,10 @@ export function AccountCard({
           >
             {planDisplay}
           </span>
-          {resetCreditsCount && compactResetCredits && (
-            <div
-              className={`flex min-w-0 max-w-full items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] leading-none ${resetCreditsTone.container} ${resetCreditsTone.text}`}
-              title={[resetCreditsCount, resetCreditsExpiry].filter(Boolean).join(" · ")}
-            >
-              <span className="shrink-0 whitespace-nowrap font-semibold">
-                {resetCreditsCount}
-              </span>
-              {resetCreditsExpiry && (
-                <span className="truncate">
-                  · {resetCreditsExpiry}
-                </span>
-              )}
-            </div>
-          )}
-          {resetCreditsCount && !compactResetCredits && (
-            <div
-              className={`flex max-w-full items-center gap-2 rounded-lg border px-2 py-1.5 text-xs ${resetCreditsTone.container}`}
-            >
-              <span className={`whitespace-nowrap rounded-full border px-2.5 py-0.5 font-medium ${resetCreditsTone.badge}`}>
-                {resetCreditsCount}
-              </span>
-              {resetCreditsExpiry && (
-                <span className={`truncate ${resetCreditsTone.text}`}>
-                  {resetCreditsExpiry}
-                </span>
-              )}
-            </div>
-          )}
+          <ResetCreditsMenu
+            compact={compactResetCredits}
+            resetCredits={resetCredits}
+          />
         </div>
       </div>
 

--- a/src/components/ResetCreditsMenu.tsx
+++ b/src/components/ResetCreditsMenu.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useId, useRef, useState } from "react";
+import type { AccountResetCredits } from "../types";
+import { formatResetCreditDateTime, getAvailableResetCredits } from "../lib/resetCredits";
+
+function getResetCreditsTone(resetCredits: AccountResetCredits | null): {
+  container: string;
+  badge: string;
+  text: string;
+} {
+  const fallback = {
+    container: "border-sky-200 bg-sky-50/70 dark:border-sky-800 dark:bg-sky-950/30",
+    badge: "border-sky-200 bg-sky-100 text-sky-700 dark:border-sky-700 dark:bg-sky-900/50 dark:text-sky-300",
+    text: "text-sky-700/80 dark:text-sky-300/80",
+  };
+
+  if (!resetCredits?.next_expires_at) return fallback;
+
+  const expiry = new Date(resetCredits.next_expires_at);
+  if (Number.isNaN(expiry.getTime())) return fallback;
+
+  const remainingMs = expiry.getTime() - Date.now();
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  if (remainingMs <= 3 * dayMs) {
+    return {
+      container: "border-red-200 bg-red-50/70 dark:border-red-800 dark:bg-red-950/30",
+      badge: "border-red-200 bg-red-100 text-red-700 dark:border-red-700 dark:bg-red-900/50 dark:text-red-300",
+      text: "text-red-700/80 dark:text-red-300/80",
+    };
+  }
+
+  if (remainingMs <= 10 * dayMs) {
+    return {
+      container: "border-amber-200 bg-amber-50/70 dark:border-amber-800 dark:bg-amber-950/30",
+      badge: "border-amber-200 bg-amber-100 text-amber-700 dark:border-amber-700 dark:bg-amber-900/50 dark:text-amber-300",
+      text: "text-amber-700/80 dark:text-amber-300/80",
+    };
+  }
+
+  return fallback;
+}
+
+function formatExpiryDetail(expiresAt: string | null): string {
+  const expiry = formatResetCreditDateTime(expiresAt);
+  if (expiry === "No expiry" || expiry === "Expiry unavailable") return expiry;
+  return `Expires ${expiry}`;
+}
+
+export function ResetCreditsMenu({
+  compact,
+  resetCredits,
+}: {
+  compact: boolean;
+  resetCredits: AccountResetCredits | null;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popupId = useId();
+  const availableCredits = getAvailableResetCredits(resetCredits);
+  const count = availableCredits.length;
+  const countLabel = count === 1 ? "1 reset" : `${count} resets`;
+  const nextExpiry = formatResetCreditDateTime(
+    availableCredits[0]?.expires_at ?? null,
+    { compact },
+  );
+  const nextExpiryLabel =
+    nextExpiry === "No expiry"
+      ? "no expiry"
+      : nextExpiry === "Expiry unavailable"
+        ? "expiry unavailable"
+        : `closest ${nextExpiry}`;
+  const tone = getResetCreditsTone(resetCredits);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!wrapperRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      setIsOpen(false);
+      buttonRef.current?.focus();
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    setIsOpen(false);
+  }, [resetCredits]);
+
+  if (count === 0) return null;
+
+  return (
+    <div ref={wrapperRef} className="relative min-w-0 max-w-full">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls={popupId}
+        aria-haspopup="dialog"
+        onClick={() => setIsOpen((open) => !open)}
+        className={
+          compact
+            ? `flex min-w-0 max-w-full items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] leading-none transition-colors hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-sky-400/60 ${tone.container} ${tone.text}`
+            : `flex max-w-full items-center gap-2 rounded-lg border px-2 py-1.5 text-xs transition-colors hover:brightness-95 focus:outline-none focus:ring-2 focus:ring-sky-400/60 ${tone.container}`
+        }
+        title={`${countLabel} · ${nextExpiryLabel} · Click for expiry details`}
+      >
+        <span
+          className={
+            compact
+              ? "shrink-0 whitespace-nowrap font-semibold"
+              : `whitespace-nowrap rounded-full border px-2.5 py-0.5 font-medium ${tone.badge}`
+          }
+        >
+          {countLabel}
+        </span>
+        <span className={`truncate ${compact ? "" : tone.text}`}>
+          · {nextExpiryLabel}
+        </span>
+        <svg
+          className={`h-3 w-3 shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
+          viewBox="0 0 12 12"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="m3 4.5 3 3 3-3"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          id={popupId}
+          role="dialog"
+          aria-label="Reset credit expiry details"
+          className="absolute right-0 top-full z-30 mt-2 w-80 max-w-[calc(100vw-3rem)] overflow-hidden rounded-xl border border-gray-200 bg-white text-left shadow-xl dark:border-gray-700 dark:bg-gray-900"
+        >
+          <div className="flex items-center justify-between border-b border-gray-100 px-3 py-2.5 dark:border-gray-800">
+            <span className="text-xs font-semibold text-gray-900 dark:text-gray-100">
+              Available resets
+            </span>
+            <span className="text-[11px] text-gray-500 dark:text-gray-400">
+              {count}
+            </span>
+          </div>
+          <div className="max-h-64 overflow-y-auto py-1">
+            {availableCredits.map((credit, index) => (
+              <div
+                key={credit.id}
+                className="flex items-start gap-2.5 px-3 py-2.5 text-xs"
+              >
+                <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full font-semibold ${tone.badge}`}>
+                  {index + 1}
+                </span>
+                <div className="min-w-0">
+                  <div className="truncate font-medium text-gray-800 dark:text-gray-200">
+                    {credit.title?.trim() || `Reset ${index + 1}`}
+                  </div>
+                  <div className="mt-0.5 text-[11px] text-gray-500 dark:text-gray-400">
+                    {formatExpiryDetail(credit.expires_at)}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="border-t border-gray-100 px-3 py-2 text-[10px] text-gray-400 dark:border-gray-800 dark:text-gray-500">
+            Times shown in your local time
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/resetCredits.ts
+++ b/src/lib/resetCredits.ts
@@ -1,0 +1,53 @@
+import type { AccountResetCredit, AccountResetCredits } from "../types";
+
+interface ResetCreditDateTimeFormatOptions {
+  compact?: boolean;
+  locale?: string;
+  timeZone?: string;
+}
+
+function expiryTimestamp(credit: AccountResetCredit): number | null {
+  if (!credit.expires_at) return null;
+  const timestamp = new Date(credit.expires_at).getTime();
+  return Number.isNaN(timestamp) ? null : timestamp;
+}
+
+export function getAvailableResetCredits(
+  resetCredits: AccountResetCredits | null,
+  now = Date.now(),
+): AccountResetCredit[] {
+  if (!resetCredits) return [];
+
+  return resetCredits.credits
+    .map((credit, index) => ({ credit, index, timestamp: expiryTimestamp(credit) }))
+    .filter(({ credit, timestamp }) => {
+      if (credit.status.toLowerCase() !== "available") return false;
+      return timestamp === null || timestamp > now;
+    })
+    .sort((a, b) => {
+      if (a.timestamp === null && b.timestamp === null) return a.index - b.index;
+      if (a.timestamp === null) return 1;
+      if (b.timestamp === null) return -1;
+      return a.timestamp - b.timestamp || a.index - b.index;
+    })
+    .map(({ credit }) => credit);
+}
+
+export function formatResetCreditDateTime(
+  expiresAt: string | null,
+  options: ResetCreditDateTimeFormatOptions = {},
+): string {
+  if (!expiresAt) return "No expiry";
+
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) return "Expiry unavailable";
+
+  return new Intl.DateTimeFormat(options.locale, {
+    month: "short",
+    day: "numeric",
+    ...(options.compact ? {} : { year: "numeric" }),
+    hour: "numeric",
+    minute: "2-digit",
+    ...(options.timeZone ? { timeZone: options.timeZone } : {}),
+  }).format(expiry);
+}

--- a/tests/resetCredits.test.ts
+++ b/tests/resetCredits.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatResetCreditDateTime,
+  getAvailableResetCredits,
+} from "../src/lib/resetCredits.ts";
+import type { AccountResetCredit, AccountResetCredits } from "../src/types/index.ts";
+
+function credit(
+  id: string,
+  status: string,
+  expiresAt: string | null,
+): AccountResetCredit {
+  return {
+    id,
+    reset_type: "codex_rate_limits",
+    status,
+    granted_at: null,
+    expires_at: expiresAt,
+    redeem_started_at: null,
+    redeemed_at: null,
+    title: null,
+    description: null,
+  };
+}
+
+test("available reset credits exclude redeemed and expired rows and sort by expiry", () => {
+  const resetCredits: AccountResetCredits = {
+    available_count: 4,
+    next_expires_at: "2026-07-28T08:30:00Z",
+    credits: [
+      credit("no-expiry", "available", null),
+      credit("later", "available", "2026-07-30T08:30:00Z"),
+      credit("redeemed", "redeemed", "2026-07-28T08:30:00Z"),
+      credit("expired", "available", "2026-07-26T08:30:00Z"),
+      credit("earlier", "available", "2026-07-28T08:30:00Z"),
+    ],
+  };
+
+  const available = getAvailableResetCredits(
+    resetCredits,
+    new Date("2026-07-27T08:30:00Z").getTime(),
+  );
+
+  assert.deepEqual(available.map(({ id }) => id), ["earlier", "later", "no-expiry"]);
+});
+
+test("reset expiry includes both date and local time", () => {
+  assert.equal(
+    formatResetCreditDateTime("2026-07-28T08:30:00Z", {
+      locale: "en-US",
+      timeZone: "UTC",
+    }),
+    "Jul 28, 2026, 8:30 AM",
+  );
+  assert.equal(
+    formatResetCreditDateTime("2026-07-28T08:30:00Z", {
+      compact: true,
+      locale: "en-US",
+      timeZone: "UTC",
+    }),
+    "Jul 28, 8:30 AM",
+  );
+});
+
+test("missing and malformed expiry values remain visible", () => {
+  assert.equal(formatResetCreditDateTime(null), "No expiry");
+  assert.equal(formatResetCreditDateTime("not-a-date"), "Expiry unavailable");
+});


### PR DESCRIPTION
## Summary

- show the nearest reset-credit expiry with both date and local time
- make the reset-credit badge clickable and list every available reset in expiry order
- exclude redeemed and expired credits while preserving no-expiry entries
- support outside-click and Escape dismissal with accessible popup semantics
- add focused tests for inventory filtering, ordering, and date-time formatting

## Why

The existing badge only showed the nearest expiry date and did not expose the individual reset-credit expiration timestamps. This made it difficult to plan around multiple available resets.

## Validation

- `pnpm test:reset-credits`
- `pnpm build`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`
- interactive browser verification for open/close behavior and narrow-card layout
