### PR TITLE
fix: reconcile live auth and improve release UX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
         description: 'Version tag (e.g., v1.0.0)'
         required: true
         type: string
+      release_note:
+        description: 'Short release note shown in the update prompt'
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -37,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -72,6 +78,24 @@ jobs:
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Determine release note
+        id: release_note
+        shell: bash
+        env:
+          INPUT_RELEASE_NOTE: ${{ inputs.release_note }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            note="$INPUT_RELEASE_NOTE"
+          else
+            note="$(git tag --list --format='%(contents)' "$RELEASE_TAG")"
+          fi
+          {
+            echo 'note<<RELEASE_NOTE_EOF'
+            echo "$note"
+            echo 'RELEASE_NOTE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and release
         uses: tauri-apps/tauri-action@v0
         env:
@@ -81,6 +105,7 @@ jobs:
         with:
           tagName: ${{ steps.tag.outputs.tag }}
           releaseName: ${{ steps.tag.outputs.tag }}
+          releaseBody: ${{ steps.release_note.outputs.note }}
           generateReleaseNotes: true
           releaseDraft: false
           prerelease: false

--- a/README.md
+++ b/README.md
@@ -200,10 +200,13 @@ pnpm version:minor
 pnpm version:major
 
 # Prepare a release commit and tag
-# This automatically runs the version bump first.
+# This prompts for a short release note and runs the version bump first.
 pnpm release patch
 
 # Prepare and push a release
-# This automatically runs the version bump first.
+# The tag stores the release note for the in-app update prompt.
 pnpm release patch -- --push
+
+# For non-interactive use, pass the note explicitly.
+pnpm release patch -- --push --note "Fixed account switching issues"
 ```

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,14 +1,42 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { createInterface } from "node:readline/promises";
 
 const root = process.cwd();
 const input = process.argv[2];
 const shouldPush = process.argv.includes("--push");
+const noteFlagIndex = process.argv.indexOf("--note");
+const noteFlagValue = noteFlagIndex === -1 ? undefined : process.argv[noteFlagIndex + 1];
+
+if (noteFlagIndex !== -1 && (!noteFlagValue || noteFlagValue.startsWith("--"))) {
+  console.error('--note requires a value, for example: --note "Fixed account switching".');
+  process.exit(1);
+}
+
+let releaseNote = noteFlagValue?.trim() ?? "";
 
 if (!input) {
-  console.error("Usage: node scripts/release.mjs <version|major|minor|patch> [--push]");
+  console.error(
+    "Usage: node scripts/release.mjs <version|major|minor|patch> [--push] [--note \"short note\"]",
+  );
   process.exit(1);
+}
+
+if (!releaseNote) {
+  if (!process.stdin.isTTY) {
+    console.error("A release note is required. Pass it with --note \"short note\".");
+    process.exit(1);
+  }
+
+  const prompt = createInterface({ input: process.stdin, output: process.stdout });
+  releaseNote = (await prompt.question("Short release note: ")).trim();
+  prompt.close();
+
+  if (!releaseNote) {
+    console.error("Release note cannot be empty.");
+    process.exit(1);
+  }
 }
 
 const VERSION_FILES = [
@@ -105,7 +133,7 @@ assertVersionsMatch(nextVersion);
 
 run("git", ["add", ...VERSION_FILES]);
 run("git", ["commit", "-m", `chore: release ${nextVersion}`]);
-run("git", ["tag", "-a", `v${nextVersion}`, "-m", `v${nextVersion}`]);
+run("git", ["tag", "-a", `v${nextVersion}`, "-m", releaseNote]);
 
 console.log(`Created commit and tag for v${nextVersion}.`);
 

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -34,17 +34,25 @@ pub fn sync_active_account_tokens(store: &mut AccountsStore, auth: &AuthDotJson)
         return false;
     };
 
+    let stored_account_id = parse_chatgpt_id_token_claims(id_token)
+        .account_id
+        .or_else(|| account_id.clone());
     let current_account_id = parse_chatgpt_id_token_claims(&tokens.id_token)
         .account_id
         .or_else(|| tokens.account_id.clone());
-    if account_id.is_some() && account_id.as_ref() != current_account_id.as_ref() {
+    let (Some(stored_account_id), Some(current_account_id)) =
+        (stored_account_id, current_account_id)
+    else {
+        return false;
+    };
+    if stored_account_id != current_account_id {
         return false;
     }
 
     let changed = *id_token != tokens.id_token
         || *access_token != tokens.access_token
         || *refresh_token != tokens.refresh_token
-        || (current_account_id.is_some() && *account_id != current_account_id);
+        || account_id.as_ref() != Some(&current_account_id);
     if !changed {
         return false;
     }
@@ -52,9 +60,7 @@ pub fn sync_active_account_tokens(store: &mut AccountsStore, auth: &AuthDotJson)
     id_token.clone_from(&tokens.id_token);
     access_token.clone_from(&tokens.access_token);
     refresh_token.clone_from(&tokens.refresh_token);
-    if current_account_id.is_some() {
-        account_id.clone_from(&current_account_id);
-    }
+    *account_id = Some(current_account_id);
     true
 }
 
@@ -395,6 +401,13 @@ mod tests {
         }
     }
 
+    fn id_token_with_account_id(account_id: &str, suffix: &str) -> String {
+        let payload =
+            format!(r#"{{"https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}"}}}}"#);
+        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+        format!("header.{encoded}.{suffix}")
+    }
+
     #[test]
     fn preserves_rotated_tokens_before_switching_away_and_back() {
         let account_a = account("A", "workspace-a", "a1");
@@ -413,11 +426,9 @@ mod tests {
         ));
         assert_eq!(refresh_token(&store.accounts[0]), "refresh-a1");
 
-        let payload = r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"workspace-b"}}"#;
-        let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
         let mut auth_without_top_level_id = auth("workspace-b", "missing-id");
         let tokens = auth_without_top_level_id.tokens.as_mut().unwrap();
-        tokens.id_token = format!("header.{encoded}.signature");
+        tokens.id_token = id_token_with_account_id("workspace-b", "signature");
         tokens.account_id = None;
         assert!(!sync_active_account_tokens(
             &mut store,
@@ -448,5 +459,65 @@ mod tests {
             panic!("expected ChatGPT account");
         };
         assert_eq!(refresh_token, "refresh-a2");
+    }
+
+    #[test]
+    fn rejects_live_tokens_when_stored_account_identity_is_unknown() {
+        let mut account = account("A", "workspace-a", "a1");
+        let account_id = account.id.clone();
+        let AuthData::ChatGPT {
+            id_token,
+            account_id: chatgpt_account_id,
+            ..
+        } = &mut account.auth_data
+        else {
+            panic!("expected ChatGPT account");
+        };
+        *id_token = "opaque-id-token".into();
+        *chatgpt_account_id = None;
+
+        let mut store = AccountsStore {
+            accounts: vec![account],
+            active_account_id: Some(account_id),
+            ..AccountsStore::default()
+        };
+
+        assert!(!sync_active_account_tokens(
+            &mut store,
+            &auth("workspace-a", "a2")
+        ));
+        assert_eq!(refresh_token(&store.accounts[0]), "refresh-a1");
+    }
+
+    #[test]
+    fn derives_stored_identity_from_id_token_and_backfills_account_id() {
+        let mut account = account("A", "workspace-a", "a1");
+        let account_id = account.id.clone();
+        let AuthData::ChatGPT {
+            id_token,
+            account_id: chatgpt_account_id,
+            ..
+        } = &mut account.auth_data
+        else {
+            panic!("expected ChatGPT account");
+        };
+        *id_token = id_token_with_account_id("workspace-a", "stored");
+        *chatgpt_account_id = None;
+
+        let mut store = AccountsStore {
+            accounts: vec![account],
+            active_account_id: Some(account_id),
+            ..AccountsStore::default()
+        };
+
+        assert!(sync_active_account_tokens(
+            &mut store,
+            &auth("workspace-a", "a2")
+        ));
+        let AuthData::ChatGPT { account_id, .. } = &store.accounts[0].auth_data else {
+            panic!("expected ChatGPT account");
+        };
+        assert_eq!(account_id.as_deref(), Some("workspace-a"));
+        assert_eq!(refresh_token(&store.accounts[0]), "refresh-a2");
     }
 }

--- a/src-tauri/src/auth/token_refresh.rs
+++ b/src-tauri/src/auth/token_refresh.rs
@@ -5,8 +5,13 @@ use base64::Engine;
 use chrono::Utc;
 use tokio::time::{sleep, Duration};
 
-use super::{load_accounts, switch_to_account, update_account_chatgpt_tokens, AUTH_OPERATION_LOCK};
-use crate::types::{parse_chatgpt_id_token_claims, AuthData, StoredAccount};
+use super::{
+    load_accounts, read_current_auth, save_accounts, switch_to_account, sync_active_account_tokens,
+    update_account_chatgpt_tokens, AUTH_OPERATION_LOCK,
+};
+use crate::types::{
+    parse_chatgpt_id_token_claims, AccountsStore, AuthData, AuthDotJson, StoredAccount,
+};
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
@@ -48,12 +53,9 @@ pub(crate) async fn ensure_chatgpt_tokens_fresh_locked(
         return Ok(account.clone());
     }
 
-    // The account may have been refreshed while this task waited for the lock.
-    let current = load_accounts()?
-        .accounts
-        .into_iter()
-        .find(|stored| stored.id == account.id)
-        .context("Account not found")?;
+    // Codex may have refreshed the active account while this task waited for
+    // the lock. Prefer those live credentials over rotating the stored token.
+    let (current, _) = load_account_reconciling_live_auth(&account.id)?;
 
     match &current.auth_data {
         AuthData::ApiKey { .. } => Ok(current.clone()),
@@ -86,11 +88,16 @@ pub async fn refresh_chatgpt_tokens(account: &StoredAccount) -> Result<StoredAcc
 }
 
 async fn refresh_chatgpt_tokens_locked(account: &StoredAccount) -> Result<StoredAccount> {
-    let current = load_accounts()?
-        .accounts
-        .into_iter()
-        .find(|stored| stored.id == account.id)
-        .context("Account not found")?;
+    let (current, is_active) = load_account_reconciling_live_auth(&account.id)?;
+
+    if is_active && crate::commands::process::ensure_codex_not_running().is_err() {
+        println!(
+            "[Auth] Using the running app's live credentials for active account {}",
+            current.name
+        );
+        return Ok(current);
+    }
+
     let (current_id_token, current_refresh_token, current_account_id) = match &current.auth_data {
         AuthData::ChatGPT {
             id_token,
@@ -103,13 +110,6 @@ async fn refresh_chatgpt_tokens_locked(account: &StoredAccount) -> Result<Stored
 
     if current_refresh_token.is_empty() {
         anyhow::bail!("Missing refresh token for account {}", current.name);
-    }
-
-    let is_active = load_accounts()?.active_account_id.as_deref() == Some(account.id.as_str());
-    if is_active && crate::commands::process::ensure_codex_not_running().is_err() {
-        anyhow::bail!(
-            "Cannot refresh the active account while Codex/ChatGPT is running; let the running app refresh its session"
-        );
     }
 
     let refreshed = refresh_tokens_with_refresh_token(&current_refresh_token).await?;
@@ -149,6 +149,38 @@ async fn refresh_chatgpt_tokens_locked(account: &StoredAccount) -> Result<Stored
     }
 
     Ok(updated)
+}
+
+fn reconcile_active_account_from_auth(
+    store: &mut AccountsStore,
+    account_id: &str,
+    auth: &AuthDotJson,
+) -> bool {
+    if store.active_account_id.as_deref() != Some(account_id) {
+        return false;
+    }
+
+    sync_active_account_tokens(store, auth)
+}
+
+fn load_account_reconciling_live_auth(account_id: &str) -> Result<(StoredAccount, bool)> {
+    let mut store = load_accounts()?;
+    let is_active = store.active_account_id.as_deref() == Some(account_id);
+
+    if is_active {
+        if let Some(auth) = read_current_auth()? {
+            if reconcile_active_account_from_auth(&mut store, account_id, &auth) {
+                save_accounts(&store)?;
+            }
+        }
+    }
+
+    let account = store
+        .accounts
+        .into_iter()
+        .find(|stored| stored.id == account_id)
+        .context("Account not found")?;
+    Ok((account, is_active))
 }
 
 /// Build a new ChatGPT account from a refresh token.
@@ -317,14 +349,22 @@ async fn refresh_tokens_with_refresh_token(refresh_token: &str) -> Result<Refres
 #[cfg(test)]
 mod tests {
     use super::{
-        chatgpt_tokens_need_refresh_at, merge_refresh_response, resolve_refreshed_id_token,
-        RefreshTokenResponse,
+        chatgpt_tokens_need_refresh, chatgpt_tokens_need_refresh_at, merge_refresh_response,
+        reconcile_active_account_from_auth, resolve_refreshed_id_token, RefreshTokenResponse,
     };
+    use crate::types::{AccountsStore, AuthData, AuthDotJson, StoredAccount, TokenData};
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
     fn jwt_with_exp(exp: i64) -> String {
         let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
         format!("header.{payload}.signature")
+    }
+
+    fn account_jwt(account_id: &str, exp: i64, signature: &str) -> String {
+        let payload = URL_SAFE_NO_PAD.encode(format!(
+            r#"{{"exp":{exp},"https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}"}}}}"#
+        ));
+        format!("header.{payload}.{signature}")
     }
 
     #[test]
@@ -386,6 +426,88 @@ mod tests {
         let resolved = resolve_refreshed_id_token(current_id_token.clone(), None, now).unwrap();
 
         assert_eq!(resolved, current_id_token);
+    }
+
+    #[test]
+    fn active_account_uses_fresh_tokens_from_live_auth() {
+        let now = chrono::Utc::now().timestamp();
+        let mut account = StoredAccount::new_chatgpt(
+            "Active".into(),
+            None,
+            None,
+            None,
+            account_jwt("workspace-a", now - 3_600, "stored"),
+            jwt_with_exp(now - 3_600),
+            "stored-refresh".into(),
+            Some("workspace-a".into()),
+        );
+        let local_id = account.id.clone();
+        let mut store = AccountsStore {
+            accounts: vec![account.clone()],
+            active_account_id: Some(local_id.clone()),
+            ..AccountsStore::default()
+        };
+        let auth = AuthDotJson {
+            openai_api_key: None,
+            tokens: Some(TokenData {
+                id_token: account_jwt("workspace-a", now + 3_600, "live"),
+                access_token: jwt_with_exp(now + 3_600),
+                refresh_token: "live-refresh".into(),
+                account_id: Some("workspace-a".into()),
+            }),
+            last_refresh: None,
+        };
+
+        assert!(chatgpt_tokens_need_refresh(&account));
+        assert!(reconcile_active_account_from_auth(
+            &mut store, &local_id, &auth
+        ));
+
+        account = store.accounts.remove(0);
+        assert!(!chatgpt_tokens_need_refresh(&account));
+        let AuthData::ChatGPT { refresh_token, .. } = account.auth_data else {
+            panic!("expected ChatGPT account");
+        };
+        assert_eq!(refresh_token, "live-refresh");
+    }
+
+    #[test]
+    fn inactive_account_does_not_use_live_auth() {
+        let now = chrono::Utc::now().timestamp();
+        let account = StoredAccount::new_chatgpt(
+            "Inactive".into(),
+            None,
+            None,
+            None,
+            account_jwt("workspace-a", now - 3_600, "stored"),
+            jwt_with_exp(now - 3_600),
+            "stored-refresh".into(),
+            Some("workspace-a".into()),
+        );
+        let local_id = account.id.clone();
+        let mut store = AccountsStore {
+            accounts: vec![account],
+            active_account_id: Some("different-local-account".into()),
+            ..AccountsStore::default()
+        };
+        let auth = AuthDotJson {
+            openai_api_key: None,
+            tokens: Some(TokenData {
+                id_token: account_jwt("workspace-a", now + 3_600, "live"),
+                access_token: jwt_with_exp(now + 3_600),
+                refresh_token: "live-refresh".into(),
+                account_id: Some("workspace-a".into()),
+            }),
+            last_refresh: None,
+        };
+
+        assert!(!reconcile_active_account_from_auth(
+            &mut store, &local_id, &auth
+        ));
+        let AuthData::ChatGPT { refresh_token, .. } = &store.accounts[0].auth_data else {
+            panic!("expected ChatGPT account");
+        };
+        assert_eq!(refresh_token, "stored-refresh");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1414,11 +1414,14 @@ function App() {
               <button
                 onClick={() => void handleWarmupAll()}
                 disabled={isWarmingAll || accounts.length === 0}
-                className="flex h-10 items-center justify-center gap-2 rounded-lg bg-gray-100 px-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 shrink-0 whitespace-nowrap"
+                className={`flex h-10 w-10 items-center justify-center rounded-lg transition-colors disabled:opacity-50 shrink-0 ${
+                  isWarmingAll
+                    ? "bg-amber-100 text-amber-500 dark:bg-amber-900/30 dark:text-amber-300"
+                    : "bg-amber-50 text-amber-700 hover:bg-amber-100 dark:bg-amber-900/20 dark:text-amber-300 dark:hover:bg-amber-900/40"
+                }`}
                 title={isWarmingAll ? "Warming up all accounts" : "Warm up all accounts"}
               >
                 <span className={isWarmingAll ? "animate-pulse" : ""}>⚡</span>
-                <span>{isWarmingAll ? "Warming..." : "Warm Up All"}</span>
               </button>
               {isAccountSearchEnabled && (
                 <button

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1411,6 +1411,15 @@ function App() {
               >
                 <span className={isRefreshing ? "animate-spin inline-block" : ""}>↻</span>
               </button>
+              <button
+                onClick={() => void handleWarmupAll()}
+                disabled={isWarmingAll || accounts.length === 0}
+                className="flex h-10 items-center justify-center gap-2 rounded-lg bg-gray-100 px-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 disabled:opacity-50 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 shrink-0 whitespace-nowrap"
+                title={isWarmingAll ? "Warming up all accounts" : "Warm up all accounts"}
+              >
+                <span className={isWarmingAll ? "animate-pulse" : ""}>⚡</span>
+                <span>{isWarmingAll ? "Warming..." : "Warm Up All"}</span>
+              </button>
               {isAccountSearchEnabled && (
                 <button
                   onClick={() => {
@@ -1454,22 +1463,6 @@ function App() {
                 </button>
                 {isNavMenuOpen && (
                   <div className="absolute right-0 z-50 mt-2 w-64 rounded-xl border border-gray-200 bg-white p-2 text-gray-700 shadow-xl dark:border-neutral-800 dark:bg-black dark:text-white">
-                    <button
-                      onClick={() => {
-                        setIsNavMenuOpen(false);
-                        void handleWarmupAll();
-                      }}
-                      disabled={isWarmingAll || accounts.length === 0}
-                      className="flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-gray-100 disabled:opacity-50 dark:text-white dark:hover:bg-neutral-900"
-                    >
-                      <span className="flex items-center gap-2">
-                        <span className={isWarmingAll ? "animate-pulse" : ""}>⚡</span>
-                        Warm Up
-                      </span>
-                      <span className="text-[11px] text-gray-400 dark:text-gray-500">
-                        {isWarmingAll ? "Warming..." : "All accounts"}
-                      </span>
-                    </button>
                     <button
                       onClick={() => {
                         setIsNavMenuOpen(false);


### PR DESCRIPTION
## Summary

- Require the stored account and live `auth.json` credentials to resolve to the same ChatGPT account ID before synchronizing tokens.
- Preserve legacy accounts by deriving their account ID from the stored ID token when possible.
- Reconcile the active account with Codex's live credentials before fetching usage.
- Allow usage limits and account metadata to load while Codex/ChatGPT is running without rotating its active refresh token.
- Add a required release note to the release helper and store it in the annotated Git tag.
- Pass the release note to the GitHub release body so it appears in the updater prompt.
- Move the Warm Up All action from the overflow menu to an icon-only amber button in the navigation bar.

## Why

PRs #128 and #134 fixed stale refresh-token restoration and expired ID tokens during account switching.

This follow-up addresses two remaining problems:

1. Live credentials could be copied into a stored profile when the stored account identity was unknown.
2. Refreshing usage for the active account failed while Codex was running with:

   `Cannot refresh the active account while Codex/ChatGPT is running`

The active account now uses credentials already refreshed by the running Codex app. Codex Switcher does not attempt to rotate that account's refresh token.

## Validation

- [x] `cargo test --manifest-path src-tauri/Cargo.toml` — 47 passed
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets` — completed with 11 pre-existing warnings
- [x] `pnpm build`
- [x] Workflow YAML validation
- [x] `git diff --check`
- [ ] Manually refresh usage while Codex is running
- [ ] Manually trigger Warm Up All from the navigation bar
- [ ] Verify a test release displays the supplied release note

## Related

- Follow-up to #128
- Follow-up to #134
- Related to #129