### PR TITLE
Fix tray reliability and macOS popup placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:major": "node scripts/release.mjs major"
   },
   "dependencies": {
-    "@tauri-apps/api": "^2.10.0",
+    "@tauri-apps/api": "2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@tauri-apps/api':
-        specifier: ^2.10.0
+        specifier: 2.10.1
         version: 2.10.1
       '@tauri-apps/plugin-dialog':
         specifier: ^2.6.0

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -535,6 +535,8 @@ dependencies = [
  "dirs",
  "flate2",
  "futures",
+ "objc2",
+ "objc2-app-kit",
  "pbkdf2",
  "plist",
  "rand 0.9.2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -550,6 +550,8 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tauri-runtime",
+ "tauri-runtime-wry",
  "thiserror 2.0.18",
  "tiny_http",
  "tokio",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,10 @@ tauri-build = { version = "=2.5.6", features = [] }
 
 [dependencies]
 tauri = { version = "=2.10.3", features = ["tray-icon", "macos-private-api"] }
+# Tauri 2.11's window runtime regresses the macOS status-item popup. Keep the
+# transitive runtime from independently crossing that compatibility boundary.
+tauri-runtime = "=2.10.1"
+tauri-runtime-wry = "=2.10.1"
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2.6"
 tauri-plugin-process = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,4 +41,12 @@ chacha20poly1305 = "0.10"
 pbkdf2 = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-app-kit = { version = "0.3", default-features = false, features = [
+  "std",
+  "AppKitDefines",
+  "NSEvent",
+  "NSScreen",
+  "NSWindow",
+] }
 plist = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,10 +11,10 @@ name = "codex_switcher_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "=2.5.6", features = [] }
 
 [dependencies]
-tauri = { version = "2.10", features = ["tray-icon", "macos-private-api"] }
+tauri = { version = "=2.10.3", features = ["tray-icon", "macos-private-api"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2.6"
 tauri-plugin-process = "2"

--- a/src-tauri/src/app_menu.rs
+++ b/src-tauri/src/app_menu.rs
@@ -61,6 +61,9 @@ fn tray_display_mode_for_item(item_id: &str) -> Option<TrayDisplayMode> {
 pub(crate) fn update_tray_display_mode(app: &AppHandle, mode: TrayDisplayMode) {
     let mut settings = load_app_settings().unwrap_or_default();
     if settings.tray_display_mode == mode {
+        // Treat reselecting the active mode as an explicit repair request. This
+        // is useful if macOS retained the status item but stopped painting it.
+        crate::tray::refresh_display(app);
         return;
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -81,14 +81,19 @@ pub fn refresh<R: Runtime>(app: &AppHandle<R>) {
     refresh_menu(app);
 }
 
-/// Store usage reported by the main app and refresh the native menu labels.
+/// Store usage reported by the main app and refresh the compact tray display.
 pub fn ingest_usage<R: Runtime>(app: &AppHandle<R>, usages: Vec<UsageInfo>) {
     if let Ok(mut cache) = TRAY_USAGE.lock() {
         for usage in usages {
             cache.insert(usage.account_id.clone(), usage);
         }
     }
-    refresh_menu(app);
+    // Usage arrives from both the webview and the background poller. Replacing
+    // the whole native menu on every report makes macOS repeatedly rebuild its
+    // NSStatusItem scene, which can leave the status item present but visually
+    // absent. Usage changes only affect the compact title, so keep the existing
+    // menu and status item alive here.
+    refresh_title(app);
 }
 
 // ============================================================================
@@ -108,9 +113,13 @@ fn create_tray_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .decorations(false)
         .transparent(true)
         .always_on_top(true)
+        .visible_on_all_workspaces(true)
         .skip_taskbar(true)
         .visible(false)
         .build()?;
+
+    #[cfg(target_os = "macos")]
+    configure_macos_tray_window(&window)?;
 
     // Hide the popup as soon as it loses focus so it behaves like a native menu.
     let app_handle = app.clone();
@@ -122,6 +131,21 @@ fn create_tray_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         }
     });
 
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn configure_macos_tray_window<R: Runtime>(window: &tauri::WebviewWindow<R>) -> tauri::Result<()> {
+    use objc2_app_kit::{NSPopUpMenuWindowLevel, NSWindow, NSWindowCollectionBehavior};
+
+    let ns_window = unsafe { &*window.ns_window()?.cast::<NSWindow>() };
+    let behavior = ns_window.collectionBehavior()
+        | NSWindowCollectionBehavior::CanJoinAllSpaces
+        | NSWindowCollectionBehavior::FullScreenAuxiliary
+        | NSWindowCollectionBehavior::Transient
+        | NSWindowCollectionBehavior::IgnoresCycle;
+    ns_window.setCollectionBehavior(behavior);
+    ns_window.setLevel(NSPopUpMenuWindowLevel);
     Ok(())
 }
 
@@ -155,6 +179,57 @@ fn toggle_tray_window<R: Runtime>(app: &AppHandle<R>, cursor: PhysicalPosition<f
     let _ = app.emit_to(TRAY_WINDOW, TRAY_REFRESH_EVENT, ());
 }
 
+#[cfg(target_os = "macos")]
+fn position_near_cursor<R: Runtime>(
+    window: &tauri::WebviewWindow<R>,
+    _cursor: PhysicalPosition<f64>,
+) {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::{NSEvent, NSScreen, NSWindow};
+
+    let Ok(ns_window) = window.ns_window() else {
+        return;
+    };
+    let ns_window_address = ns_window as usize;
+
+    // NSScreen and NSWindow are MainActor APIs. Queue this before `show()`;
+    // Tauri preserves event-loop message order, so the native frame is placed
+    // before the hidden popup becomes visible.
+    let _ = window.run_on_main_thread(move || {
+        let Some(mtm) = MainThreadMarker::new() else {
+            return;
+        };
+        let mouse = NSEvent::mouseLocation();
+        let screens = NSScreen::screens(mtm);
+        let Some(screen) = screens.iter().find(|screen| {
+            let frame = screen.frame();
+            mouse.x >= frame.origin.x
+                && mouse.x < frame.origin.x + frame.size.width
+                && mouse.y >= frame.origin.y
+                && mouse.y < frame.origin.y + frame.size.height
+        }) else {
+            return;
+        };
+
+        // Apple documents visibleFrame as the portion safe for app content;
+        // on camera-housing Macs it excludes the bezel and both adjacent areas.
+        let visible = screen.visibleFrame();
+        let ns_window = unsafe { &*(ns_window_address as *mut NSWindow) };
+        let width = ns_window.frame().size.width;
+        let x = clamp_popup_axis(
+            mouse.x - width / 2.0,
+            visible.origin.x,
+            visible.origin.x + visible.size.width,
+            width,
+        );
+        let mut top_left = visible.origin;
+        top_left.x = x;
+        top_left.y += visible.size.height - 4.0;
+        ns_window.setFrameTopLeftPoint(top_left);
+    });
+}
+
+#[cfg(not(target_os = "macos"))]
 #[cfg_attr(target_os = "linux", allow(dead_code))]
 fn position_near_cursor<R: Runtime>(
     window: &tauri::WebviewWindow<R>,
@@ -163,17 +238,22 @@ fn position_near_cursor<R: Runtime>(
     let size = window.outer_size().ok();
     let width = size.map(|s| s.width as f64).unwrap_or(TRAY_WIDTH);
     let height = size.map(|s| s.height as f64).unwrap_or(TRAY_HEIGHT);
+    let monitor = window.monitor_from_point(cursor.x, cursor.y).ok().flatten();
 
-    let x = (cursor.x - width / 2.0).max(0.0);
-    // macOS menu bar sits at the top, so drop the popup below the icon.
-    // Other platforms keep the tray at the bottom, so float it above the cursor.
-    let y = if cfg!(target_os = "macos") {
-        cursor.y + 4.0
-    } else {
-        (cursor.y - height - 4.0).max(0.0)
-    };
-
+    let x = monitor
+        .as_ref()
+        .map(|monitor| {
+            let left = monitor.position().x as f64;
+            let right = left + monitor.size().width as f64;
+            clamp_popup_axis(cursor.x - width / 2.0, left, right, width)
+        })
+        .unwrap_or_else(|| (cursor.x - width / 2.0).max(0.0));
+    let y = (cursor.y - height - 4.0).max(0.0);
     let _ = window.set_position(PhysicalPosition::new(x, y));
+}
+
+fn clamp_popup_axis(preferred: f64, start: f64, end: f64, extent: f64) -> f64 {
+    preferred.clamp(start, (end - extent).max(start))
 }
 
 // ============================================================================
@@ -290,6 +370,84 @@ fn refresh_menu<R: Runtime>(app: &AppHandle<R>) {
     }
 }
 
+pub(crate) fn refresh_display<R: Runtime>(app: &AppHandle<R>) {
+    let app_handle = app.clone();
+    if let Err(error) = app.run_on_main_thread(move || {
+        refresh_display_on_main_thread(&app_handle);
+    }) {
+        eprintln!("Failed to schedule tray display refresh: {error}");
+    }
+}
+
+fn refresh_title<R: Runtime>(app: &AppHandle<R>) {
+    let app_handle = app.clone();
+    if let Err(error) = app.run_on_main_thread(move || {
+        refresh_title_on_main_thread(&app_handle);
+    }) {
+        eprintln!("Failed to schedule tray title refresh: {error}");
+    }
+}
+
+fn refresh_title_on_main_thread<R: Runtime>(app: &AppHandle<R>) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+
+    let store = match load_accounts() {
+        Ok(store) => store,
+        Err(error) => {
+            eprintln!("Failed to load accounts for tray title: {error}");
+            return;
+        }
+    };
+    let settings = match load_app_settings() {
+        Ok(settings) => settings,
+        Err(error) => {
+            eprintln!("Failed to load settings for tray title: {error}");
+            return;
+        }
+    };
+    if settings.tray_display_mode == TrayDisplayMode::Hidden {
+        return;
+    }
+
+    let title = active_tray_title(
+        store.active_account_id.as_deref(),
+        settings.tray_display_mode,
+    );
+    if let Err(error) = tray.set_title(title.as_deref()) {
+        eprintln!("Failed to refresh tray title: {error}");
+    }
+}
+
+fn refresh_display_on_main_thread<R: Runtime>(app: &AppHandle<R>) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+
+    let store = match load_accounts() {
+        Ok(store) => store,
+        Err(error) => {
+            eprintln!("Failed to load accounts for tray display: {error}");
+            return;
+        }
+    };
+    let settings = match load_app_settings() {
+        Ok(settings) => settings,
+        Err(error) => {
+            // A transient settings read must never switch the tray to the
+            // default text-only mode and clear the macOS icon.
+            eprintln!("Failed to load settings for tray display: {error}");
+            return;
+        }
+    };
+    let title = active_tray_title(
+        store.active_account_id.as_deref(),
+        settings.tray_display_mode,
+    );
+    refresh_tray_display(&tray, settings.tray_display_mode, title.as_deref());
+}
+
 fn refresh_menu_on_main_thread<R: Runtime>(app: &AppHandle<R>) {
     let Some(tray) = app.tray_by_id(TRAY_ID) else {
         return;
@@ -298,7 +456,7 @@ fn refresh_menu_on_main_thread<R: Runtime>(app: &AppHandle<R>) {
     match load_accounts()
         .map_err(|error| error.to_string())
         .and_then(|store| {
-            let settings = load_app_settings().unwrap_or_default();
+            let settings = load_app_settings().map_err(|error| error.to_string())?;
             let title = active_tray_title(
                 store.active_account_id.as_deref(),
                 settings.tray_display_mode,
@@ -573,6 +731,13 @@ mod tests {
             menu_label("Research & Development"),
             "Research && Development"
         );
+    }
+
+    #[test]
+    fn popup_position_is_clamped_to_its_target_display() {
+        assert_eq!(clamp_popup_axis(-220.0, -100.0, 900.0, 300.0), -100.0);
+        assert_eq!(clamp_popup_axis(850.0, -100.0, 900.0, 300.0), 600.0);
+        assert_eq!(clamp_popup_axis(125.0, -100.0, 900.0, 300.0), 125.0);
     }
 
     #[test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -3,7 +3,9 @@ use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use tauri::{
-    menu::{CheckMenuItemBuilder, Menu, MenuItemBuilder, PredefinedMenuItem, Submenu},
+    menu::{
+        CheckMenuItemBuilder, Menu, MenuItemBuilder, MenuItemKind, PredefinedMenuItem, Submenu,
+    },
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Emitter, Manager, PhysicalPosition, Runtime, WebviewUrl, WebviewWindowBuilder,
     WindowEvent,
@@ -40,11 +42,22 @@ struct SwitchAccountBlockedPayload {
     error: String,
 }
 
+/// Owns the one native menu attached to the status item. Account changes mutate
+/// the leading account section; they never replace the menu/status-item scene.
+struct NativeMenuState<R: Runtime> {
+    inner: Mutex<NativeMenu<R>>,
+}
+
+struct NativeMenu<R: Runtime> {
+    menu: Menu<R>,
+    account_section_len: usize,
+}
+
 pub fn setup(app: &AppHandle) -> tauri::Result<()> {
     #[cfg(not(target_os = "linux"))]
     create_tray_window(app)?;
 
-    let menu = build_menu(app, &load_accounts().unwrap_or_default())?;
+    let (menu, account_section_len) = build_menu(app, &load_accounts().unwrap_or_default())?;
 
     #[cfg(target_os = "linux")]
     let icon = app
@@ -70,6 +83,12 @@ pub fn setup(app: &AppHandle) -> tauri::Result<()> {
         .show_menu_on_left_click(false);
 
     builder.build(app)?;
+    app.manage(NativeMenuState {
+        inner: Mutex::new(NativeMenu {
+            menu,
+            account_section_len,
+        }),
+    });
     refresh_menu(app);
 
     watch_accounts_file(app.clone());
@@ -260,24 +279,15 @@ fn clamp_popup_axis(preferred: f64, start: f64, end: f64, extent: f64) -> f64 {
 // Native menu (the only tray interaction on Linux; right-click on macOS/Windows)
 // ============================================================================
 
-fn build_menu<R: Runtime>(app: &AppHandle<R>, store: &AccountsStore) -> tauri::Result<Menu<R>> {
+fn build_menu<R: Runtime>(
+    app: &AppHandle<R>,
+    store: &AccountsStore,
+) -> tauri::Result<(Menu<R>, usize)> {
     let menu = Menu::new(app)?;
 
-    if store.accounts.is_empty() {
-        menu.append(
-            &MenuItemBuilder::with_id("empty", "No accounts configured")
-                .enabled(false)
-                .build(app)?,
-        )?;
-    } else {
-        for account in &store.accounts {
-            let label = format!("{}{}", account.name, usage_suffix(&account.id));
-            let item =
-                CheckMenuItemBuilder::with_id(account_menu_id(&account.id), menu_label(&label))
-                    .checked(store.active_account_id.as_deref() == Some(&account.id))
-                    .build(app)?;
-            menu.append(&item)?;
-        }
+    let account_items = build_account_menu_items(app, store)?;
+    for item in &account_items {
+        menu.append(item)?;
     }
 
     menu.append(&PredefinedMenuItem::separator(app)?)?;
@@ -287,7 +297,61 @@ fn build_menu<R: Runtime>(app: &AppHandle<R>, store: &AccountsStore) -> tauri::R
     menu.append(&PredefinedMenuItem::separator(app)?)?;
     menu.append(&MenuItemBuilder::with_id(OPEN_ITEM_ID, "Open Codex Switcher").build(app)?)?;
     menu.append(&MenuItemBuilder::with_id(QUIT_ITEM_ID, "Quit").build(app)?)?;
-    Ok(menu)
+    Ok((menu, account_items.len()))
+}
+
+fn build_account_menu_items<R: Runtime>(
+    app: &AppHandle<R>,
+    store: &AccountsStore,
+) -> tauri::Result<Vec<MenuItemKind<R>>> {
+    if store.accounts.is_empty() {
+        return Ok(vec![MenuItemKind::MenuItem(
+            MenuItemBuilder::with_id("empty", "No accounts configured")
+                .enabled(false)
+                .build(app)?,
+        )]);
+    }
+
+    store
+        .accounts
+        .iter()
+        .map(|account| {
+            let label = format!("{}{}", account.name, usage_suffix(&account.id));
+            CheckMenuItemBuilder::with_id(account_menu_id(&account.id), menu_label(&label))
+                .checked(store.active_account_id.as_deref() == Some(&account.id))
+                .build(app)
+                .map(MenuItemKind::Check)
+        })
+        .collect()
+}
+
+fn refresh_account_menu_items<R: Runtime>(
+    app: &AppHandle<R>,
+    store: &AccountsStore,
+) -> Result<(), String> {
+    let items = build_account_menu_items(app, store).map_err(|error| error.to_string())?;
+    let state = app
+        .try_state::<NativeMenuState<R>>()
+        .ok_or_else(|| "Native tray menu state is unavailable".to_string())?;
+    let mut native = state
+        .inner
+        .lock()
+        .map_err(|error| format!("Native tray menu state is poisoned: {error}"))?;
+
+    for _ in 0..native.account_section_len {
+        native
+            .menu
+            .remove_at(0)
+            .map_err(|error| error.to_string())?;
+    }
+    for (position, item) in items.iter().enumerate() {
+        native
+            .menu
+            .insert(item, position)
+            .map_err(|error| error.to_string())?;
+    }
+    native.account_section_len = items.len();
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -461,15 +525,10 @@ fn refresh_menu_on_main_thread<R: Runtime>(app: &AppHandle<R>) {
                 store.active_account_id.as_deref(),
                 settings.tray_display_mode,
             );
-            let menu = build_menu(app, &store).map_err(|error| error.to_string())?;
-            Ok((menu, title, settings.tray_display_mode))
+            refresh_account_menu_items(app, &store)?;
+            Ok((title, settings.tray_display_mode))
         }) {
-        Ok((menu, title, mode)) => {
-            if let Err(error) = tray.set_menu(Some(menu)) {
-                eprintln!("Failed to refresh tray menu: {error}");
-            }
-            refresh_tray_display(&tray, mode, title.as_deref());
-        }
+        Ok((title, mode)) => refresh_tray_display(&tray, mode, title.as_deref()),
         Err(error) => eprintln!("Failed to build tray menu: {error}"),
     }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1871,7 +1871,7 @@ function App() {
             </div>
             <div className="p-5 space-y-4">
               <p className="text-sm text-gray-600 dark:text-gray-300">
-                When the window is closed, Codex Switcher can stay in the Dock or live only in the menu bar.
+                When the window is closed, Codex Switcher can stay in the Dock, live only in the menu bar, or quit completely.
               </p>
               <p className="text-sm text-gray-600 dark:text-gray-300">
                 You can always change this later from the tray popup.
@@ -1907,6 +1907,13 @@ function App() {
                 className="px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 transition-colors disabled:opacity-50"
               >
                 Menu Bar Only
+              </button>
+              <button
+                onClick={() => void invokeBackend("quit_app")}
+                disabled={isCompletingCloseBehavior}
+                className="px-4 py-2.5 text-sm font-medium rounded-lg bg-red-600 hover:bg-red-700 text-white transition-colors disabled:opacity-50"
+              >
+                Quit Codex Switcher
               </button>
             </div>
           </div>


### PR DESCRIPTION
Related to #95.

## Summary

Fix cross-platform tray-menu lifecycle failures plus macOS-specific popup presentation failures:

- keep one native tray menu attached for the application lifetime and update its account rows in place
- avoid replacing the native menu during periodic account and usage refreshes
- provide an explicit repair path when the current tray display mode is reselected
- make the original React/Tauri tray popup visible in full-screen Spaces
- keep the macOS popup below the camera housing/notch and within the target display
- allow the close flow to quit completely instead of forcing the app to remain in the Dock or menu bar
- hold the popup implementation on the verified Tauri 2.10 runtime because Tauri 2.11 regresses its macOS presentation

## Root causes

### Native tray menu becomes unresponsive

Usage and account updates rebuilt and reattached the complete native tray menu. This lifecycle was shared by Windows, macOS, and Linux. In the Windows backend used by the pinned `tray-icon` dependency, replacing a menu detaches the old menu subclass from the hidden tray window, attaches the new one, updates the popup-menu handle, and replaces the retained menu. Repeating that lifecycle is a plausible cause of #95's report that every command in the Windows menu, including **Quit**, becomes unresponsive.

The revised path attaches the native menu once during setup. Routine usage updates only refresh the compact tray title, while account/storage changes replace the account rows inside the existing menu. The stable-menu correction is platform-neutral and is expected to address #95, but the issue should remain open until the reporter validates a Windows build over time.

On macOS, repeatedly replacing the native menu could also leave the status item alive but no longer painted. A transient settings read failure could fall back to the default text-only mode and clear the configured icon.

### Popup opens behind full-screen apps or under the camera housing

The popup did not opt into the all-Spaces and full-screen auxiliary window behavior, so it could open behind a full-screen application even though its right-click native menu remained available.

Popup placement also used the tray click's Y coordinate. On a Mac with a camera housing, this positioned the popup inside the physically obscured menu-bar region. The macOS path now performs placement on AppKit's main thread using `NSScreen.visibleFrame` and `NSWindow.setFrameTopLeftPoint`, Apple's native safe-content and screen-coordinate APIs. Other platforms retain the Tauri positioning path with horizontal display-edge clamping.

### Tauri 2.11 rendering regression

The dependency declarations used compatible version ranges, so a lockfile refresh could move the popup from the working Tauri 2.10 window stack to Tauri 2.11. A controlled bisect reproduced the failure on the 2.11 stack and restored the original React popup on Tauri 2.10 without replacing it with a native AppKit popover.

The PR now pins `tauri` 2.10.3, `tauri-build` 2.5.6, `tauri-runtime` 2.10.1, `tauri-runtime-wry` 2.10.1, and `@tauri-apps/api` 2.10.1. The direct runtime constraints are intentional: pinning only the top-level `tauri` crate still allowed Cargo to resolve its runtime crates to 2.11.

### Close button cannot quit

The main window's close-behavior prompt only offered **Show in Dock** and **Menu Bar Only**. That made the close button unable to terminate the application. The prompt now includes an explicit **Quit Codex Switcher** action while retaining both background-running choices.

## Changes

- retain one native `Menu` instance for the lifetime of the tray
- update account rows in place when `accounts.json` changes
- update only the tray title during routine usage refreshes
- reload settings without silently substituting an icon-clearing display mode
- reapply visibility, icon/template state, and title when repairing the tray display
- configure the macOS popup with all-Spaces/full-screen-auxiliary collection behavior and popup-menu window level
- position the macOS popup against the clicked screen's `visibleFrame` on the main thread
- add a clearly labeled **Quit Codex Switcher** action to the close-behavior prompt
- add regression coverage for popup edge clamping
- constrain the complete Tauri popup runtime to the verified 2.10 compatibility boundary

## Scope

This PR does not include the colored macOS status-item title or the later platform-renderer refactor. It preserves the existing React popup and contains only the tray lifecycle, popup rendering/placement, close-flow, and required runtime compatibility fixes.

## Validation

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`
- `cargo test --locked --manifest-path src-tauri/Cargo.toml` — 36 passed
- `pnpm build`
- `cargo tree --locked -p codex-switcher --depth 1` confirms Tauri 2.10.3 and both runtime crates at 2.10.1
- bundled macOS app passed strict local signature verification
- manual validation in a full-screen Space on a notched MacBook display
- WindowServer measurement confirmed the popup moved from clipped `Y=19` to safe `Y=37`
- controlled runtime test confirmed the original React popup works on the pinned 2.10 stack
- source-level verification against Tauri 2.10.3, `tray-icon` 0.21.3, and `muda` 0.17.1 Windows backends
- `cargo xwin check --target x86_64-pc-windows-msvc`
- `cargo xwin test --target x86_64-pc-windows-msvc --no-run` — all Windows test executables compiled and linked
- `cargo xwin build --target x86_64-pc-windows-msvc --release --bin codex-switcher` — produced a 64-bit Windows GUI executable

Windows runtime validation is still requested because #95 is intermittent and cannot be reproduced faithfully on macOS.
