### PR TITLE
fix: serialize account store updates

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -548,6 +548,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "tempfile",
  "thiserror 2.0.18",
  "tiny_http",
  "tokio",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ urlencoding = "2"
 futures = "0.3"
 url = "2"
 flate2 = "1"
+tempfile = "3"
 chacha20poly1305 = "0.10"
 pbkdf2 = "0.12"
 

--- a/src-tauri/src/auth/account_store.rs
+++ b/src-tauri/src/auth/account_store.rs
@@ -1,0 +1,304 @@
+//! Single-writer account store with bounded update admission.
+
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{Arc, OnceLock, RwLock},
+    thread::{self, JoinHandle},
+};
+
+use anyhow::{Context, Result};
+use tempfile::NamedTempFile;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::types::AccountsStore;
+
+const UPDATE_QUEUE_CAPACITY: usize = 16;
+
+static DEFAULT_CLIENT: OnceLock<AccountStoreClient> = OnceLock::new();
+
+type UpdateRequest = Box<dyn ErasedUpdate>;
+
+enum WorkerRequest {
+    Update(UpdateRequest),
+    Shutdown,
+}
+
+/// Cheap snapshot reads plus bounded admission to the sole account-store writer.
+#[derive(Clone)]
+pub(crate) struct AccountStoreClient {
+    requests: mpsc::Sender<WorkerRequest>,
+    snapshot: Arc<RwLock<AccountsStore>>,
+}
+
+/// Guard-bound worker capability. The worker loop is unreachable without this value.
+struct AccountStoreWorkerGuard {
+    path: PathBuf,
+    control: mpsc::Sender<WorkerRequest>,
+    requests: mpsc::Receiver<WorkerRequest>,
+    snapshot: Arc<RwLock<AccountsStore>>,
+    current: AccountsStore,
+}
+
+/// Keeps the single writer alive and drains it during normal process shutdown.
+pub(crate) struct AccountStoreRuntimeGuard {
+    requests: mpsc::Sender<WorkerRequest>,
+    worker: Option<JoinHandle<()>>,
+}
+
+trait ErasedUpdate: Send {
+    fn execute(
+        self: Box<Self>,
+        current: &mut AccountsStore,
+        snapshot: &RwLock<AccountsStore>,
+        path: &Path,
+    );
+}
+
+struct TypedUpdate<Update, Output> {
+    update: Update,
+    reply: oneshot::Sender<Result<Output>>,
+}
+
+impl AccountStoreClient {
+    fn open(path: PathBuf) -> Result<(Self, AccountStoreWorkerGuard)> {
+        let current = read_store(&path)?;
+        let snapshot = Arc::new(RwLock::new(current.clone()));
+        let (requests, receiver) = mpsc::channel(UPDATE_QUEUE_CAPACITY);
+        Ok((
+            Self {
+                requests: requests.clone(),
+                snapshot: Arc::clone(&snapshot),
+            },
+            AccountStoreWorkerGuard {
+                path,
+                control: requests.clone(),
+                requests: receiver,
+                snapshot,
+                current,
+            },
+        ))
+    }
+
+    pub(crate) fn snapshot(&self) -> Result<AccountsStore> {
+        self.snapshot
+            .read()
+            .map(|store| store.clone())
+            .map_err(|error| anyhow::anyhow!("Account store snapshot lock is poisoned: {error}"))
+    }
+
+    pub(crate) async fn update<Output, Update>(&self, update: Update) -> Result<Output>
+    where
+        Output: Send + 'static,
+        Update: FnOnce(&mut AccountsStore) -> Result<Output> + Send + 'static,
+    {
+        let (reply, response) = oneshot::channel();
+        self.requests
+            .send(WorkerRequest::Update(Box::new(TypedUpdate {
+                update,
+                reply,
+            })))
+            .await
+            .map_err(|_| anyhow::anyhow!("Account store worker stopped before update admission"))?;
+        response
+            .await
+            .context("Account store worker dropped an admitted update")?
+    }
+}
+
+impl AccountStoreWorkerGuard {
+    fn spawn(self) -> Result<AccountStoreRuntimeGuard> {
+        let requests = self.control.clone();
+        let worker = thread::Builder::new()
+            .name("account-store-writer".to_string())
+            .spawn(move || self.run())
+            .context("Failed to start account store worker")?;
+        Ok(AccountStoreRuntimeGuard {
+            requests,
+            worker: Some(worker),
+        })
+    }
+
+    fn run(mut self) {
+        while let Some(request) = self.requests.blocking_recv() {
+            match request {
+                WorkerRequest::Update(update) => {
+                    update.execute(&mut self.current, &self.snapshot, &self.path)
+                }
+                WorkerRequest::Shutdown => {
+                    self.requests.close();
+                    while let Some(request) = self.requests.blocking_recv() {
+                        if let WorkerRequest::Update(update) = request {
+                            update.execute(&mut self.current, &self.snapshot, &self.path);
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+    }
+}
+
+impl Drop for AccountStoreRuntimeGuard {
+    fn drop(&mut self) {
+        let Some(worker) = self.worker.take() else {
+            return;
+        };
+        let requests = self.requests.clone();
+        let _ = thread::Builder::new()
+            .name("account-store-shutdown".to_string())
+            .spawn(move || {
+                let _ = requests.blocking_send(WorkerRequest::Shutdown);
+                let _ = worker.join();
+            });
+    }
+}
+
+impl AccountStoreRuntimeGuard {
+    /// Drain every admitted update, stop the worker, and observe its exit.
+    pub(crate) fn shutdown(mut self) -> Result<()> {
+        self.requests
+            .blocking_send(WorkerRequest::Shutdown)
+            .map_err(|_| anyhow::anyhow!("Account store worker stopped before shutdown"))?;
+        if let Some(worker) = self.worker.take() {
+            worker
+                .join()
+                .map_err(|_| anyhow::anyhow!("Account store worker panicked"))?;
+        }
+        Ok(())
+    }
+}
+
+impl<Update, Output> ErasedUpdate for TypedUpdate<Update, Output>
+where
+    Output: Send + 'static,
+    Update: FnOnce(&mut AccountsStore) -> Result<Output> + Send + 'static,
+{
+    fn execute(
+        self: Box<Self>,
+        current: &mut AccountsStore,
+        snapshot: &RwLock<AccountsStore>,
+        path: &Path,
+    ) {
+        let mut candidate = current.clone();
+        let result = (self.update)(&mut candidate).and_then(|output| {
+            write_store_atomically(path, &candidate)?;
+            *current = candidate.clone();
+            let mut published = snapshot.write().map_err(|error| {
+                anyhow::anyhow!("Account store snapshot lock is poisoned: {error}")
+            })?;
+            *published = candidate;
+            Ok(output)
+        });
+        let _ = self.reply.send(result);
+    }
+}
+
+pub(crate) fn initialize_default_store(path: PathBuf) -> Result<AccountStoreRuntimeGuard> {
+    let (client, worker) = AccountStoreClient::open(path)?;
+    DEFAULT_CLIENT
+        .set(client)
+        .map_err(|_| anyhow::anyhow!("Account store is already initialized"))?;
+    worker.spawn()
+}
+
+pub(crate) fn default_client() -> Result<&'static AccountStoreClient> {
+    DEFAULT_CLIENT
+        .get()
+        .context("Account store is not initialized")
+}
+
+fn read_store(path: &Path) -> Result<AccountsStore> {
+    if !path.exists() {
+        return Ok(AccountsStore::default());
+    }
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read accounts file: {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse accounts file: {}", path.display()))
+}
+
+fn write_store_atomically(path: &Path, store: &AccountsStore) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("Accounts file has no parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
+
+    let content = serde_json::to_vec_pretty(store).context("Failed to serialize accounts store")?;
+    let mut temporary = NamedTempFile::new_in(parent).with_context(|| {
+        format!(
+            "Failed to create temporary accounts file in {}",
+            parent.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        temporary
+            .as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    temporary.write_all(&content)?;
+    temporary.as_file().sync_all()?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("Failed to replace accounts file: {}", path.display()))?;
+
+    #[cfg(unix)]
+    fs::File::open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn serializes_concurrent_updates_without_losing_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("accounts.json");
+        let (client, worker) = AccountStoreClient::open(path.clone()).unwrap();
+        let runtime = worker.spawn().unwrap();
+
+        let mut tasks = Vec::new();
+        for index in 0..32 {
+            let client = client.clone();
+            tasks.push(tokio::spawn(async move {
+                client
+                    .update(move |store| {
+                        store.masked_account_ids.push(format!("account-{index}"));
+                        Ok(())
+                    })
+                    .await
+                    .unwrap();
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        let store: AccountsStore =
+            serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(store.masked_account_ids.len(), 32);
+        drop(client);
+        drop(runtime);
+    }
+
+    #[tokio::test]
+    async fn executes_updates_on_the_guard_owned_worker_thread() {
+        let directory = tempfile::tempdir().unwrap();
+        let (client, worker) =
+            AccountStoreClient::open(directory.path().join("accounts.json")).unwrap();
+        let runtime = worker.spawn().unwrap();
+        let caller = thread::current().id();
+
+        let worker_thread = client.update(|_| Ok(thread::current().id())).await.unwrap();
+
+        assert_ne!(caller, worker_thread);
+        drop(client);
+        drop(runtime);
+    }
+}

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -1,5 +1,6 @@
 //! Authentication module
 
+mod account_store;
 pub mod oauth_server;
 pub mod storage;
 pub mod switcher;
@@ -9,3 +10,7 @@ pub use oauth_server::*;
 pub use storage::*;
 pub use switcher::*;
 pub use token_refresh::*;
+
+pub(crate) use account_store::{
+    default_client, initialize_default_store, AccountStoreRuntimeGuard,
+};

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 
+use super::{default_client, initialize_default_store, AccountStoreRuntimeGuard};
 use crate::types::{AccountsStore, AppSettings, AuthData, StoredAccount};
 
 /// Get the path to the codex-switcher config directory
@@ -23,21 +24,14 @@ pub fn get_settings_file() -> Result<PathBuf> {
     Ok(get_config_dir()?.join("settings.json"))
 }
 
-/// Load the accounts store from disk
+/// Start the sole account-store writer before serving UI or web requests.
+pub(crate) fn initialize_accounts() -> Result<AccountStoreRuntimeGuard> {
+    initialize_default_store(get_accounts_file()?)
+}
+
+/// Return the worker-published in-memory snapshot without disk I/O.
 pub fn load_accounts() -> Result<AccountsStore> {
-    let path = get_accounts_file()?;
-
-    if !path.exists() {
-        return Ok(AccountsStore::default());
-    }
-
-    let content = fs::read_to_string(&path)
-        .with_context(|| format!("Failed to read accounts file: {}", path.display()))?;
-
-    let store: AccountsStore = serde_json::from_str(&content)
-        .with_context(|| format!("Failed to parse accounts file: {}", path.display()))?;
-
-    Ok(store)
+    default_client()?.snapshot()
 }
 
 pub fn load_app_settings() -> Result<AppSettings> {
@@ -78,86 +72,63 @@ pub fn save_app_settings(settings: &AppSettings) -> Result<()> {
     Ok(())
 }
 
-/// Save the accounts store to disk
-pub fn save_accounts(store: &AccountsStore) -> Result<()> {
-    let path = get_accounts_file()?;
-
-    // Ensure the config directory exists
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create config directory: {}", parent.display()))?;
-    }
-
-    let content =
-        serde_json::to_string_pretty(store).context("Failed to serialize accounts store")?;
-
-    fs::write(&path, content)
-        .with_context(|| format!("Failed to write accounts file: {}", path.display()))?;
-
-    // Set restrictive permissions on Unix
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = fs::Permissions::from_mode(0o600);
-        fs::set_permissions(&path, perms)?;
-    }
-
-    Ok(())
+/// Apply one serialized mutation on the account-store worker.
+pub(crate) async fn update_accounts<Output, Update>(update: Update) -> Result<Output>
+where
+    Output: Send + 'static,
+    Update: FnOnce(&mut AccountsStore) -> Result<Output> + Send + 'static,
+{
+    default_client()?.update(update).await
 }
 
 /// Add a new account to the store
-pub fn add_account(account: StoredAccount) -> Result<StoredAccount> {
-    let mut store = load_accounts()?;
-
-    // Check for duplicate names
-    if store.accounts.iter().any(|a| a.name == account.name) {
-        anyhow::bail!("An account with name '{}' already exists", account.name);
-    }
-
-    let account_clone = account.clone();
-    store.accounts.push(account);
-
-    // If this is the first account, make it active
-    if store.accounts.len() == 1 {
-        store.active_account_id = Some(account_clone.id.clone());
-    }
-
-    save_accounts(&store)?;
-    Ok(account_clone)
+pub async fn add_account(account: StoredAccount) -> Result<StoredAccount> {
+    update_accounts(move |store| {
+        if store.accounts.iter().any(|a| a.name == account.name) {
+            anyhow::bail!("An account with name '{}' already exists", account.name);
+        }
+        let account_clone = account.clone();
+        store.accounts.push(account);
+        if store.accounts.len() == 1 {
+            store.active_account_id = Some(account_clone.id.clone());
+        }
+        Ok(account_clone)
+    })
+    .await
 }
 
 /// Remove an account by ID
-pub fn remove_account(account_id: &str) -> Result<()> {
-    let mut store = load_accounts()?;
-
-    let initial_len = store.accounts.len();
-    store.accounts.retain(|a| a.id != account_id);
-
-    if store.accounts.len() == initial_len {
-        anyhow::bail!("Account not found: {account_id}");
-    }
-
-    // If we removed the active account, clear it or set to first available
-    if store.active_account_id.as_deref() == Some(account_id) {
-        store.active_account_id = store.accounts.first().map(|a| a.id.clone());
-    }
-
-    save_accounts(&store)?;
-    Ok(())
+pub async fn remove_account(account_id: &str) -> Result<()> {
+    let account_id = account_id.to_string();
+    update_accounts(move |store| {
+        let initial_len = store.accounts.len();
+        store.accounts.retain(|a| a.id != account_id);
+        if store.accounts.len() == initial_len {
+            anyhow::bail!("Account not found: {account_id}");
+        }
+        if store.active_account_id.as_deref() == Some(account_id.as_str()) {
+            store.active_account_id = store.accounts.first().map(|a| a.id.clone());
+        }
+        Ok(())
+    })
+    .await
 }
 
-/// Update the active account ID
-pub fn set_active_account(account_id: &str) -> Result<()> {
-    let mut store = load_accounts()?;
-
-    // Verify the account exists
-    if !store.accounts.iter().any(|a| a.id == account_id) {
-        anyhow::bail!("Account not found: {account_id}");
-    }
-
-    store.active_account_id = Some(account_id.to_string());
-    save_accounts(&store)?;
-    Ok(())
+/// Activate an account and record its use in one durable update.
+pub async fn set_active_account(account_id: &str) -> Result<()> {
+    let account_id = account_id.to_string();
+    update_accounts(move |store| {
+        let account = store
+            .accounts
+            .iter_mut()
+            .find(|account| account.id == account_id)
+            .with_context(|| format!("Account not found: {account_id}"))?;
+        super::switch_to_account(account)?;
+        account.last_used_at = Some(Utc::now());
+        store.active_account_id = Some(account_id);
+        Ok(())
+    })
+    .await
 }
 
 /// Get an account by ID
@@ -176,69 +147,49 @@ pub fn get_active_account() -> Result<Option<StoredAccount>> {
     Ok(store.accounts.into_iter().find(|a| a.id == *active_id))
 }
 
-/// Update an account's last_used_at timestamp
-pub fn touch_account(account_id: &str) -> Result<()> {
-    let mut store = load_accounts()?;
-
-    if let Some(account) = store.accounts.iter_mut().find(|a| a.id == account_id) {
-        account.last_used_at = Some(chrono::Utc::now());
-        save_accounts(&store)?;
-    }
-
-    Ok(())
-}
-
 /// Update an account's metadata (name, email, plan_type, subscription expiry)
-pub fn update_account_metadata(
+pub async fn update_account_metadata(
     account_id: &str,
     name: Option<String>,
     email: Option<String>,
     plan_type: Option<String>,
     subscription_expires_at: Option<Option<DateTime<Utc>>>,
 ) -> Result<StoredAccount> {
-    let mut store = load_accounts()?;
-
-    // Check for duplicate names first (if renaming)
-    if let Some(ref new_name) = name {
-        if store
-            .accounts
-            .iter()
-            .any(|a| a.id != account_id && a.name == *new_name)
-        {
-            anyhow::bail!("An account with name '{new_name}' already exists");
+    let account_id = account_id.to_string();
+    update_accounts(move |store| {
+        if let Some(ref new_name) = name {
+            if store
+                .accounts
+                .iter()
+                .any(|a| a.id != account_id && a.name == *new_name)
+            {
+                anyhow::bail!("An account with name '{new_name}' already exists");
+            }
         }
-    }
-
-    // Now find and update the account
-    let account = store
-        .accounts
-        .iter_mut()
-        .find(|a| a.id == account_id)
-        .context("Account not found")?;
-
-    if let Some(new_name) = name {
-        account.name = new_name;
-    }
-
-    if email.is_some() {
-        account.email = email;
-    }
-
-    if plan_type.is_some() {
-        account.plan_type = plan_type;
-    }
-
-    if let Some(subscription_expires_at) = subscription_expires_at {
-        account.subscription_expires_at = subscription_expires_at;
-    }
-
-    let updated = account.clone();
-    save_accounts(&store)?;
-    Ok(updated)
+        let account = store
+            .accounts
+            .iter_mut()
+            .find(|a| a.id == account_id)
+            .context("Account not found")?;
+        if let Some(new_name) = name {
+            account.name = new_name;
+        }
+        if email.is_some() {
+            account.email = email;
+        }
+        if plan_type.is_some() {
+            account.plan_type = plan_type;
+        }
+        if let Some(subscription_expires_at) = subscription_expires_at {
+            account.subscription_expires_at = subscription_expires_at;
+        }
+        Ok(account.clone())
+    })
+    .await
 }
 
 /// Update ChatGPT OAuth tokens for an account and return the updated account.
-pub fn update_account_chatgpt_tokens(
+pub async fn update_account_chatgpt_tokens(
     account_id: &str,
     id_token: String,
     access_token: String,
@@ -248,48 +199,47 @@ pub fn update_account_chatgpt_tokens(
     plan_type: Option<String>,
     subscription_expires_at: Option<DateTime<Utc>>,
 ) -> Result<StoredAccount> {
-    let mut store = load_accounts()?;
-
-    let account = store
-        .accounts
-        .iter_mut()
-        .find(|a| a.id == account_id)
-        .context("Account not found")?;
-
-    match &mut account.auth_data {
-        AuthData::ChatGPT {
-            id_token: stored_id_token,
-            access_token: stored_access_token,
-            refresh_token: stored_refresh_token,
-            account_id: stored_account_id,
-        } => {
-            *stored_id_token = id_token;
-            *stored_access_token = access_token;
-            *stored_refresh_token = refresh_token;
-            if let Some(new_account_id) = chatgpt_account_id {
-                *stored_account_id = Some(new_account_id);
+    let account_id = account_id.to_string();
+    update_accounts(move |store| {
+        let is_active = store.active_account_id.as_deref() == Some(account_id.as_str());
+        let account = store
+            .accounts
+            .iter_mut()
+            .find(|a| a.id == account_id)
+            .context("Account not found")?;
+        match &mut account.auth_data {
+            AuthData::ChatGPT {
+                id_token: stored_id_token,
+                access_token: stored_access_token,
+                refresh_token: stored_refresh_token,
+                account_id: stored_account_id,
+            } => {
+                *stored_id_token = id_token;
+                *stored_access_token = access_token;
+                *stored_refresh_token = refresh_token;
+                if let Some(new_account_id) = chatgpt_account_id {
+                    *stored_account_id = Some(new_account_id);
+                }
+            }
+            AuthData::ApiKey { .. } => {
+                anyhow::bail!("Cannot update OAuth tokens for an API key account");
             }
         }
-        AuthData::ApiKey { .. } => {
-            anyhow::bail!("Cannot update OAuth tokens for an API key account");
+        if let Some(new_email) = email {
+            account.email = Some(new_email);
         }
-    }
-
-    if let Some(new_email) = email {
-        account.email = Some(new_email);
-    }
-
-    if let Some(new_plan_type) = plan_type {
-        account.plan_type = Some(new_plan_type);
-    }
-
-    if let Some(subscription_expires_at) = subscription_expires_at {
-        account.subscription_expires_at = Some(subscription_expires_at);
-    }
-
-    let updated = account.clone();
-    save_accounts(&store)?;
-    Ok(updated)
+        if let Some(new_plan_type) = plan_type {
+            account.plan_type = Some(new_plan_type);
+        }
+        if let Some(subscription_expires_at) = subscription_expires_at {
+            account.subscription_expires_at = Some(subscription_expires_at);
+        }
+        if is_active {
+            super::switch_to_account(account)?;
+        }
+        Ok(account.clone())
+    })
+    .await
 }
 
 /// Get the list of masked account IDs
@@ -299,9 +249,10 @@ pub fn get_masked_account_ids() -> Result<Vec<String>> {
 }
 
 /// Set the list of masked account IDs
-pub fn set_masked_account_ids(ids: Vec<String>) -> Result<()> {
-    let mut store = load_accounts()?;
-    store.masked_account_ids = ids;
-    save_accounts(&store)?;
-    Ok(())
+pub async fn set_masked_account_ids(ids: Vec<String>) -> Result<()> {
+    update_accounts(move |store| {
+        store.masked_account_ids = ids;
+        Ok(())
+    })
+    .await
 }

--- a/src-tauri/src/auth/token_refresh.rs
+++ b/src-tauri/src/auth/token_refresh.rs
@@ -5,7 +5,7 @@ use base64::Engine;
 use chrono::Utc;
 use tokio::time::{sleep, Duration};
 
-use super::{load_accounts, switch_to_account, update_account_chatgpt_tokens};
+use super::update_account_chatgpt_tokens;
 use crate::types::{parse_chatgpt_id_token_claims, AuthData, StoredAccount};
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
@@ -65,8 +65,6 @@ pub async fn refresh_chatgpt_tokens(account: &StoredAccount) -> Result<StoredAcc
     let claims = parse_chatgpt_id_token_claims(&next_id_token);
     let next_account_id = claims.account_id.or(current_account_id);
 
-    let is_active = load_accounts()?.active_account_id.as_deref() == Some(account.id.as_str());
-
     let updated = update_account_chatgpt_tokens(
         &account.id,
         next_id_token,
@@ -76,14 +74,8 @@ pub async fn refresh_chatgpt_tokens(account: &StoredAccount) -> Result<StoredAcc
         claims.email,
         claims.plan_type,
         claims.subscription_expires_at,
-    )?;
-
-    // Keep ~/.codex/auth.json in sync when this is the active account.
-    if is_active {
-        if let Err(err) = switch_to_account(&updated) {
-            println!("[Auth] Failed to sync active auth.json after token refresh: {err}");
-        }
-    }
+    )
+    .await?;
 
     Ok(updated)
 }

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -3,7 +3,7 @@
 use crate::auth::{
     add_account, create_chatgpt_account_from_refresh_token, get_active_account,
     import_from_auth_json, import_from_auth_json_contents, load_accounts, remove_account,
-    save_accounts, set_active_account, switch_to_account, touch_account,
+    set_active_account, update_accounts,
 };
 use crate::types::{AccountInfo, AccountsStore, AuthData, ImportAccountsSummary, StoredAccount};
 
@@ -103,7 +103,7 @@ pub async fn add_account_from_file(path: String, name: String) -> Result<Account
     let account = import_from_auth_json(&path, name).map_err(|e| e.to_string())?;
 
     // Add to storage
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let stored = add_account(account).await.map_err(|e| e.to_string())?;
 
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();
@@ -117,7 +117,7 @@ pub async fn add_account_from_auth_json_text(
     contents: String,
 ) -> Result<AccountInfo, String> {
     let account = import_from_auth_json_contents(&contents, name).map_err(|e| e.to_string())?;
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let stored = add_account(account).await.map_err(|e| e.to_string())?;
 
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();
@@ -128,29 +128,16 @@ pub async fn add_account_from_auth_json_text(
 /// Switch to a different account
 #[tauri::command]
 pub async fn switch_account(account_id: String) -> Result<(), String> {
-    switch_account_by_id(&account_id)
+    switch_account_by_id(&account_id).await
 }
 
-pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
-    let store = load_accounts().map_err(|e| e.to_string())?;
-
-    // Find the account
-    let account = store
-        .accounts
-        .iter()
-        .find(|a| a.id == account_id)
-        .ok_or_else(|| format!("Account not found: {account_id}"))?;
-
+pub async fn switch_account_by_id(account_id: &str) -> Result<(), String> {
     ensure_codex_not_running()?;
 
-    // Write to ~/.codex/auth.json
-    switch_to_account(account).map_err(|e| e.to_string())?;
-
-    // Update the active account in our store
-    set_active_account(account_id).map_err(|e| e.to_string())?;
-
-    // Update last_used_at
-    touch_account(account_id).map_err(|e| e.to_string())?;
+    // Update the active account and auth.json through the ordered store worker.
+    set_active_account(account_id)
+        .await
+        .map_err(|e| e.to_string())?;
 
     // Restart Antigravity background process if it is running
     // This allows it to pick up the new authorization file seamlessly
@@ -178,7 +165,9 @@ pub fn switch_account_by_id(account_id: &str) -> Result<(), String> {
 /// Remove an account
 #[tauri::command]
 pub async fn delete_account(account_id: String) -> Result<(), String> {
-    remove_account(&account_id).map_err(|e| e.to_string())?;
+    remove_account(&account_id)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok(())
 }
 
@@ -186,6 +175,7 @@ pub async fn delete_account(account_id: String) -> Result<(), String> {
 #[tauri::command]
 pub async fn rename_account(account_id: String, new_name: String) -> Result<(), String> {
     crate::auth::storage::update_account_metadata(&account_id, Some(new_name), None, None, None)
+        .await
         .map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -216,8 +206,13 @@ pub async fn import_accounts_slim_text(payload: String) -> Result<ImportAccounts
         })?;
     validate_imported_store(&imported).map_err(|e| format!("{e:#}"))?;
 
-    let (merged, summary) = merge_accounts_store(current, imported);
-    save_accounts(&merged).map_err(|e| e.to_string())?;
+    let summary = update_accounts(move |current| {
+        let (merged, summary) = merge_accounts_store(current.clone(), imported);
+        *current = merged;
+        Ok(summary)
+    })
+    .await
+    .map_err(|e| e.to_string())?;
     Ok(ImportAccountsSummary {
         total_in_payload,
         imported_count: summary.imported_count,
@@ -251,10 +246,13 @@ pub async fn import_accounts_full_encrypted_file(
         .map_err(|e| e.to_string())?;
     validate_imported_store(&imported).map_err(|e| e.to_string())?;
 
-    let current = load_accounts().map_err(|e| e.to_string())?;
-    let (merged, summary) = merge_accounts_store(current, imported);
-    save_accounts(&merged).map_err(|e| e.to_string())?;
-    Ok(summary)
+    update_accounts(move |current| {
+        let (merged, summary) = merge_accounts_store(current.clone(), imported);
+        *current = merged;
+        Ok(summary)
+    })
+    .await
+    .map_err(|e| e.to_string())
 }
 
 /// Import full account config from encrypted bytes uploaded through the browser UI.
@@ -265,10 +263,13 @@ pub async fn import_accounts_full_encrypted_bytes(
         decode_full_encrypted_store(&bytes, FULL_PRESET_PASSPHRASE).map_err(|e| e.to_string())?;
     validate_imported_store(&imported).map_err(|e| e.to_string())?;
 
-    let current = load_accounts().map_err(|e| e.to_string())?;
-    let (merged, summary) = merge_accounts_store(current, imported);
-    save_accounts(&merged).map_err(|e| e.to_string())?;
-    Ok(summary)
+    update_accounts(move |current| {
+        let (merged, summary) = merge_accounts_store(current.clone(), imported);
+        *current = merged;
+        Ok(summary)
+    })
+    .await
+    .map_err(|e| e.to_string())
 }
 
 /// Find all running Antigravity codex assistant processes
@@ -742,5 +743,7 @@ pub async fn get_masked_account_ids() -> Result<Vec<String>, String> {
 /// Set the list of masked account IDs
 #[tauri::command]
 pub async fn set_masked_account_ids(ids: Vec<String>) -> Result<(), String> {
-    crate::auth::storage::set_masked_account_ids(ids).map_err(|e| e.to_string())
+    crate::auth::storage::set_masked_account_ids(ids)
+        .await
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -5,9 +5,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 
 use crate::auth::oauth_server::{start_oauth_login, wait_for_oauth_login, OAuthLoginResult};
-use crate::auth::{
-    add_account, load_accounts, set_active_account, switch_to_account, touch_account,
-};
+use crate::auth::{add_account, load_accounts, set_active_account};
 use crate::types::{AccountInfo, OAuthLoginInfo};
 
 struct PendingOAuth {
@@ -57,13 +55,12 @@ pub async fn complete_login() -> Result<AccountInfo, String> {
         .map_err(|e| e.to_string())?;
 
     // Add the account to storage
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let stored = add_account(account).await.map_err(|e| e.to_string())?;
 
     // Make it active and switch to it
-    set_active_account(&stored.id).map_err(|e| e.to_string())?;
-    switch_to_account(&stored).map_err(|e| e.to_string())?;
-    touch_account(&stored.id).map_err(|e| e.to_string())?;
-
+    set_active_account(&stored.id)
+        .await
+        .map_err(|e| e.to_string())?;
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();
 

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -57,6 +57,7 @@ pub async fn refresh_account_metadata(account_id: String) -> Result<AccountInfo,
                 live_metadata.plan_type,
                 Some(live_metadata.subscription_expires_at),
             )
+            .await
             .map_err(|e| e.to_string())?
         }
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,8 @@ use tauri::Emitter;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    let account_store_runtime =
+        auth::initialize_accounts().expect("failed to initialize account store");
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
@@ -107,4 +109,7 @@ pub fn run() {
                 commands::restore_main_window(_app);
             }
         });
+    account_store_runtime
+        .shutdown()
+        .expect("failed to shut down account store");
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -259,24 +259,25 @@ fn handle_menu_event(app: &AppHandle, event: tauri::menu::MenuEvent) {
                 return;
             }
 
-            if let Err(error) = switch_account_by_id(account_id) {
-                eprintln!("Failed to switch account from tray: {error}");
-                refresh_menu(app);
-                if is_codex_running_switch_block(&error) {
-                    show_main_window(app);
-                    let _ = app.emit(
-                        SWITCH_ACCOUNT_BLOCKED_EVENT,
-                        SwitchAccountBlockedPayload {
-                            account_id: account_id.to_string(),
-                            error,
-                        },
-                    );
+            let app = app.clone();
+            let account_id = account_id.to_string();
+            tauri::async_runtime::spawn(async move {
+                if let Err(error) = switch_account_by_id(&account_id).await {
+                    eprintln!("Failed to switch account from tray: {error}");
+                    refresh_menu(&app);
+                    if is_codex_running_switch_block(&error) {
+                        show_main_window(&app);
+                        let _ = app.emit(
+                            SWITCH_ACCOUNT_BLOCKED_EVENT,
+                            SwitchAccountBlockedPayload { account_id, error },
+                        );
+                    }
+                    return;
                 }
-                return;
-            }
 
-            refresh_menu(app);
-            let _ = app.emit(ACCOUNTS_CHANGED_EVENT, ());
+                refresh_menu(&app);
+                let _ = app.emit(ACCOUNTS_CHANGED_EVENT, ());
+            });
         }
     }
 }

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -72,6 +72,7 @@ struct FileImportArgs {
 }
 
 pub fn run_lan_server(host: &str, port: u16) -> anyhow::Result<()> {
+    let account_store_runtime = crate::auth::initialize_accounts()?;
     let address = format!("{host}:{port}");
     let server = Server::http(&address)
         .map_err(|err| anyhow::anyhow!("Failed to bind HTTP server on {address}: {err}"))?;
@@ -89,6 +90,7 @@ pub fn run_lan_server(host: &str, port: u16) -> anyhow::Result<()> {
         }
     }
 
+    account_store_runtime.shutdown()?;
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #100.

## Summary

- route every `accounts.json` mutation through one bounded, guard-owned worker
- persist updates with same-directory atomic replacement instead of concurrent `fs::write` calls
- keep disk I/O off the UI/runtime thread and publish read-only in-memory snapshots
- serialize account selection and active-account token refresh so stale refresh state cannot overwrite `auth.json`
- close update admission and drain accepted writes during desktop or standalone web shutdown

## Why

The Refresh flow launches concurrent metadata and token updates. Each update previously performed its own load-modify-write sequence against `accounts.json`, so writes could race and leave valid JSON followed by a stale duplicated suffix. That makes subsequent refreshes fail with `Failed to parse accounts file`.

The same stale-state pattern also allowed an in-flight token refresh to rewrite `~/.codex/auth.json` for an account that was no longer active.

## Scope

This keeps the existing desktop and optional `codex-web` entrypoints. Each gets the same single-writer behavior when run independently. Coordinating simultaneous desktop and web processes is intentionally out of scope for this fix.

## Validation

- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml` (37 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets` (passes with existing warnings)
- `pnpm build`
- `pnpm tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'`
- `git diff --check`

New tests exercise concurrent account updates and confirm mutations execute on the dedicated worker thread.
