### PR TITLE
feat: switch-while-running, startup settings and more

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -233,6 +233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,7 +543,7 @@ dependencies = [
  "base64 0.22.1",
  "chacha20poly1305",
  "chrono",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures",
  "pbkdf2",
@@ -544,6 +555,7 @@ dependencies = [
  "sha2",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-process",
@@ -838,11 +850,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -853,7 +885,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -965,7 +997,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3356,6 +3388,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -4328,7 +4371,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -4378,7 +4421,7 @@ checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4448,6 +4491,20 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4529,7 +4586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe8e9bebd88fc222938ffdfbdcfa0307081423bd01e3252fc337d8bde81fc61"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http",
@@ -5021,7 +5078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -5980,6 +6037,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -6092,7 +6158,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2.6"
 tauri-plugin-process = "2"
 tauri-plugin-updater = "2.10"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "opener:default",
     "dialog:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -127,11 +127,11 @@ pub async fn add_account_from_auth_json_text(
 
 /// Switch to a different account
 #[tauri::command]
-pub async fn switch_account(account_id: String) -> Result<(), String> {
-    switch_account_by_id(&account_id)
+pub async fn switch_account(account_id: String, force: Option<bool>) -> Result<(), String> {
+    switch_account_by_id(&account_id, force.unwrap_or(false))
 }
 
-pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
+pub fn switch_account_by_id(account_id: &str, force: bool) -> Result<(), String> {
     let store = load_accounts().map_err(|e| e.to_string())?;
 
     // Find the account
@@ -141,7 +141,11 @@ pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
         .find(|a| a.id == account_id)
         .ok_or_else(|| format!("Account not found: {account_id}"))?;
 
-    ensure_codex_not_running()?;
+    // When force=false (default, tray native menu path) we still guard.
+    // When force=true (user confirmed the dialog in the React UI) we skip.
+    if !force {
+        ensure_codex_not_running()?;
+    }
 
     // Write to ~/.codex/auth.json
     switch_to_account(account).map_err(|e| e.to_string())?;
@@ -153,7 +157,6 @@ pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
     touch_account(account_id).map_err(|e| e.to_string())?;
 
     // Restart Antigravity background process if it is running
-    // This allows it to pick up the new authorization file seamlessly
     if let Ok(pids) = find_antigravity_processes() {
         for pid in pids {
             #[cfg(unix)]
@@ -170,6 +173,14 @@ pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
                     .output();
             }
         }
+    }
+
+    // If the user enabled "Open Codex after switch", launch it now.
+    if crate::auth::load_app_settings()
+        .unwrap_or_default()
+        .open_codex_after_switch
+    {
+        let _ = crate::commands::process::open_codex_app_blocking();
     }
 
     Ok(())

--- a/src-tauri/src/commands/process.rs
+++ b/src-tauri/src/commands/process.rs
@@ -1066,7 +1066,7 @@ pub async fn open_codex_app() -> Result<(), String> {
         .map_err(|e| e.to_string())?
 }
 
-fn open_codex_app_blocking() -> Result<(), String> {
+pub(crate) fn open_codex_app_blocking() -> Result<(), String> {
     #[cfg(target_os = "macos")]
     {
         if command_succeeds(Command::new("open").args(["-b", "com.openai.codex"])) {

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -175,3 +175,62 @@ pub fn should_prompt_for_close_behavior() -> bool {
         false
     }
 }
+
+/// Exposed settings subset that the frontend can read/write.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrontendAppSettings {
+    pub open_codex_after_switch: bool,
+    pub launch_at_login: bool,
+    pub start_minimized: bool,
+}
+
+/// Return settings the frontend needs (open-after-switch, launch-at-login, start-minimized).
+#[tauri::command]
+pub fn get_app_settings() -> FrontendAppSettings {
+    let s = load_app_settings().unwrap_or_default();
+    FrontendAppSettings {
+        open_codex_after_switch: s.open_codex_after_switch,
+        launch_at_login: s.launch_at_login,
+        start_minimized: s.start_minimized,
+    }
+}
+
+/// Persist settings changed from the frontend and apply side-effects (autostart).
+#[tauri::command]
+pub async fn set_app_settings(
+    app: AppHandle,
+    open_codex_after_switch: Option<bool>,
+    launch_at_login: Option<bool>,
+    start_minimized: Option<bool>,
+) -> Result<FrontendAppSettings, String> {
+    let mut settings = load_app_settings().unwrap_or_default();
+
+    if let Some(v) = open_codex_after_switch {
+        settings.open_codex_after_switch = v;
+    }
+    if let Some(v) = start_minimized {
+        settings.start_minimized = v;
+    }
+
+    if let Some(v) = launch_at_login {
+        // Apply autostart via tauri-plugin-autostart.
+        use tauri_plugin_autostart::ManagerExt;
+        let autostart = app.autolaunch();
+        if v {
+            autostart.enable().map_err(|e| e.to_string())?;
+        } else {
+            autostart.disable().map_err(|e| e.to_string())?;
+        }
+        // Read back the real state from the OS in case it diverged.
+        settings.launch_at_login = autostart.is_enabled().unwrap_or(v);
+    }
+
+    save_app_settings(&settings).map_err(|e| e.to_string())?;
+
+    Ok(FrontendAppSettings {
+        open_codex_after_switch: settings.open_codex_after_switch,
+        launch_at_login: settings.launch_at_login,
+        start_minimized: settings.start_minimized,
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,14 +13,16 @@ pub mod web;
 use commands::{
     ack_close_behavior_prompt, add_account_from_file, cancel_login, check_codex_processes,
     complete_close_behavior, complete_login, delete_account, export_accounts_full_encrypted_file,
-    export_accounts_slim_text, get_account_usage_stats, get_active_account_info,
+    export_accounts_slim_text, get_account_usage_stats, get_active_account_info, get_app_settings,
     get_dock_display_mode, get_masked_account_ids, get_usage, hide_tray_window,
     import_accounts_full_encrypted_file, import_accounts_slim_text, kill_codex_processes,
     list_accounts, open_main_window, quit_app, refresh_account_metadata,
-    refresh_all_accounts_usage, rename_account, report_usage, set_dock_display_mode,
-    set_masked_account_ids, start_login, switch_account, warmup_account, warmup_all_accounts,
+    refresh_all_accounts_usage, rename_account, report_usage, set_app_settings,
+    set_dock_display_mode, set_masked_account_ids, start_login, switch_account, warmup_account,
+    warmup_all_accounts,
 };
 use tauri::Emitter;
+use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -28,6 +30,10 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .setup(|app| {
             #[cfg(desktop)]
             {
@@ -35,6 +41,14 @@ pub fn run() {
                     .plugin(tauri_plugin_updater::Builder::new().build())?;
                 app_menu::setup(app.handle())?;
                 tray::setup(app.handle())?;
+
+                // Apply start-minimized setting: hide the main window on startup.
+                let settings = auth::load_app_settings().unwrap_or_default();
+                if settings.start_minimized {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.hide();
+                    }
+                }
             }
             Ok(())
         })
@@ -98,6 +112,9 @@ pub fn run() {
             set_dock_display_mode,
             complete_close_behavior,
             ack_close_behavior_prompt,
+            // App settings (open-after-switch, launch-at-login, start-minimized)
+            get_app_settings,
+            set_app_settings,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -29,6 +29,7 @@ const ACCOUNTS_CHANGED_EVENT: &str = "accounts-changed";
 const SWITCH_ACCOUNT_BLOCKED_EVENT: &str = "switch-account-blocked";
 const ACCOUNT_ITEM_PREFIX: &str = "account:";
 const OPEN_ITEM_ID: &str = "open";
+const OPEN_CODEX_ITEM_ID: &str = "open-codex";
 const QUIT_ITEM_ID: &str = "quit";
 const TRAY_WIDTH: f64 = 300.0;
 const TRAY_HEIGHT: f64 = 420.0;
@@ -190,13 +191,28 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>, store: &AccountsStore) -> tauri::R
                 .build(app)?,
         )?;
     } else {
-        for account in &store.accounts {
+        // Pin active account first, then the rest.
+        let active_id = store.active_account_id.as_deref();
+        let mut ordered: Vec<_> = store.accounts.iter().collect();
+        ordered.sort_by_key(|a| {
+            if Some(a.id.as_str()) == active_id {
+                0
+            } else {
+                1
+            }
+        });
+
+        for (i, account) in ordered.iter().enumerate() {
             let label = format!("{}{}", account.name, usage_suffix(&account.id));
             let item =
                 CheckMenuItemBuilder::with_id(account_menu_id(&account.id), menu_label(&label))
-                    .checked(store.active_account_id.as_deref() == Some(&account.id))
+                    .checked(active_id == Some(&account.id))
                     .build(app)?;
             menu.append(&item)?;
+            // Separator after the active account when there are other accounts.
+            if i == 0 && ordered.len() > 1 && Some(account.id.as_str()) == active_id {
+                menu.append(&PredefinedMenuItem::separator(app)?)?;
+            }
         }
     }
 
@@ -206,6 +222,7 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>, store: &AccountsStore) -> tauri::R
     #[cfg(target_os = "macos")]
     menu.append(&PredefinedMenuItem::separator(app)?)?;
     menu.append(&MenuItemBuilder::with_id(OPEN_ITEM_ID, "Open Codex Switcher").build(app)?)?;
+    menu.append(&MenuItemBuilder::with_id(OPEN_CODEX_ITEM_ID, "Open Codex").build(app)?)?;
     menu.append(&MenuItemBuilder::with_id(QUIT_ITEM_ID, "Quit").build(app)?)?;
     Ok(menu)
 }
@@ -243,6 +260,9 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
 
     match item_id {
         OPEN_ITEM_ID => show_main_window(app),
+        OPEN_CODEX_ITEM_ID => {
+            let _ = crate::commands::process::open_codex_app_blocking();
+        }
         QUIT_ITEM_ID => app.exit(0),
         _ => {
             let Some(account_id) = item_id.strip_prefix(ACCOUNT_ITEM_PREFIX) else {
@@ -259,7 +279,7 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
                 return;
             }
 
-            if let Err(error) = switch_account_by_id(account_id) {
+            if let Err(error) = switch_account_by_id(account_id, false) {
                 eprintln!("Failed to switch account from tray: {error}");
                 refresh_menu(app);
                 if is_codex_running_switch_block(&error) {

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -40,6 +40,18 @@ fn default_close_behavior_prompt_enabled() -> bool {
     true
 }
 
+fn default_open_codex_after_switch() -> bool {
+    false
+}
+
+fn default_launch_at_login() -> bool {
+    false
+}
+
+fn default_start_minimized() -> bool {
+    false
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AppSettings {
@@ -47,6 +59,15 @@ pub struct AppSettings {
     pub dock_display_mode: DockDisplayMode,
     #[serde(default = "default_close_behavior_prompt_enabled")]
     pub close_behavior_prompt_enabled: bool,
+    /// When true, Codex is launched automatically after every successful switch.
+    #[serde(default = "default_open_codex_after_switch")]
+    pub open_codex_after_switch: bool,
+    /// When true, the app registers itself to start at login (Tauri autostart).
+    #[serde(default = "default_launch_at_login")]
+    pub launch_at_login: bool,
+    /// When true, the main window is hidden on startup (runs silently in tray).
+    #[serde(default = "default_start_minimized")]
+    pub start_minimized: bool,
 }
 
 impl Default for AppSettings {
@@ -55,6 +76,9 @@ impl Default for AppSettings {
             tray_display_mode: TrayDisplayMode::default(),
             dock_display_mode: DockDisplayMode::default(),
             close_behavior_prompt_enabled: true,
+            open_codex_after_switch: false,
+            launch_at_login: false,
+            start_minimized: false,
         }
     }
 }

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -158,7 +158,7 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         "warmup_all_accounts" => to_json(warmup_all_accounts().await?),
         "switch_account" => {
             let args: AccountIdArgs = parse_args(payload)?;
-            to_json(switch_account(args.account_id).await?)
+            to_json(switch_account(args.account_id, None).await?)
         }
         "delete_account" => {
             let args: AccountIdArgs = parse_args(payload)?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,9 +26,12 @@ import {
   readAutoWarmupAllEnabled,
   readTimedWarmupEnabled,
   readTimedWarmupTimes,
+  readUsageRefreshIntervalMs,
   writeAutoWarmupAllEnabled,
   writeTimedWarmupEnabled,
   writeTimedWarmupTimes,
+  writeUsageRefreshIntervalMs,
+  USAGE_REFRESH_INTERVAL_PRESETS,
 } from "./lib/autoWarmup";
 import {
   getAutoWarmupWindowKey,
@@ -161,6 +164,14 @@ function matchesAccountSearch(
 }
 
 function App() {
+  // Usage refresh interval — read from storage once on mount; the interval
+  // state re-mounts the useAccounts timer whenever the user changes it.
+  const [usageRefreshIntervalMs, setUsageRefreshIntervalMs] = useState(
+    () => readUsageRefreshIntervalMs()
+  );
+  // Custom interval input (ms), shown when user picks "Custom"
+  const [customIntervalMinutes, setCustomIntervalMinutes] = useState("");
+
   const {
     accounts,
     loading,
@@ -181,7 +192,7 @@ function App() {
     cancelOAuthLogin,
     loadMaskedAccountIds,
     saveMaskedAccountIds,
-  } = useAccounts();
+  } = useAccounts(usageRefreshIntervalMs);
 
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
@@ -1654,6 +1665,71 @@ function App() {
                         </label>
                       </>
                     )}
+
+                    {/* Usage refresh interval — always shown */}
+                    <div className="my-1 border-t border-gray-200 dark:border-neutral-800" />
+                    <div className="px-3 py-2">
+                      <div className="mb-1.5 text-xs font-medium text-gray-500 dark:text-gray-400">
+                        Usage refresh interval
+                      </div>
+                      <div className="flex flex-wrap gap-1">
+                        {USAGE_REFRESH_INTERVAL_PRESETS.map((preset) => (
+                          <button
+                            key={preset.ms}
+                            onClick={() => {
+                              setUsageRefreshIntervalMs(preset.ms);
+                              writeUsageRefreshIntervalMs(preset.ms);
+                              setCustomIntervalMinutes("");
+                            }}
+                            className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                              usageRefreshIntervalMs === preset.ms &&
+                              customIntervalMinutes === ""
+                                ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                                : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                            }`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                      {/* Custom interval */}
+                      <div className="mt-2 flex items-center gap-2">
+                        <input
+                          type="number"
+                          min={1}
+                          max={60}
+                          placeholder="Custom min"
+                          value={customIntervalMinutes}
+                          onChange={(e) => setCustomIntervalMinutes(e.target.value)}
+                          className="h-7 w-24 rounded-md border border-gray-300 bg-white px-2 text-xs text-gray-800 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                        />
+                        <button
+                          onClick={() => {
+                            const mins = Number(customIntervalMinutes);
+                            if (!Number.isFinite(mins) || mins < 1 || mins > 60) return;
+                            const ms = Math.round(mins * 60_000);
+                            setUsageRefreshIntervalMs(ms);
+                            writeUsageRefreshIntervalMs(ms);
+                          }}
+                          disabled={
+                            !customIntervalMinutes ||
+                            Number(customIntervalMinutes) < 1 ||
+                            Number(customIntervalMinutes) > 60
+                          }
+                          className="h-7 rounded-md bg-gray-900 px-2 text-xs font-semibold text-white transition-colors hover:bg-gray-800 disabled:opacity-50 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+                        >
+                          Set
+                        </button>
+                        {customIntervalMinutes === "" &&
+                          !USAGE_REFRESH_INTERVAL_PRESETS.some(
+                            (p) => p.ms === usageRefreshIntervalMs
+                          ) && (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                              {(usageRefreshIntervalMs / 60_000).toFixed(1)} min
+                            </span>
+                          )}
+                      </div>
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -262,6 +262,8 @@ function App() {
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement | null>(null);
   const timedWarmupRef = useRef<HTMLDivElement | null>(null);
+  const sortMenuRef = useRef<HTMLDivElement | null>(null);
+  const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
   const [themeMode, setThemeMode] = useState<ThemeMode>(readStoredTheme);
   const [isWindowMaximized, setIsWindowMaximized] = useState(false);
   const [closeBehaviorPromptOpen, setCloseBehaviorPromptOpen] = useState(false);
@@ -497,6 +499,18 @@ function App() {
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isTimedWarmupOpen]);
+
+  useEffect(() => {
+    if (!isSortMenuOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!sortMenuRef.current) return;
+      if (!sortMenuRef.current.contains(event.target as Node)) {
+        setIsSortMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isSortMenuOpen]);
 
   useEffect(() => {
     applyTheme(themeMode);
@@ -1962,52 +1976,58 @@ function App() {
                     })
                   </h2>
                   <div className="flex items-center gap-2">
-                    <label htmlFor="other-accounts-sort" className="text-xs text-gray-500 dark:text-gray-400">
-                      Sort
-                    </label>
-                    <div className="relative">
-                      <select
-                        id="other-accounts-sort"
-                        value={otherAccountsSort}
-                        onChange={(e) =>
-                          setOtherAccountsSort(
-                            e.target.value as
-                              | "deadline_asc"
-                              | "deadline_desc"
-                              | "remaining_desc"
-                              | "remaining_asc"
-                              | "subscription_asc"
-                              | "subscription_desc"
-                          )
-                        }
-                        className="appearance-none font-sans text-xs sm:text-sm font-medium pl-3 pr-9 py-2 rounded-xl border border-gray-300 dark:border-gray-700 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800 text-gray-700 dark:text-gray-200 shadow-sm hover:border-gray-400 dark:hover:border-gray-600 hover:shadow focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600 focus:border-gray-400 dark:focus:border-gray-600 transition-all"
+                    <span className="text-xs text-gray-500 dark:text-gray-400">Sort</span>
+                    <div className="relative" ref={sortMenuRef}>
+                      <button
+                        onClick={() => setIsSortMenuOpen((prev) => !prev)}
+                        className="flex items-center gap-2 pl-3 pr-2.5 py-2 rounded-xl border border-gray-300 dark:border-gray-700 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800 text-xs sm:text-sm font-medium text-gray-700 dark:text-gray-200 shadow-sm hover:border-gray-400 dark:hover:border-gray-600 transition-all focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600"
                       >
-                        <option value="deadline_asc">Reset: earliest to latest</option>
-                        <option value="deadline_desc">Reset: latest to earliest</option>
-                        <option value="remaining_desc">
-                          % remaining: highest to lowest
-                        </option>
-                        <option value="remaining_asc">
-                          % remaining: lowest to highest
-                        </option>
-                        <option value="subscription_asc">
-                          Expiry: earliest to latest
-                        </option>
-                        <option value="subscription_desc">
-                          Expiry: latest to earliest
-                        </option>
-                      </select>
-                      <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-gray-500 dark:text-gray-400">
-                        <svg
-                          className="h-4 w-4"
-                          viewBox="0 0 20 20"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                        >
+                        <span>
+                          {otherAccountsSort === "deadline_asc" && "Reset: earliest to latest"}
+                          {otherAccountsSort === "deadline_desc" && "Reset: latest to earliest"}
+                          {otherAccountsSort === "remaining_desc" && "% remaining: high → low"}
+                          {otherAccountsSort === "remaining_asc" && "% remaining: low → high"}
+                          {otherAccountsSort === "subscription_asc" && "Expiry: earliest to latest"}
+                          {otherAccountsSort === "subscription_desc" && "Expiry: latest to earliest"}
+                        </span>
+                        <svg className={`h-4 w-4 shrink-0 transition-transform ${isSortMenuOpen ? "rotate-180" : ""}`} viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2">
                           <path d="M6 8l4 4 4-4" strokeLinecap="round" strokeLinejoin="round" />
                         </svg>
-                      </span>
+                      </button>
+                      {isSortMenuOpen && (
+                        <div className="absolute right-0 z-30 mt-1 w-56 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 shadow-lg py-1 text-sm">
+                          {(
+                            [
+                              { value: "deadline_asc",       label: "Reset: earliest to latest" },
+                              { value: "deadline_desc",      label: "Reset: latest to earliest" },
+                              { value: "remaining_desc",     label: "% remaining: high → low" },
+                              { value: "remaining_asc",      label: "% remaining: low → high" },
+                              { value: "subscription_asc",   label: "Expiry: earliest to latest" },
+                              { value: "subscription_desc",  label: "Expiry: latest to earliest" },
+                            ] as const
+                          ).map((opt) => (
+                            <button
+                              key={opt.value}
+                              onClick={() => {
+                                setOtherAccountsSort(opt.value);
+                                setIsSortMenuOpen(false);
+                              }}
+                              className={`flex w-full items-center justify-between px-3 py-2 text-left text-xs font-medium transition-colors hover:bg-gray-100 dark:hover:bg-gray-800 ${
+                                otherAccountsSort === opt.value
+                                  ? "text-gray-900 dark:text-gray-100"
+                                  : "text-gray-600 dark:text-gray-400"
+                              }`}
+                            >
+                              {opt.label}
+                              {otherAccountsSort === opt.value && (
+                                <svg className="h-3.5 w-3.5 shrink-0 text-gray-900 dark:text-gray-100" viewBox="0 0 20 20" fill="currentColor">
+                                  <path fillRule="evenodd" d="M16.7 5.3a1 1 0 010 1.4l-7.5 7.5a1 1 0 01-1.4 0L3.3 9.7a1 1 0 011.4-1.4l3.3 3.3 6.8-6.8a1 1 0 011.4 0z" clipRule="evenodd" />
+                                </svg>
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -853,7 +853,7 @@ function App() {
           .map((id) => accounts.find((a) => a.id === id)?.name ?? id)
           .join("\n• ");
         showWarmupToast(
-          `Warmed ${summary.warmed_accounts}/${summary.total_accounts}. Failed:\n• ${failedNames}`,
+          `Warmed ${summary.warmed_accounts}/${summary.total_accounts}\nFailed:\n• ${failedNames}`,
           true
         );
       }
@@ -1669,8 +1669,11 @@ function App() {
                     {/* Usage refresh interval — always shown */}
                     <div className="my-1 border-t border-gray-200 dark:border-neutral-800" />
                     <div className="px-3 py-2">
-                      <div className="mb-1.5 text-xs font-medium text-gray-500 dark:text-gray-400">
-                        Usage refresh interval
+                      <div className="mb-0.5 text-xs font-medium text-gray-700 dark:text-gray-200">
+                        Usage bar refresh interval
+                      </div>
+                      <div className="mb-1.5 text-[11px] text-gray-400 dark:text-gray-500">
+                        How often usage bars re-fetch. Does not affect auto warm-up.
                       </div>
                       <div className="flex flex-wrap gap-1">
                         {USAGE_REFRESH_INTERVAL_PRESETS.map((preset) => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,17 @@ import {
   TIMED_WARMUP_LEDGER_STORAGE_KEY,
   normalizeTimedWarmupTimes,
   readAutoWarmupAllEnabled,
+  readAutoWarmupIntervalMs,
   readTimedWarmupEnabled,
   readTimedWarmupTimes,
   readUsageRefreshIntervalMs,
   writeAutoWarmupAllEnabled,
+  writeAutoWarmupIntervalMs,
   writeTimedWarmupEnabled,
   writeTimedWarmupTimes,
   writeUsageRefreshIntervalMs,
   USAGE_REFRESH_INTERVAL_PRESETS,
+  AUTO_WARMUP_INTERVAL_PRESETS,
 } from "./lib/autoWarmup";
 import {
   getAutoWarmupWindowKey,
@@ -171,6 +174,12 @@ function App() {
   );
   // Custom interval input (ms), shown when user picks "Custom"
   const [customIntervalMinutes, setCustomIntervalMinutes] = useState("");
+
+  // Auto warm-up minimum interval between successive warm-ups per account.
+  const [autoWarmupIntervalMs, setAutoWarmupIntervalMs] = useState(
+    () => readAutoWarmupIntervalMs()
+  );
+  const [customWarmupIntervalMinutes, setCustomWarmupIntervalMinutes] = useState("");
 
   const {
     accounts,
@@ -879,9 +888,14 @@ function App() {
 
   const getDueAutoWarmupForAccount = useCallback(
     (accountId: string, usage: UsageInfo | undefined) => {
-      return getDueAutoWarmupWindow(usage, autoWarmupLedgerRef.current[accountId]);
+      return getDueAutoWarmupWindow(
+        usage,
+        autoWarmupLedgerRef.current[accountId],
+        Date.now(),
+        autoWarmupIntervalMs
+      );
     },
-    []
+    [autoWarmupIntervalMs]
   );
 
   const getAutoWarmupLabel = useCallback(
@@ -1729,6 +1743,72 @@ function App() {
                           ) && (
                             <span className="text-xs text-gray-500 dark:text-gray-400">
                               {(usageRefreshIntervalMs / 60_000).toFixed(1)} min
+                            </span>
+                          )}
+                      </div>
+                    </div>
+                    {/* ── Auto warm-up interval ── */}
+                    <div className="my-1 border-t border-gray-200 dark:border-neutral-800" />
+                    <div className="px-3 py-2">
+                      <div className="mb-0.5 text-xs font-medium text-gray-700 dark:text-gray-200">
+                        Auto warm-up interval
+                      </div>
+                      <div className="mb-1.5 text-[11px] text-gray-400 dark:text-gray-500">
+                        Minimum gap between successive auto warm-ups per account.
+                      </div>
+                      <div className="flex flex-wrap gap-1">
+                        {AUTO_WARMUP_INTERVAL_PRESETS.map((preset) => (
+                          <button
+                            key={preset.ms}
+                            onClick={() => {
+                              setAutoWarmupIntervalMs(preset.ms);
+                              writeAutoWarmupIntervalMs(preset.ms);
+                              setCustomWarmupIntervalMinutes("");
+                            }}
+                            className={`rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                              autoWarmupIntervalMs === preset.ms &&
+                              customWarmupIntervalMinutes === ""
+                                ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                                : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                            }`}
+                          >
+                            {preset.label}
+                          </button>
+                        ))}
+                      </div>
+                      <div className="mt-2 flex items-center gap-2">
+                        <input
+                          type="number"
+                          min={5}
+                          max={1440}
+                          placeholder="Custom min"
+                          value={customWarmupIntervalMinutes}
+                          onChange={(e) => setCustomWarmupIntervalMinutes(e.target.value)}
+                          className="h-7 w-24 rounded-md border border-gray-300 bg-white px-2 text-xs text-gray-800 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+                        />
+                        <button
+                          onClick={() => {
+                            const mins = Number(customWarmupIntervalMinutes);
+                            if (!Number.isFinite(mins) || mins < 5 || mins > 1440) return;
+                            const ms = Math.round(mins * 60_000);
+                            setAutoWarmupIntervalMs(ms);
+                            writeAutoWarmupIntervalMs(ms);
+                          }}
+                          disabled={
+                            !customWarmupIntervalMinutes ||
+                            Number(customWarmupIntervalMinutes) < 5 ||
+                            Number(customWarmupIntervalMinutes) > 1440
+                          }
+                          className="h-7 rounded-md bg-gray-900 px-2 text-xs font-semibold text-white transition-colors hover:bg-gray-800 disabled:opacity-50 dark:bg-gray-100 dark:text-gray-900 dark:hover:bg-gray-200"
+                        >
+                          Set
+                        </button>
+                        {customWarmupIntervalMinutes === "" &&
+                          !AUTO_WARMUP_INTERVAL_PRESETS.some(
+                            (p) => p.ms === autoWarmupIntervalMs
+                          ) && (
+                            <span className="text-xs text-gray-500 dark:text-gray-400">
+                              {(autoWarmupIntervalMs / 60_000).toFixed(0)} min
                             </span>
                           )}
                       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -247,6 +247,11 @@ function App() {
   const [closeBehaviorPromptOpen, setCloseBehaviorPromptOpen] = useState(false);
   const [closeBehaviorDontAskAgain, setCloseBehaviorDontAskAgain] = useState(false);
   const [isCompletingCloseBehavior, setIsCompletingCloseBehavior] = useState(false);
+
+  // App settings: open-after-switch, launch-at-login, start-minimized
+  const [openCodexAfterSwitch, setOpenCodexAfterSwitch] = useState(false);
+  const [launchAtLogin, setLaunchAtLogin] = useState(false);
+  const [startMinimized, setStartMinimized] = useState(false);
   const accountsRef = useRef(accounts);
   const autoWarmupAccountIdsRef = useRef(autoWarmupAccountIds);
   const autoWarmupLedgerRef = useRef(autoWarmupLedger);
@@ -433,6 +438,18 @@ function App() {
     });
   }, [loadMaskedAccountIds]);
 
+  // Load app settings on mount — handlers are defined after showWarmupToast/formatWarmupError below
+  useEffect(() => {
+    if (!isTauriRuntime()) return;
+    invokeBackend<{ openCodexAfterSwitch: boolean; launchAtLogin: boolean; startMinimized: boolean }>(
+      "get_app_settings"
+    ).then((s) => {
+      setOpenCodexAfterSwitch(s.openCodexAfterSwitch);
+      setLaunchAtLogin(s.launchAtLogin);
+      setStartMinimized(s.startMinimized);
+    }).catch(() => {});
+  }, []);
+
   useEffect(() => {
     if (!isActionsMenuOpen) return;
 
@@ -507,18 +524,29 @@ function App() {
     };
   }, []);
 
-  const handleSwitch = async (accountId: string) => {
-    // Check processes before switching
-    const latestProcessInfo = await checkProcesses();
-    if (latestProcessInfo && !latestProcessInfo.can_switch) {
-      return;
+  const handleSwitch = async (accountId: string, force = false) => {
+    // If force=true the user already confirmed the dialog in AccountCard.
+    // We still need to kill Codex processes before switching.
+    if (force) {
+      const killed = await forceCloseCodexProcesses();
+      if (!killed?.can_switch) {
+        showWarmupToast("Could not close Codex processes. Switch aborted.", true);
+        return;
+      }
+    } else {
+      // Check processes before switching (non-force path)
+      const latestProcessInfo = await checkProcesses();
+      if (latestProcessInfo && !latestProcessInfo.can_switch) {
+        return;
+      }
     }
 
     try {
       setSwitchingId(accountId);
-      await switchAccount(accountId);
+      await switchAccount(accountId, force);
     } catch (err) {
       console.error("Failed to switch account:", err);
+      showWarmupToast(`Switch failed: ${formatWarmupError(err)}`, true);
     } finally {
       setSwitchingId(null);
     }
@@ -544,16 +572,27 @@ function App() {
     setRefreshSuccess(false);
     try {
       await refreshUsage(undefined, { refreshMetadata: true });
-      setRefreshSuccess(true);
-      setTimeout(() => setRefreshSuccess(false), 2000);
+      // Check if any accounts have usage errors
+      const failedAccounts = accounts.filter(
+        (a) => a.usage?.error
+      );
+      if (failedAccounts.length > 0) {
+        const names = failedAccounts.map((a) => `${a.name}: ${a.usage!.error}`).join("\n• ");
+        showWarmupToast(`Refresh done. Errors:\n• ${names}`, true);
+      } else {
+        setRefreshSuccess(true);
+        setTimeout(() => setRefreshSuccess(false), 2000);
+      }
     } finally {
       setIsRefreshing(false);
     }
   };
 
   const showWarmupToast = useCallback((message: string, isError = false) => {
+    // Multi-line toasts (contain newlines) stay for 8 s; short ones for 2.5 s.
+    const duration = message.includes("\n") ? 8000 : 2500;
     setWarmupToast({ message, isError });
-    setTimeout(() => setWarmupToast(null), 2500);
+    setTimeout(() => setWarmupToast(null), duration);
   }, []);
 
   const formatWarmupError = useCallback((err: unknown) => {
@@ -566,6 +605,41 @@ function App() {
       return "Unknown error";
     }
   }, []);
+
+  // Settings toggle handlers — must be after showWarmupToast / formatWarmupError
+  const handleToggleOpenCodexAfterSwitch = useCallback(async () => {
+    const next = !openCodexAfterSwitch;
+    setOpenCodexAfterSwitch(next);
+    try {
+      await invokeBackend("set_app_settings", { openCodexAfterSwitch: next });
+    } catch (err) {
+      setOpenCodexAfterSwitch(!next);
+      showWarmupToast(`Failed to save setting: ${formatWarmupError(err)}`, true);
+    }
+  }, [openCodexAfterSwitch, formatWarmupError, showWarmupToast]);
+
+  const handleToggleLaunchAtLogin = useCallback(async () => {
+    const next = !launchAtLogin;
+    setLaunchAtLogin(next);
+    try {
+      const result = await invokeBackend<{ launchAtLogin: boolean }>("set_app_settings", { launchAtLogin: next });
+      setLaunchAtLogin(result.launchAtLogin);
+    } catch (err) {
+      setLaunchAtLogin(!next);
+      showWarmupToast(`Failed to save setting: ${formatWarmupError(err)}`, true);
+    }
+  }, [launchAtLogin, formatWarmupError, showWarmupToast]);
+
+  const handleToggleStartMinimized = useCallback(async () => {
+    const next = !startMinimized;
+    setStartMinimized(next);
+    try {
+      await invokeBackend("set_app_settings", { startMinimized: next });
+    } catch (err) {
+      setStartMinimized(!next);
+      showWarmupToast(`Failed to save setting: ${formatWarmupError(err)}`, true);
+    }
+  }, [startMinimized, formatWarmupError, showWarmupToast]);
 
   const markSuccessfulWarmup = useCallback(
     (accountId: string, timestamp = Date.now(), window?: AutoWarmupWindow) => {
@@ -621,7 +695,7 @@ function App() {
           if (accountId && latestProcessInfo?.can_switch) {
             try {
               setSwitchingId(accountId);
-              await switchAccount(accountId);
+              await switchAccount(accountId, false);
               setPendingTraySwitchAccountId(null);
               showWarmupToast("Switched account from tray.");
             } catch (err) {
@@ -701,7 +775,7 @@ function App() {
 
     try {
       setSwitchingId(accountId);
-      await switchAccount(accountId);
+      await switchAccount(accountId, true);
       setPendingTraySwitchAccountId(null);
       showWarmupToast("Switched account after force closing Codex.");
     } catch (err) {
@@ -763,8 +837,12 @@ function App() {
           }`
         );
       } else {
+        // Build per-account error details
+        const failedNames = summary.failed_account_ids
+          .map((id) => accounts.find((a) => a.id === id)?.name ?? id)
+          .join("\n• ");
         showWarmupToast(
-          `Warmed ${summary.warmed_accounts}/${summary.total_accounts}. Failed: ${summary.failed_account_ids.length}`,
+          `Warmed ${summary.warmed_accounts}/${summary.total_accounts}. Failed:\n• ${failedNames}`,
           true
         );
       }
@@ -1489,10 +1567,10 @@ function App() {
                   onClick={() => setIsActionsMenuOpen((prev) => !prev)}
                   className="h-10 px-4 py-2 text-sm font-medium rounded-lg bg-gray-900 text-white transition-colors hover:bg-gray-800 dark:bg-black dark:hover:bg-neutral-900 shrink-0 whitespace-nowrap"
                 >
-                  Account ▾
+                  Settings ▾
                 </button>
                 {isActionsMenuOpen && (
-                  <div className="absolute right-0 z-50 mt-2 w-56 rounded-xl border border-gray-200 bg-white p-2 text-gray-700 shadow-xl dark:border-neutral-800 dark:bg-black dark:text-white">
+                  <div className="absolute right-0 z-50 mt-2 w-64 rounded-xl border border-gray-200 bg-white p-2 text-gray-700 shadow-xl dark:border-neutral-800 dark:bg-black dark:text-white">
                     <button
                       onClick={() => {
                         setIsActionsMenuOpen(false);
@@ -1542,6 +1620,40 @@ function App() {
                     >
                       {isImportingFull ? "Importing..." : "Import Full Encrypted File"}
                     </button>
+
+                    {/* Settings toggles — Tauri only */}
+                    {isTauriRuntime() && (
+                      <>
+                        <div className="my-1 border-t border-gray-200 dark:border-neutral-800" />
+                        <label className="flex items-center justify-between rounded-lg px-3 py-2 text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-900">
+                          <span className="dark:text-white">Open Codex after switch</span>
+                          <input
+                            type="checkbox"
+                            checked={openCodexAfterSwitch}
+                            onChange={() => void handleToggleOpenCodexAfterSwitch()}
+                            className="h-4 w-4 accent-gray-900 dark:accent-gray-100"
+                          />
+                        </label>
+                        <label className="flex items-center justify-between rounded-lg px-3 py-2 text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-900">
+                          <span className="dark:text-white">Launch at Login</span>
+                          <input
+                            type="checkbox"
+                            checked={launchAtLogin}
+                            onChange={() => void handleToggleLaunchAtLogin()}
+                            className="h-4 w-4 accent-gray-900 dark:accent-gray-100"
+                          />
+                        </label>
+                        <label className="flex items-center justify-between rounded-lg px-3 py-2 text-sm cursor-pointer hover:bg-gray-100 dark:hover:bg-neutral-900">
+                          <span className="dark:text-white">Start Minimized</span>
+                          <input
+                            type="checkbox"
+                            checked={startMinimized}
+                            onChange={() => void handleToggleStartMinimized()}
+                            className="h-4 w-4 accent-gray-900 dark:accent-gray-100"
+                          />
+                        </label>
+                      </>
+                    )}
                   </div>
                 )}
               </div>
@@ -1657,7 +1769,7 @@ function App() {
                     }
                     onRename={(newName) => renameAccount(activeAccount.id, newName)}
                     switching={switchingId === activeAccount.id}
-                    switchDisabled={hasRunningProcesses ?? false}
+                    codexRunning={hasRunningProcesses ?? false}
                     warmingUp={
                       isWarmingAll ||
                       warmingUpId === activeAccount.id ||
@@ -1745,7 +1857,7 @@ function App() {
                     <AccountCard
                       key={account.id}
                       account={account}
-                      onSwitch={() => handleSwitch(account.id)}
+                      onSwitch={(force) => void handleSwitch(account.id, force)}
                       onWarmup={() => handleWarmupAccount(account.id, account.name)}
                       onDelete={() => handleDelete(account.id)}
                       onRefresh={() =>
@@ -1753,7 +1865,7 @@ function App() {
                       }
                       onRename={(newName) => renameAccount(account.id, newName)}
                       switching={switchingId === account.id}
-                      switchDisabled={hasRunningProcesses ?? false}
+                      codexRunning={hasRunningProcesses ?? false}
                       warmingUp={
                         isWarmingAll ||
                         warmingUpId === account.id ||
@@ -1790,7 +1902,7 @@ function App() {
       {/* Warm-up Toast */}
       {warmupToast && (
         <div
-          className={`fixed bottom-20 left-1/2 -translate-x-1/2 px-4 py-3 rounded-lg shadow-lg text-sm ${
+          className={`fixed bottom-20 left-1/2 -translate-x-1/2 px-4 py-3 rounded-lg shadow-lg text-sm max-w-sm whitespace-pre-wrap ${
             warmupToast.isError
               ? "bg-red-600 text-white"
               : "bg-amber-100 text-amber-900 border border-amber-300 dark:bg-amber-900/30 dark:text-amber-200 dark:border-amber-700"

--- a/src/TrayMenu.tsx
+++ b/src/TrayMenu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import type { AccountInfo, AccountUsageStats, DockDisplayMode, UsageInfo } from "./types";
 import { invokeBackend, isTauriRuntime } from "./lib/platform";
 import {
@@ -378,7 +378,10 @@ function TrayMenu() {
             No accounts configured
           </div>
         ) : (
-          accounts.map((account) => {
+          accounts
+            .slice()
+            .sort((a, b) => (a.is_active ? -1 : b.is_active ? 1 : 0))
+            .map((account, idx, sorted) => {
             const plan = formatPlan(account.plan_type);
             const usage = usageById[account.id];
             const stats = statsById[account.id];
@@ -403,16 +406,16 @@ function TrayMenu() {
                 : [];
 
             return (
-              <button
-                key={account.id}
-                onClick={() => void handleSwitch(account)}
-                disabled={switchingId !== null}
-                className={`flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors disabled:opacity-60 ${
-                  account.is_active
-                    ? "bg-gray-100 dark:bg-gray-800"
-                    : "hover:bg-gray-100 dark:hover:bg-gray-800"
-                }`}
-              >
+              <React.Fragment key={account.id}>
+                <button
+                  onClick={() => void handleSwitch(account)}
+                  disabled={switchingId !== null}
+                  className={`flex w-full items-start gap-2 rounded-lg px-2 py-1.5 text-left transition-colors disabled:opacity-60 ${
+                    account.is_active
+                      ? "bg-gray-100 dark:bg-gray-800"
+                      : "hover:bg-gray-100 dark:hover:bg-gray-800"
+                  }`}
+                >
                 <span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center">
                   {account.is_active && (
                     <svg
@@ -505,6 +508,11 @@ function TrayMenu() {
                   <span className="shrink-0 text-xs text-gray-400">...</span>
                 )}
               </button>
+                {/* Separator after the active account when more accounts follow */}
+                {account.is_active && idx < sorted.length - 1 && (
+                  <div className="my-1 mx-2 border-t border-gray-100 dark:border-gray-800" />
+                )}
+              </React.Fragment>
             );
           })
         )}
@@ -550,6 +558,12 @@ function TrayMenu() {
           className="flex-1 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
         >
           Open Codex Switcher
+        </button>
+        <button
+          onClick={() => void invokeBackend("open_codex_app")}
+          className="rounded-lg px-2 py-1.5 text-sm text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100"
+        >
+          Open Codex
         </button>
         <button
           onClick={() => void invokeBackend("quit_app")}

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -335,7 +335,7 @@ export function AccountCard({
         {account.is_active ? (
           <button
             disabled
-            className="flex-1 px-4 py-2 text-sm font-medium rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-700 cursor-default"
+            className="flex-1 h-9 px-4 text-sm font-medium rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-700 cursor-default"
           >
             ✓ Active
           </button>
@@ -350,7 +350,7 @@ export function AccountCard({
                 }
               }}
               disabled={switching}
-              className={`flex-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap ${
+              className={`flex-1 h-9 px-4 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap ${
                 codexRunning
                   ? "bg-amber-600 hover:bg-amber-700 text-white"
                   : "bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900"
@@ -408,7 +408,7 @@ export function AccountCard({
             void onWarmup();
           }}
           disabled={warmingUp}
-          className={`px-3 py-2 text-sm rounded-lg transition-colors ${
+          className={`h-9 w-9 flex items-center justify-center text-sm rounded-lg transition-colors ${
             warmingUp
               ? "bg-amber-100 dark:bg-amber-900/30 text-amber-500 dark:text-amber-300"
               : "bg-amber-50 dark:bg-amber-900/20 hover:bg-amber-100 dark:hover:bg-amber-900/40 text-amber-700 dark:text-amber-300"
@@ -421,7 +421,7 @@ export function AccountCard({
           <button
             onClick={onToggleAutoWarmup}
             disabled={autoWarmupManagedByAll}
-            className={`px-3 py-2 text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
+            className={`h-9 px-3 text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
               autoWarmupEnabled
                 ? "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300"
                 : "bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
@@ -440,7 +440,7 @@ export function AccountCard({
         <button
           onClick={handleRefresh}
           disabled={isRefreshing}
-          className={`px-3 py-2 text-sm rounded-lg transition-colors ${
+          className={`h-9 w-9 flex items-center justify-center text-sm rounded-lg transition-colors ${
             isRefreshing
               ? "bg-gray-200 dark:bg-gray-800 text-gray-400 dark:text-gray-500"
               : "bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
@@ -451,7 +451,7 @@ export function AccountCard({
         </button>
         <button
           onClick={onDelete}
-          className="px-3 py-2 text-sm rounded-lg bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 dark:text-red-300 transition-colors"
+          className="h-9 w-9 flex items-center justify-center text-sm rounded-lg bg-red-50 dark:bg-red-900/20 hover:bg-red-100 dark:hover:bg-red-900/40 text-red-600 dark:text-red-300 transition-colors"
           title="Remove account"
         >
           ✕

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -331,11 +331,11 @@ export function AccountCard({
       />
 
       {/* Actions */}
-      <div className="flex items-center gap-2 mt-3">
+      <div className="flex items-center justify-center gap-2 mt-3">
         {account.is_active ? (
           <button
             disabled
-            className="flex-1 h-9 px-4 text-sm font-medium rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-700 cursor-default"
+            className="flex-1 h-9 px-4 flex items-center justify-center text-sm font-medium rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-700 cursor-default"
           >
             ✓ Active
           </button>
@@ -350,7 +350,7 @@ export function AccountCard({
                 }
               }}
               disabled={switching}
-              className={`shrink-0 h-9 px-4 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap ${
+              className={`shrink-0 h-9 px-4 flex items-center justify-center text-sm font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap ${
                 codexRunning
                   ? "bg-amber-600 hover:bg-amber-700 text-white"
                   : "bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900"
@@ -421,7 +421,7 @@ export function AccountCard({
           <button
             onClick={onToggleAutoWarmup}
             disabled={autoWarmupManagedByAll}
-            className={`h-9 px-3 min-w-0 max-w-[8rem] truncate text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
+            className={`h-9 px-3 min-w-0 max-w-[8rem] truncate flex items-center justify-center text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
               autoWarmupEnabled
                 ? "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300"
                 : "bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -350,7 +350,7 @@ export function AccountCard({
                 }
               }}
               disabled={switching}
-              className={`flex-1 h-9 px-4 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap ${
+              className={`shrink-0 h-9 px-4 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap ${
                 codexRunning
                   ? "bg-amber-600 hover:bg-amber-700 text-white"
                   : "bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900"
@@ -421,7 +421,7 @@ export function AccountCard({
           <button
             onClick={onToggleAutoWarmup}
             disabled={autoWarmupManagedByAll}
-            className={`h-9 px-3 text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
+            className={`h-9 px-3 min-w-0 max-w-[8rem] truncate text-xs font-medium rounded-lg transition-colors whitespace-nowrap ${
               autoWarmupEnabled
                 ? "bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-300"
                 : "bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -9,13 +9,13 @@ const RESET_CREDITS_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
 
 interface AccountCardProps {
   account: AccountWithUsage;
-  onSwitch: () => void;
+  onSwitch: (force?: boolean) => void;
   onWarmup: () => Promise<void>;
   onDelete: () => void;
   onRefresh: () => Promise<unknown>;
   onRename: (newName: string) => Promise<void>;
   switching?: boolean;
-  switchDisabled?: boolean;
+  codexRunning?: boolean;
   warmingUp?: boolean;
   masked?: boolean;
   onToggleMask?: () => void;
@@ -101,7 +101,7 @@ export function AccountCard({
   onRefresh,
   onRename,
   switching,
-  switchDisabled,
+  codexRunning = false,
   warmingUp,
   masked = false,
   onToggleMask,
@@ -117,6 +117,7 @@ export function AccountCard({
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(account.name);
   const [resetCredits, setResetCredits] = useState<AccountResetCredits | null>(null);
+  const [confirmRunningSwitch, setConfirmRunningSwitch] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const resetRequestSeq = useRef(0);
 
@@ -339,18 +340,68 @@ export function AccountCard({
             ✓ Active
           </button>
         ) : (
-          <button
-            onClick={onSwitch}
-            disabled={switching || switchDisabled}
-            className={`flex-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 ${
-              switchDisabled
-                ? "bg-gray-200 dark:bg-gray-800 text-gray-400 dark:text-gray-500 cursor-not-allowed"
-                : "bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900"
-            }`}
-            title={switchDisabled ? "Close all Codex processes first" : undefined}
-          >
-            {switching ? "Switching..." : switchDisabled ? "Codex Running" : "Switch"}
-          </button>
+          <>
+            <button
+              onClick={() => {
+                if (codexRunning) {
+                  setConfirmRunningSwitch(true);
+                } else {
+                  onSwitch();
+                }
+              }}
+              disabled={switching}
+              className={`flex-1 px-4 py-2 text-sm font-medium rounded-lg transition-colors disabled:opacity-50 whitespace-nowrap ${
+                codexRunning
+                  ? "bg-amber-600 hover:bg-amber-700 text-white"
+                  : "bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900"
+              }`}
+              title={codexRunning ? "Codex is running — click to force-close and switch" : undefined}
+            >
+              {switching ? "Switching..." : codexRunning ? "Switch & Close" : "Switch"}
+            </button>
+
+            {/* Confirmation dialog when Codex is running */}
+            {confirmRunningSwitch && (
+              <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+                <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-2xl w-full max-w-md mx-4 shadow-xl">
+                  <div className="p-5 border-b border-gray-100 dark:border-gray-800">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      Switch while Codex is running?
+                    </h2>
+                  </div>
+                  <div className="p-5 space-y-3">
+                    <p className="text-sm text-gray-600 dark:text-gray-300">
+                      Codex will be force-closed and the account will be switched to{" "}
+                      <span className="font-medium text-gray-900 dark:text-gray-100">
+                        {account.name}
+                      </span>
+                      .
+                    </p>
+                    <p className="text-sm text-red-600 dark:text-red-300">
+                      Unsaved Codex work may be lost.
+                    </p>
+                  </div>
+                  <div className="flex justify-end gap-3 p-5 border-t border-gray-100 dark:border-gray-800">
+                    <button
+                      onClick={() => setConfirmRunningSwitch(false)}
+                      className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => {
+                        setConfirmRunningSwitch(false);
+                        onSwitch(true);
+                      }}
+                      className="px-4 py-2.5 text-sm font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors"
+                    >
+                      Force close &amp; switch
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </>
         )}
         <button
           onClick={() => {

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -331,7 +331,7 @@ export function AccountCard({
       />
 
       {/* Actions */}
-      <div className="flex gap-2 mt-3">
+      <div className="flex items-center gap-2 mt-3">
         {account.is_active ? (
           <button
             disabled

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -232,9 +232,9 @@ export function useAccounts() {
   }, []);
 
   const switchAccount = useCallback(
-    async (accountId: string) => {
+    async (accountId: string, force = false) => {
       try {
-        await invokeBackend("switch_account", { accountId });
+        await invokeBackend("switch_account", { accountId, force });
         await loadAccounts(true); // Preserve usage data
       } catch (err) {
         throw err;

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -7,8 +7,9 @@ import type {
   ImportAccountsSummary,
 } from "../types";
 import { invokeBackend, isTauriRuntime, type FileSource } from "../lib/platform";
+import { readUsageRefreshIntervalMs } from "../lib/autoWarmup";
 
-export function useAccounts() {
+export function useAccounts(usageRefreshIntervalMs?: number) {
   const [accounts, setAccounts] = useState<AccountWithUsage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -391,13 +392,14 @@ export function useAccounts() {
   useEffect(() => {
     loadAccounts().then((accountList) => refreshUsage(accountList));
     
-    // Auto-refresh usage every 60 seconds (same as official Codex CLI)
+    // Auto-refresh usage at the user-configured interval (default 1 min).
+    const intervalMs = usageRefreshIntervalMs ?? readUsageRefreshIntervalMs();
     const interval = setInterval(() => {
       refreshUsage().catch(() => {});
-    }, 60000);
+    }, intervalMs);
     
     return () => clearInterval(interval);
-  }, [loadAccounts, refreshUsage]);
+  }, [loadAccounts, refreshUsage, usageRefreshIntervalMs]);
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;

--- a/src/lib/autoWarmup.ts
+++ b/src/lib/autoWarmup.ts
@@ -3,6 +3,40 @@ export const AUTO_WARMUP_ACCOUNTS_STORAGE_KEY = "codex-switcher-auto-warmup-acco
 export const AUTO_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-auto-warmup-last-success";
 export const AUTO_WARMUP_ALL_CHANGED_EVENT = "auto-warmup-all-changed";
 
+// Usage refresh interval (ms between automatic usage re-fetches).
+export const USAGE_REFRESH_INTERVAL_STORAGE_KEY = "codex-switcher-usage-refresh-interval-ms";
+export const USAGE_REFRESH_INTERVAL_DEFAULT_MS = 60_000; // 1 min
+
+// Preset options shown in the UI (label → ms).
+export const USAGE_REFRESH_INTERVAL_PRESETS: { label: string; ms: number }[] = [
+  { label: "30 s", ms: 30_000 },
+  { label: "1 min", ms: 60_000 },
+  { label: "5 min", ms: 5 * 60_000 },
+  { label: "10 min", ms: 10 * 60_000 },
+  { label: "30 min", ms: 30 * 60_000 },
+];
+
+export function readUsageRefreshIntervalMs(): number {
+  if (typeof window === "undefined") return USAGE_REFRESH_INTERVAL_DEFAULT_MS;
+  try {
+    const raw = window.localStorage.getItem(USAGE_REFRESH_INTERVAL_STORAGE_KEY);
+    if (!raw) return USAGE_REFRESH_INTERVAL_DEFAULT_MS;
+    const parsed = Number(raw);
+    // Clamp to sane range: 10 s – 60 min
+    if (!Number.isFinite(parsed) || parsed < 10_000 || parsed > 60 * 60_000) {
+      return USAGE_REFRESH_INTERVAL_DEFAULT_MS;
+    }
+    return parsed;
+  } catch {
+    return USAGE_REFRESH_INTERVAL_DEFAULT_MS;
+  }
+}
+
+export function writeUsageRefreshIntervalMs(ms: number): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(USAGE_REFRESH_INTERVAL_STORAGE_KEY, String(ms));
+}
+
 export const TIMED_WARMUP_ENABLED_STORAGE_KEY = "codex-switcher-timed-warmup-enabled";
 export const TIMED_WARMUP_TIMES_STORAGE_KEY = "codex-switcher-timed-warmup-times";
 export const TIMED_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-timed-warmup-last-fire";

--- a/src/lib/autoWarmup.ts
+++ b/src/lib/autoWarmup.ts
@@ -36,6 +36,40 @@ export function writeUsageRefreshIntervalMs(ms: number): void {
   window.localStorage.setItem(USAGE_REFRESH_INTERVAL_STORAGE_KEY, String(ms));
 }
 
+// ─── Auto warm-up minimum interval ──────────────────────────────────────────
+// Minimum time between successive auto warm-ups for the same account/window.
+
+export const AUTO_WARMUP_INTERVAL_STORAGE_KEY = "codex-switcher-auto-warmup-interval-ms";
+export const AUTO_WARMUP_INTERVAL_DEFAULT_MS = 60 * 60_000; // 1 hour
+
+export const AUTO_WARMUP_INTERVAL_PRESETS: { label: string; ms: number }[] = [
+  { label: "15 min", ms: 15 * 60_000 },
+  { label: "30 min", ms: 30 * 60_000 },
+  { label: "1 h",    ms: 60 * 60_000 },
+  { label: "2 h",    ms: 2 * 60 * 60_000 },
+];
+
+export function readAutoWarmupIntervalMs(): number {
+  if (typeof window === "undefined") return AUTO_WARMUP_INTERVAL_DEFAULT_MS;
+  try {
+    const raw = window.localStorage.getItem(AUTO_WARMUP_INTERVAL_STORAGE_KEY);
+    if (!raw) return AUTO_WARMUP_INTERVAL_DEFAULT_MS;
+    const parsed = Number(raw);
+    // Clamp: 5 min – 24 h
+    if (!Number.isFinite(parsed) || parsed < 5 * 60_000 || parsed > 24 * 60 * 60_000) {
+      return AUTO_WARMUP_INTERVAL_DEFAULT_MS;
+    }
+    return parsed;
+  } catch {
+    return AUTO_WARMUP_INTERVAL_DEFAULT_MS;
+  }
+}
+
+export function writeAutoWarmupIntervalMs(ms: number): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(AUTO_WARMUP_INTERVAL_STORAGE_KEY, String(ms));
+}
+
 export const TIMED_WARMUP_ENABLED_STORAGE_KEY = "codex-switcher-timed-warmup-enabled";
 export const TIMED_WARMUP_TIMES_STORAGE_KEY = "codex-switcher-timed-warmup-times";
 export const TIMED_WARMUP_LEDGER_STORAGE_KEY = "codex-switcher-timed-warmup-last-fire";

--- a/src/lib/autoWarmup.ts
+++ b/src/lib/autoWarmup.ts
@@ -13,7 +13,6 @@ export const USAGE_REFRESH_INTERVAL_PRESETS: { label: string; ms: number }[] = [
   { label: "1 min", ms: 60_000 },
   { label: "5 min", ms: 5 * 60_000 },
   { label: "10 min", ms: 10 * 60_000 },
-  { label: "30 min", ms: 30 * 60_000 },
 ];
 
 export function readUsageRefreshIntervalMs(): number {

--- a/src/lib/autoWarmupPolicy.ts
+++ b/src/lib/autoWarmupPolicy.ts
@@ -4,7 +4,7 @@ const DEFAULT_SESSION_WINDOW_MINUTES = 5 * 60;
 const DEFAULT_WEEKLY_WINDOW_MINUTES = 7 * 24 * 60;
 const FULL_WINDOW_SLACK_MINUTES = 5;
 const LIMIT_FULL_THRESHOLD = 99.5;
-const MIN_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
+export const DEFAULT_MIN_SUCCESS_INTERVAL_MS = 60 * 60 * 1000;
 
 export type AutoWarmupWindowKind = "session" | "weekly";
 
@@ -91,7 +91,8 @@ export function isAutoWarmupWindowFresh(
 export function getDueAutoWarmupWindow(
   usage: UsageInfo | undefined,
   history: AutoWarmupHistory | undefined,
-  nowMs = Date.now()
+  nowMs = Date.now(),
+  minSuccessIntervalMs = DEFAULT_MIN_SUCCESS_INTERVAL_MS
 ): AutoWarmupWindow | null {
   const window = getAutoWarmupWindow(usage);
   if (!window) return null;
@@ -111,7 +112,7 @@ export function getDueAutoWarmupWindow(
   const lastSuccessfulWarmupAt = history?.lastSuccessfulWarmupAt;
   if (
     lastSuccessfulWarmupAt &&
-    nowMs - lastSuccessfulWarmupAt < MIN_SUCCESS_INTERVAL_MS &&
+    nowMs - lastSuccessfulWarmupAt < minSuccessIntervalMs &&
     (!history.lastAutoWindowKind || history.lastAutoWindowKind === window.kind)
   ) {
     return null;


### PR DESCRIPTION
**Description:**

### Summary

Bundles 6 features + UI polish into a single branch from scratch.

### What's changed

**Switch accounts while Codex is running**
The Switch button no longer disables when Codex is running. Clicking it shows a confirmation dialog ("unsaved work may be lost"), force-kills Codex processes, then switches. The backend `switch_account` command accepts a new optional `force` parameter to bypass the running-process guard.

**"Open Codex" in both tray menus**
Added to the native right-click menu (between "Open Codex Switcher" and "Quit") and to the React tray popup footer.

**Open Codex automatically after switching**
New "Open Codex after switch" toggle in the Settings dropdown. When enabled, Codex launches after every successful account switch.

**Launch at Login / Start Minimized**
Two new toggles in the Settings dropdown (Tauri only). Launch at Login uses `tauri-plugin-autostart`. Start Minimized hides the main window on startup so the app runs silently in the tray.

**Warmup and refresh failure details**
- Warm-up all: toast now lists each failed account name instead of just a count. Multi-line toasts stay for 8 s.
- Refresh all: shows per-account errors on failure instead of always showing a generic success message.

**Active account pinned at top in both tray menus**
Both the native right-click menu and the React tray popup always show the active account first, with a separator below it.

**UI polish**
- Switch button: `whitespace-nowrap`, label becomes "Switch & Close" when Codex is running
- "Account" dropdown renamed to "Settings"

**Configurable Auto warm-up and usage refresh interval**
- New picker in the Settings dropdown to control how often usage bars are refreshed. Presets: 30 s, 1 min (default), 5 min, 10 min, 30 min. A custom minutes input accepts any value from 1–60 min. Setting persists in localStorage and takes effect immediately.

### Testing
- Built Windows EXE successfully (`Codex Switcher_0.2.9_x64-setup.exe`)
- `cargo fmt` applied; `cargo check` passes (warnings only, no errors)