### PR TITLE
fix: allow re-authenticating an existing account

### DIFF
--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -105,25 +105,105 @@ pub fn save_accounts(store: &AccountsStore) -> Result<()> {
     Ok(())
 }
 
-/// Add a new account to the store
-pub fn add_account(account: StoredAccount) -> Result<StoredAccount> {
-    let mut store = load_accounts()?;
+fn insert_or_replace_account(
+    store: &mut AccountsStore,
+    mut account: StoredAccount,
+    overwrite_existing: bool,
+) -> Result<StoredAccount> {
+    if let Some(existing) = store
+        .accounts
+        .iter_mut()
+        .find(|existing| existing.name == account.name)
+    {
+        if !overwrite_existing {
+            anyhow::bail!("An account with name '{}' already exists", account.name);
+        }
 
-    // Check for duplicate names
-    if store.accounts.iter().any(|a| a.name == account.name) {
-        anyhow::bail!("An account with name '{}' already exists", account.name);
+        // Keep the stable local identity so active-account and masking references remain valid.
+        account.id = existing.id.clone();
+        account.created_at = existing.created_at;
+        account.last_used_at = existing.last_used_at;
+        *existing = account.clone();
+        return Ok(account);
     }
 
     let account_clone = account.clone();
     store.accounts.push(account);
 
-    // If this is the first account, make it active
+    // If this is the first account, make it active.
     if store.accounts.len() == 1 {
         store.active_account_id = Some(account_clone.id.clone());
     }
 
-    save_accounts(&store)?;
     Ok(account_clone)
+}
+
+/// Add a new account, or explicitly replace an account with the same name.
+pub fn add_account(account: StoredAccount, overwrite_existing: bool) -> Result<StoredAccount> {
+    let mut store = load_accounts()?;
+    let stored = insert_or_replace_account(&mut store, account, overwrite_existing)?;
+    save_accounts(&store)?;
+    Ok(stored)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::insert_or_replace_account;
+    use crate::types::{AccountsStore, StoredAccount};
+
+    fn account(name: &str, key: &str) -> StoredAccount {
+        StoredAccount::new_api_key(name.to_string(), key.to_string())
+    }
+
+    #[test]
+    fn duplicate_name_is_rejected_without_explicit_overwrite() {
+        let existing = account("Work", "old-key");
+        let mut store = AccountsStore {
+            accounts: vec![existing.clone()],
+            active_account_id: Some(existing.id.clone()),
+            masked_account_ids: vec![existing.id.clone()],
+            ..AccountsStore::default()
+        };
+
+        let error = insert_or_replace_account(&mut store, account("Work", "new-key"), false)
+            .expect_err("duplicate name should require confirmation");
+
+        assert!(error.to_string().contains("already exists"));
+        assert_eq!(store.accounts.len(), 1);
+        assert_eq!(store.accounts[0].id, existing.id);
+    }
+
+    #[test]
+    fn explicit_overwrite_preserves_local_account_identity() {
+        let mut existing = account("Work", "old-key");
+        existing.last_used_at = Some(chrono::Utc::now());
+        let existing_id = existing.id.clone();
+        let existing_created_at = existing.created_at;
+        let existing_last_used_at = existing.last_used_at;
+        let mut store = AccountsStore {
+            accounts: vec![existing],
+            active_account_id: Some(existing_id.clone()),
+            masked_account_ids: vec![existing_id.clone()],
+            ..AccountsStore::default()
+        };
+
+        let replacement = insert_or_replace_account(&mut store, account("Work", "new-key"), true)
+            .expect("confirmed replacement should succeed");
+
+        assert_eq!(store.accounts.len(), 1);
+        assert_eq!(replacement.id, existing_id);
+        assert_eq!(replacement.created_at, existing_created_at);
+        assert_eq!(replacement.last_used_at, existing_last_used_at);
+        assert_eq!(
+            store.active_account_id.as_deref(),
+            Some(existing_id.as_str())
+        );
+        assert_eq!(store.masked_account_ids, vec![existing_id]);
+        match replacement.auth_data {
+            crate::types::AuthData::ApiKey { key } => assert_eq!(key, "new-key"),
+            _ => panic!("expected API key account"),
+        }
+    }
 }
 
 /// Remove an account by ID

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -149,15 +149,24 @@ pub fn add_account(account: StoredAccount, overwrite_existing: bool) -> Result<S
 #[cfg(test)]
 mod tests {
     use super::insert_or_replace_account;
-    use crate::types::{AccountsStore, StoredAccount};
+    use crate::types::{AccountsStore, AuthData, StoredAccount};
 
-    fn account(name: &str, key: &str) -> StoredAccount {
-        StoredAccount::new_api_key(name.to_string(), key.to_string())
+    fn account(name: &str, token_suffix: &str) -> StoredAccount {
+        StoredAccount::new_chatgpt(
+            name.to_string(),
+            Some(format!("{token_suffix}@example.com")),
+            Some("plus".to_string()),
+            None,
+            format!("id-{token_suffix}"),
+            format!("access-{token_suffix}"),
+            format!("refresh-{token_suffix}"),
+            Some(format!("account-{token_suffix}")),
+        )
     }
 
     #[test]
     fn duplicate_name_is_rejected_without_explicit_overwrite() {
-        let existing = account("Work", "old-key");
+        let existing = account("Work", "old");
         let mut store = AccountsStore {
             accounts: vec![existing.clone()],
             active_account_id: Some(existing.id.clone()),
@@ -165,7 +174,7 @@ mod tests {
             ..AccountsStore::default()
         };
 
-        let error = insert_or_replace_account(&mut store, account("Work", "new-key"), false)
+        let error = insert_or_replace_account(&mut store, account("Work", "new"), false)
             .expect_err("duplicate name should require confirmation");
 
         assert!(error.to_string().contains("already exists"));
@@ -175,7 +184,7 @@ mod tests {
 
     #[test]
     fn explicit_overwrite_preserves_local_account_identity() {
-        let mut existing = account("Work", "old-key");
+        let mut existing = account("Work", "old");
         existing.last_used_at = Some(chrono::Utc::now());
         let existing_id = existing.id.clone();
         let existing_created_at = existing.created_at;
@@ -187,7 +196,7 @@ mod tests {
             ..AccountsStore::default()
         };
 
-        let replacement = insert_or_replace_account(&mut store, account("Work", "new-key"), true)
+        let replacement = insert_or_replace_account(&mut store, account("Work", "new"), true)
             .expect("confirmed replacement should succeed");
 
         assert_eq!(store.accounts.len(), 1);
@@ -199,9 +208,17 @@ mod tests {
             Some(existing_id.as_str())
         );
         assert_eq!(store.masked_account_ids, vec![existing_id]);
+        assert_eq!(replacement.email.as_deref(), Some("new@example.com"));
         match replacement.auth_data {
-            crate::types::AuthData::ApiKey { key } => assert_eq!(key, "new-key"),
-            _ => panic!("expected API key account"),
+            AuthData::ChatGPT {
+                access_token,
+                refresh_token,
+                ..
+            } => {
+                assert_eq!(access_token, "access-new");
+                assert_eq!(refresh_token, "refresh-new");
+            }
+            _ => panic!("expected ChatGPT account"),
         }
     }
 }

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -98,12 +98,17 @@ pub async fn get_active_account_info() -> Result<Option<AccountInfo>, String> {
 
 /// Add an account from an auth.json file
 #[tauri::command]
-pub async fn add_account_from_file(path: String, name: String) -> Result<AccountInfo, String> {
+pub async fn add_account_from_file(
+    path: String,
+    name: String,
+    overwrite_existing: Option<bool>,
+) -> Result<AccountInfo, String> {
     // Import from the file
     let account = import_from_auth_json(&path, name).map_err(|e| e.to_string())?;
 
     // Add to storage
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let stored =
+        add_account(account, overwrite_existing.unwrap_or(false)).map_err(|e| e.to_string())?;
 
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();
@@ -115,9 +120,11 @@ pub async fn add_account_from_file(path: String, name: String) -> Result<Account
 pub async fn add_account_from_auth_json_text(
     name: String,
     contents: String,
+    overwrite_existing: Option<bool>,
 ) -> Result<AccountInfo, String> {
     let account = import_from_auth_json_contents(&contents, name).map_err(|e| e.to_string())?;
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let stored =
+        add_account(account, overwrite_existing.unwrap_or(false)).map_err(|e| e.to_string())?;
 
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -13,6 +13,7 @@ use crate::types::{AccountInfo, OAuthLoginInfo};
 struct PendingOAuth {
     rx: oneshot::Receiver<anyhow::Result<OAuthLoginResult>>,
     cancelled: Arc<AtomicBool>,
+    overwrite_existing: bool,
 }
 
 // Global state for pending OAuth login
@@ -20,7 +21,10 @@ static PENDING_OAUTH: Mutex<Option<PendingOAuth>> = Mutex::new(None);
 
 /// Start the OAuth login flow
 #[tauri::command]
-pub async fn start_login(account_name: String) -> Result<OAuthLoginInfo, String> {
+pub async fn start_login(
+    account_name: String,
+    overwrite_existing: Option<bool>,
+) -> Result<OAuthLoginInfo, String> {
     // Cancel any previous pending flow so it does not keep the callback port occupied.
     if let Some(previous) = {
         let mut pending = PENDING_OAUTH.lock().unwrap();
@@ -36,7 +40,11 @@ pub async fn start_login(account_name: String) -> Result<OAuthLoginInfo, String>
     // Store the receiver for later
     {
         let mut pending = PENDING_OAUTH.lock().unwrap();
-        *pending = Some(PendingOAuth { rx, cancelled });
+        *pending = Some(PendingOAuth {
+            rx,
+            cancelled,
+            overwrite_existing: overwrite_existing.unwrap_or(false),
+        });
     }
 
     Ok(info)
@@ -57,7 +65,7 @@ pub async fn complete_login() -> Result<AccountInfo, String> {
         .map_err(|e| e.to_string())?;
 
     // Add the account to storage
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let stored = add_account(account, pending.overwrite_existing).map_err(|e| e.to_string())?;
 
     // Make it active and switch to it
     set_active_account(&stored.id).map_err(|e| e.to_string())?;

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -40,6 +40,8 @@ struct RenameAccountArgs {
 struct LoginArgs {
     #[serde(alias = "account_name")]
     account_name: String,
+    #[serde(default, alias = "overwrite_existing")]
+    overwrite_existing: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -56,6 +58,8 @@ struct MaskedIdsArgs {
 struct UploadAuthJsonArgs {
     name: String,
     contents: String,
+    #[serde(default, alias = "overwrite_existing", alias = "overwriteExisting")]
+    overwrite_existing: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,6 +73,8 @@ struct UploadEncryptedArgs {
 struct FileImportArgs {
     path: String,
     name: String,
+    #[serde(default, alias = "overwrite_existing", alias = "overwriteExisting")]
+    overwrite_existing: bool,
 }
 
 pub fn run_lan_server(host: &str, port: u16) -> anyhow::Result<()> {
@@ -132,11 +138,20 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         "get_active_account_info" => to_json(get_active_account_info().await?),
         "add_account_from_file" => {
             let args: FileImportArgs = parse_args(payload)?;
-            to_json(add_account_from_file(args.path, args.name).await?)
+            to_json(
+                add_account_from_file(args.path, args.name, Some(args.overwrite_existing)).await?,
+            )
         }
         "add_account_from_auth_json_text" => {
             let args: UploadAuthJsonArgs = parse_args(payload)?;
-            to_json(add_account_from_auth_json_text(args.name, args.contents).await?)
+            to_json(
+                add_account_from_auth_json_text(
+                    args.name,
+                    args.contents,
+                    Some(args.overwrite_existing),
+                )
+                .await?,
+            )
         }
         "get_usage" => {
             let args: AccountIdArgs = parse_args(payload)?;
@@ -170,7 +185,7 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         }
         "start_login" => {
             let args: LoginArgs = parse_args(payload)?;
-            to_json(start_login(args.account_name).await?)
+            to_json(start_login(args.account_name, Some(args.overwrite_existing)).await?)
         }
         "complete_login" => to_json(complete_login().await?),
         "cancel_login" => to_json(cancel_login().await?),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1916,6 +1916,7 @@ function App() {
       {/* Add Account Modal */}
       <AddAccountModal
         isOpen={isAddModalOpen}
+        existingAccountNames={accounts.map((account) => account.name)}
         onClose={() => setIsAddModalOpen(false)}
         onImportFile={importFromFile}
         onStartOAuth={startOAuthLogin}

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -9,9 +9,10 @@ import {
 
 interface AddAccountModalProps {
   isOpen: boolean;
+  existingAccountNames: string[];
   onClose: () => void;
-  onImportFile: (source: FileSource, name: string) => Promise<void>;
-  onStartOAuth: (name: string) => Promise<{ auth_url: string }>;
+  onImportFile: (source: FileSource, name: string, overwriteExisting: boolean) => Promise<void>;
+  onStartOAuth: (name: string, overwriteExisting: boolean) => Promise<{ auth_url: string }>;
   onCompleteOAuth: () => Promise<unknown>;
   onCancelOAuth: () => Promise<void>;
 }
@@ -20,6 +21,7 @@ type Tab = "oauth" | "import";
 
 export function AddAccountModal({
   isOpen,
+  existingAccountNames,
   onClose,
   onImportFile,
   onStartOAuth,
@@ -36,6 +38,16 @@ export function AddAccountModal({
   const [copied, setCopied] = useState<boolean>(false);
   const isPrimaryDisabled = loading || (activeTab === "oauth" && oauthPending);
   const tauriRuntime = isTauriRuntime();
+
+  const confirmOverwrite = (trimmedName: string): boolean | null => {
+    if (!trimmedName || !existingAccountNames.includes(trimmedName)) return false;
+
+    return window.confirm(
+      `An account named "${trimmedName}" already exists. Replace its saved authorization?`
+    )
+      ? true
+      : null;
+  };
 
   const resetForm = () => {
     setName("");
@@ -55,10 +67,14 @@ export function AddAccountModal({
   };
 
   const handleOAuthLogin = async () => {
+    const trimmedName = name.trim();
+    const overwriteExisting = confirmOverwrite(trimmedName);
+    if (overwriteExisting === null) return;
+
     try {
       setLoading(true);
       setError(null);
-      const info = await onStartOAuth(name.trim());
+      const info = await onStartOAuth(trimmedName, overwriteExisting);
       setAuthUrl(info.auth_url);
       setOauthPending(true);
       setLoading(false);
@@ -88,10 +104,14 @@ export function AddAccountModal({
       return;
     }
 
+    const trimmedName = name.trim();
+    const overwriteExisting = confirmOverwrite(trimmedName);
+    if (overwriteExisting === null) return;
+
     try {
       setLoading(true);
       setError(null);
-      await onImportFile(fileSource, name.trim());
+      await onImportFile(fileSource, trimmedName, overwriteExisting);
       handleClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -268,15 +268,20 @@ export function useAccounts() {
   );
 
   const importFromFile = useCallback(
-    async (source: FileSource, name: string) => {
+    async (source: FileSource, name: string, overwriteExisting: boolean) => {
       try {
         if (typeof source === "string") {
-          await invokeBackend<AccountInfo>("add_account_from_file", { path: source, name });
+          await invokeBackend<AccountInfo>("add_account_from_file", {
+            path: source,
+            name,
+            overwriteExisting,
+          });
         } else {
           const contents = await source.text();
           await invokeBackend<AccountInfo>("add_account_from_auth_json_text", {
             name,
             contents,
+            overwriteExisting,
           });
         }
         const accountList = await loadAccounts();
@@ -288,11 +293,11 @@ export function useAccounts() {
     [loadAccounts, refreshUsage]
   );
 
-  const startOAuthLogin = useCallback(async (accountName: string) => {
+  const startOAuthLogin = useCallback(async (accountName: string, overwriteExisting: boolean) => {
     try {
       const info = await invokeBackend<{ auth_url: string; callback_port: number }>(
         "start_login",
-        { accountName }
+        { accountName, overwriteExisting }
       );
       return info;
     } catch (err) {


### PR DESCRIPTION
Fixes #119.

When you try to log in or import an `auth.json` using a name that is already in the list, the app now asks before replacing it.

If you confirm, it keeps the existing local account entry (including its ID, masking, and timestamps) and replaces the account details and authorization. Cancelling leaves everything untouched. The backend also still rejects duplicates unless the replacement was explicitly confirmed.

I added regression tests for both paths: rejecting an unconfirmed duplicate and refreshing a confirmed ChatGPT account in place.

## Testing

- `pnpm build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- I could not run `cargo test` locally because this Windows environment does not have the MSVC linker (`link.exe`) installed.
