### PR TITLE
fix: validate duplicate OAuth sessions before replacement

### DIFF
--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -161,11 +161,57 @@ pub fn save_accounts(store: &AccountsStore) -> Result<()> {
     Ok(())
 }
 
-/// Add a new account to the store
+pub const ACCOUNT_REPLACE_CONFIRMATION_PREFIX: &str = "ACCOUNT_REPLACE_CONFIRMATION_REQUIRED:";
+
+fn replace_account_in_store(
+    store: &mut AccountsStore,
+    existing_index: usize,
+    mut replacement: StoredAccount,
+) -> StoredAccount {
+    let existing = &store.accounts[existing_index];
+    replacement.id = existing.id.clone();
+    replacement.created_at = existing.created_at;
+    replacement.last_used_at = existing.last_used_at;
+    store.accounts[existing_index] = replacement.clone();
+    replacement
+}
+
+/// Add or replace an account after the caller has made the duplicate-health decision.
+///
+/// Duplicate replacement requires force_replace=true. Replacement keeps the
+/// original internal account ID, creation time and last-used timestamp.
+pub fn add_or_replace_account(
+    account: StoredAccount,
+    force_replace: bool,
+) -> Result<StoredAccount> {
+    let mut store = load_accounts()?;
+
+    if let Some(existing_index) = store.accounts.iter().position(|a| a.name == account.name) {
+        if !force_replace {
+            anyhow::bail!("{ACCOUNT_REPLACE_CONFIRMATION_PREFIX}{}", account.name);
+        }
+
+        let replaced = replace_account_in_store(&mut store, existing_index, account);
+        save_accounts(&store)?;
+        return Ok(replaced);
+    }
+
+    let account_clone = account.clone();
+    store.accounts.push(account);
+
+    // If this is the first account, make it active
+    if store.accounts.len() == 1 {
+        store.active_account_id = Some(account_clone.id.clone());
+    }
+
+    save_accounts(&store)?;
+    Ok(account_clone)
+}
+
+/// Add a new account to the store, preserving the historical reject-on-duplicate behavior.
 pub fn add_account(account: StoredAccount) -> Result<StoredAccount> {
     let mut store = load_accounts()?;
 
-    // Check for duplicate names
     if store.accounts.iter().any(|a| a.name == account.name) {
         anyhow::bail!("An account with name '{}' already exists", account.name);
     }
@@ -173,7 +219,6 @@ pub fn add_account(account: StoredAccount) -> Result<StoredAccount> {
     let account_clone = account.clone();
     store.accounts.push(account);
 
-    // If this is the first account, make it active
     if store.accounts.len() == 1 {
         store.active_account_id = Some(account_clone.id.clone());
     }
@@ -364,9 +409,10 @@ pub fn set_masked_account_ids(ids: Vec<String>) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::sync_active_account_tokens;
+    use super::{replace_account_in_store, sync_active_account_tokens};
     use crate::types::{AccountsStore, AuthData, AuthDotJson, StoredAccount, TokenData};
     use base64::Engine;
+    use chrono::{Duration, Utc};
 
     fn account(name: &str, account_id: &str, suffix: &str) -> StoredAccount {
         StoredAccount::new_chatgpt(
@@ -519,5 +565,31 @@ mod tests {
         };
         assert_eq!(account_id.as_deref(), Some("workspace-a"));
         assert_eq!(refresh_token(&store.accounts[0]), "refresh-a2");
+    }
+    #[test]
+    fn replacing_duplicate_preserves_internal_identity_and_history() {
+        let mut existing = account("A", "workspace-a", "old");
+        existing.last_used_at = Some(Utc::now() - Duration::hours(2));
+        let existing_id = existing.id.clone();
+        let existing_created_at = existing.created_at;
+        let existing_last_used_at = existing.last_used_at;
+
+        let replacement = account("A", "workspace-a", "new");
+        let mut store = AccountsStore {
+            accounts: vec![existing],
+            active_account_id: Some(existing_id.clone()),
+            ..AccountsStore::default()
+        };
+
+        let replaced = replace_account_in_store(&mut store, 0, replacement);
+
+        assert_eq!(replaced.id, existing_id);
+        assert_eq!(replaced.created_at, existing_created_at);
+        assert_eq!(replaced.last_used_at, existing_last_used_at);
+        assert_eq!(
+            store.active_account_id.as_deref(),
+            Some(replaced.id.as_str())
+        );
+        assert_eq!(refresh_token(&store.accounts[0]), "refresh-new");
     }
 }

--- a/src-tauri/src/auth/token_refresh.rs
+++ b/src-tauri/src/auth/token_refresh.rs
@@ -3,6 +3,10 @@
 use anyhow::{Context, Result};
 use base64::Engine;
 use chrono::Utc;
+use std::{
+    collections::HashSet,
+    sync::{Mutex, OnceLock},
+};
 use tokio::time::{sleep, Duration};
 
 use super::{
@@ -16,6 +20,33 @@ use crate::types::{
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const EXPIRY_SKEW_SECONDS: i64 = 60;
+
+static STALE_CHATGPT_SESSION_IDS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+fn stale_chatgpt_session_ids() -> &'static Mutex<HashSet<String>> {
+    STALE_CHATGPT_SESSION_IDS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+fn mark_saved_session_stale(account_id: &str) {
+    stale_chatgpt_session_ids()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(account_id.to_string());
+}
+
+fn clear_saved_session_stale(account_id: &str) {
+    stale_chatgpt_session_ids()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(account_id);
+}
+
+fn take_saved_session_stale(account_id: &str) -> bool {
+    stale_chatgpt_session_ids()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(account_id)
+}
 
 #[derive(Debug, serde::Deserialize)]
 struct RefreshTokenResponse {
@@ -112,7 +143,18 @@ async fn refresh_chatgpt_tokens_locked(account: &StoredAccount) -> Result<Stored
         anyhow::bail!("Missing refresh token for account {}", current.name);
     }
 
-    let refreshed = refresh_tokens_with_refresh_token(&current_refresh_token).await?;
+    let refreshed = match refresh_tokens_with_refresh_token(&current_refresh_token).await {
+        Ok(refreshed) => {
+            clear_saved_session_stale(&current.id);
+            refreshed
+        }
+        Err(error) => {
+            if refresh_error_invalidates_saved_session(&error) {
+                mark_saved_session_stale(&current.id);
+            }
+            return Err(error);
+        }
+    };
     let next = merge_refresh_response(
         current_id_token,
         current_refresh_token,
@@ -210,6 +252,92 @@ pub async fn create_chatgpt_account_from_refresh_token(
         next_refresh_token,
         claims.account_id,
     ))
+}
+
+fn account_identity(account: &StoredAccount) -> Option<String> {
+    match &account.auth_data {
+        AuthData::ApiKey { .. } => None,
+        AuthData::ChatGPT {
+            id_token,
+            account_id,
+            ..
+        } => account_id
+            .clone()
+            .or_else(|| parse_chatgpt_id_token_claims(id_token).account_id),
+    }
+}
+
+fn refresh_error_invalidates_saved_session(error: &anyhow::Error) -> bool {
+    let message = format!("{error:#}").to_lowercase();
+    message.contains("refresh_token_invalidated")
+        || message.contains("refresh_token_reused")
+        || message.contains("your session has ended")
+        || message.contains("invalid refresh token")
+        || message.contains("refresh token is invalid")
+        || message.contains("invalid_grant")
+}
+
+/// Decide whether replacing a duplicate account should require user confirmation.
+///
+/// Verify the stored refresh token once even when the current access token still
+/// works. A successful refresh means the saved session is genuinely healthy, while
+/// terminal OAuth errors such as refresh_token_invalidated/reused mean it is stale
+/// and can be replaced automatically. Transient/unknown failures stay conservative
+/// and ask before overwriting credentials.
+pub async fn duplicate_account_requires_confirmation(candidate: &StoredAccount) -> Result<bool> {
+    let store = load_accounts()?;
+    let Some(existing) = store
+        .accounts
+        .iter()
+        .find(|account| account.name == candidate.name)
+        .cloned()
+    else {
+        return Ok(false);
+    };
+
+    // Same display name but a known different ChatGPT identity is not a stale
+    // re-login of the same account. Never replace that silently.
+    if let (Some(existing_id), Some(candidate_id)) =
+        (account_identity(&existing), account_identity(candidate))
+    {
+        if existing_id != candidate_id {
+            return Ok(true);
+        }
+    }
+
+    if matches!(existing.auth_data, AuthData::ApiKey { .. }) {
+        return Ok(true);
+    }
+
+    // Usage polling may already have proved that the saved refresh token is
+    // terminally invalid. Preserve that fact across the re-auth flow so an active
+    // account is not misclassified as healthy merely because Codex is currently
+    // running and refresh_chatgpt_tokens() intentionally avoids rotating its token.
+    if take_saved_session_stale(&existing.id) {
+        eprintln!(
+            "[Auth] Existing duplicate account {} was already observed with a stale OAuth session; replacing without confirmation",
+            existing.name
+        );
+        return Ok(false);
+    }
+
+    match refresh_chatgpt_tokens(&existing).await {
+        Ok(_) => Ok(true),
+        Err(error) if refresh_error_invalidates_saved_session(&error) => {
+            eprintln!(
+                "[Auth] Existing duplicate account {} has a stale OAuth session; replacing without confirmation: {error:#}",
+                existing.name
+            );
+            Ok(false)
+        }
+        Err(error) => {
+            eprintln!(
+                "[Auth] Could not verify duplicate account {} because refresh failed transiently/unknown; asking before replacement: {error:#}",
+                existing.name
+            );
+            Ok(true)
+        }
+    }
 }
 
 fn chatgpt_tokens_need_refresh(account: &StoredAccount) -> bool {
@@ -349,8 +477,10 @@ async fn refresh_tokens_with_refresh_token(refresh_token: &str) -> Result<Refres
 #[cfg(test)]
 mod tests {
     use super::{
-        chatgpt_tokens_need_refresh, chatgpt_tokens_need_refresh_at, merge_refresh_response,
-        reconcile_active_account_from_auth, resolve_refreshed_id_token, RefreshTokenResponse,
+        chatgpt_tokens_need_refresh, chatgpt_tokens_need_refresh_at, clear_saved_session_stale,
+        mark_saved_session_stale, merge_refresh_response, reconcile_active_account_from_auth,
+        refresh_error_invalidates_saved_session, resolve_refreshed_id_token,
+        take_saved_session_stale, RefreshTokenResponse,
     };
     use crate::types::{AccountsStore, AuthData, AuthDotJson, StoredAccount, TokenData};
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -365,6 +495,43 @@ mod tests {
             r#"{{"exp":{exp},"https://api.openai.com/auth":{{"chatgpt_account_id":"{account_id}"}}}}"#
         ));
         format!("header.{payload}.{signature}")
+    }
+
+    #[test]
+    fn terminal_refresh_errors_mark_saved_session_as_stale() {
+        let invalidated = anyhow::Error::msg(
+            r#"Token refresh failed: 401 Unauthorized - {"error":{"code":"refresh_token_invalidated"}}"#,
+        );
+        let reused = anyhow::Error::msg(
+            r#"Token refresh failed: 401 Unauthorized - {"error":{"code":"refresh_token_reused"}}"#,
+        );
+        let invalid_refresh_token = anyhow::anyhow!(
+            "Could not refresh the saved Codex Switcher session (401 Unauthorized). Invalid refresh token."
+        );
+        let invalid_grant = anyhow::Error::msg(
+            r#"Token refresh failed: 401 Unauthorized - {"error":{"code":"invalid_grant","message":"Invalid refresh token."}}"#,
+        );
+        let generic_unauthorized = anyhow::anyhow!(
+            "Token refresh failed: 401 Unauthorized - Please try again."
+        );
+        let transient = anyhow::anyhow!("Failed to send token refresh request: timed out");
+
+        assert!(refresh_error_invalidates_saved_session(&invalidated));
+        assert!(refresh_error_invalidates_saved_session(&reused));
+        assert!(refresh_error_invalidates_saved_session(&invalid_refresh_token));
+        assert!(refresh_error_invalidates_saved_session(&invalid_grant));
+        assert!(!refresh_error_invalidates_saved_session(&generic_unauthorized));
+        assert!(!refresh_error_invalidates_saved_session(&transient));
+    }
+
+    #[test]
+    fn observed_stale_session_marker_is_consumed_once() {
+        let account_id = "test-observed-stale-session";
+        clear_saved_session_stale(account_id);
+        mark_saved_session_stale(account_id);
+
+        assert!(take_saved_session_stale(account_id));
+        assert!(!take_saved_session_stale(account_id));
     }
 
     #[test]

--- a/src-tauri/src/commands/account.rs
+++ b/src-tauri/src/commands/account.rs
@@ -1,10 +1,12 @@
 //! Account management Tauri commands
 
 use crate::auth::{
-    add_account, create_chatgpt_account_from_refresh_token, ensure_chatgpt_tokens_fresh_locked,
+    add_or_replace_account, create_chatgpt_account_from_refresh_token,
+    duplicate_account_requires_confirmation, ensure_chatgpt_tokens_fresh_locked,
     get_active_account, import_from_auth_json, import_from_auth_json_contents, load_accounts,
     read_current_auth, remove_account, save_accounts, set_active_account, switch_to_account,
-    sync_active_account_tokens, touch_account, AUTH_OPERATION_LOCK,
+    sync_active_account_tokens, touch_account, ACCOUNT_REPLACE_CONFIRMATION_PREFIX,
+    AUTH_OPERATION_LOCK,
 };
 use crate::types::{AccountInfo, AccountsStore, AuthData, ImportAccountsSummary, StoredAccount};
 
@@ -99,12 +101,27 @@ pub async fn get_active_account_info() -> Result<Option<AccountInfo>, String> {
 
 /// Add an account from an auth.json file
 #[tauri::command]
-pub async fn add_account_from_file(path: String, name: String) -> Result<AccountInfo, String> {
+pub async fn add_account_from_file(
+    path: String,
+    name: String,
+    force_replace: Option<bool>,
+) -> Result<AccountInfo, String> {
     // Import from the file
     let account = import_from_auth_json(&path, name).map_err(|e| e.to_string())?;
 
-    // Add to storage
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let force_replace = force_replace.unwrap_or(false);
+    if !force_replace
+        && duplicate_account_requires_confirmation(&account)
+            .await
+            .map_err(|e| e.to_string())?
+    {
+        return Err(format!(
+            "{ACCOUNT_REPLACE_CONFIRMATION_PREFIX}{}",
+            account.name
+        ));
+    }
+
+    let stored = add_or_replace_account(account, true).map_err(|e| e.to_string())?;
 
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();
@@ -116,9 +133,22 @@ pub async fn add_account_from_file(path: String, name: String) -> Result<Account
 pub async fn add_account_from_auth_json_text(
     name: String,
     contents: String,
+    force_replace: Option<bool>,
 ) -> Result<AccountInfo, String> {
     let account = import_from_auth_json_contents(&contents, name).map_err(|e| e.to_string())?;
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let force_replace = force_replace.unwrap_or(false);
+    if !force_replace
+        && duplicate_account_requires_confirmation(&account)
+            .await
+            .map_err(|e| e.to_string())?
+    {
+        return Err(format!(
+            "{ACCOUNT_REPLACE_CONFIRMATION_PREFIX}{}",
+            account.name
+        ));
+    }
+
+    let stored = add_or_replace_account(account, true).map_err(|e| e.to_string())?;
 
     let store = load_accounts().map_err(|e| e.to_string())?;
     let active_id = store.active_account_id.as_deref();

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -6,22 +6,29 @@ use tokio::sync::oneshot;
 
 use crate::auth::oauth_server::{start_oauth_login, wait_for_oauth_login, OAuthLoginResult};
 use crate::auth::{
-    add_account, load_accounts, set_active_account, switch_to_account, touch_account,
+    add_or_replace_account, duplicate_account_requires_confirmation, load_accounts,
+    set_active_account, switch_to_account, touch_account, ACCOUNT_REPLACE_CONFIRMATION_PREFIX,
     AUTH_OPERATION_LOCK,
 };
-use crate::types::{AccountInfo, OAuthLoginInfo};
+use crate::types::{AccountInfo, OAuthLoginInfo, StoredAccount};
 
 struct PendingOAuth {
     rx: oneshot::Receiver<anyhow::Result<OAuthLoginResult>>,
     cancelled: Arc<AtomicBool>,
 }
 
-// Global state for pending OAuth login
+// Global state for pending OAuth login. If login succeeds but replacing a
+// healthy duplicate needs confirmation, keep the completed credentials in
+// memory so the user can confirm without authenticating in the browser again.
 static PENDING_OAUTH: Mutex<Option<PendingOAuth>> = Mutex::new(None);
+static PENDING_COMPLETED_ACCOUNT: Mutex<Option<StoredAccount>> = Mutex::new(None);
 
 /// Start the OAuth login flow
 #[tauri::command]
 pub async fn start_login(account_name: String) -> Result<OAuthLoginInfo, String> {
+    // A new login supersedes any previously staged duplicate replacement.
+    PENDING_COMPLETED_ACCOUNT.lock().unwrap().take();
+
     // Cancel any previous pending flow so it does not keep the callback port occupied.
     if let Some(previous) = {
         let mut pending = PENDING_OAUTH.lock().unwrap();
@@ -43,24 +50,49 @@ pub async fn start_login(account_name: String) -> Result<OAuthLoginInfo, String>
     Ok(info)
 }
 
-/// Wait for the OAuth login to complete and add the account
+/// Wait for the OAuth login to complete and add the account.
+///
+/// Duplicates with a stale OAuth session are replaced automatically. A healthy
+/// duplicate is staged in memory and returns ACCOUNT_REPLACE_CONFIRMATION_REQUIRED:<name>;
+/// the UI can retry with force_replace=true without making the user log in again.
 #[tauri::command]
-pub async fn complete_login() -> Result<AccountInfo, String> {
-    let pending = {
-        let mut pending = PENDING_OAUTH.lock().unwrap();
-        pending
-            .take()
-            .ok_or_else(|| "No pending OAuth login".to_string())?
+pub async fn complete_login(force_replace: Option<bool>) -> Result<AccountInfo, String> {
+    let force_replace = force_replace.unwrap_or(false);
+
+    let staged_account = {
+        let mut staged = PENDING_COMPLETED_ACCOUNT.lock().unwrap();
+        staged.take()
     };
 
-    let account = wait_for_oauth_login(pending.rx)
-        .await
-        .map_err(|e| e.to_string())?;
+    let account = if let Some(account) = staged_account {
+        account
+    } else {
+        let pending = {
+            let mut pending = PENDING_OAUTH.lock().unwrap();
+            pending
+                .take()
+                .ok_or_else(|| "No pending OAuth login".to_string())?
+        };
+
+        wait_for_oauth_login(pending.rx)
+            .await
+            .map_err(|e| e.to_string())?
+    };
+
+    if !force_replace
+        && duplicate_account_requires_confirmation(&account)
+            .await
+            .map_err(|e| e.to_string())?
+    {
+        let account_name = account.name.clone();
+        PENDING_COMPLETED_ACCOUNT.lock().unwrap().replace(account);
+        return Err(format!(
+            "{ACCOUNT_REPLACE_CONFIRMATION_PREFIX}{account_name}"
+        ));
+    }
 
     let _auth_guard = AUTH_OPERATION_LOCK.lock().await;
-
-    // Add the account to storage
-    let stored = add_account(account).map_err(|e| e.to_string())?;
+    let stored = add_or_replace_account(account, true).map_err(|e| e.to_string())?;
 
     // Make it active and switch to it
     set_active_account(&stored.id).map_err(|e| e.to_string())?;
@@ -80,5 +112,8 @@ pub async fn cancel_login() -> Result<(), String> {
     if let Some(pending_oauth) = pending.take() {
         pending_oauth.cancelled.store(true, Ordering::Relaxed);
     }
+    drop(pending);
+
+    PENDING_COMPLETED_ACCOUNT.lock().unwrap().take();
     Ok(())
 }

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -53,9 +53,12 @@ struct MaskedIdsArgs {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct UploadAuthJsonArgs {
     name: String,
     contents: String,
+    #[serde(default, alias = "force_replace")]
+    force_replace: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -66,9 +69,19 @@ struct UploadEncryptedArgs {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct FileImportArgs {
     path: String,
     name: String,
+    #[serde(default, alias = "force_replace")]
+    force_replace: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CompleteLoginArgs {
+    #[serde(default, alias = "force_replace")]
+    force_replace: Option<bool>,
 }
 
 pub fn run_lan_server(host: &str, port: u16) -> anyhow::Result<()> {
@@ -132,11 +145,14 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         "get_active_account_info" => to_json(get_active_account_info().await?),
         "add_account_from_file" => {
             let args: FileImportArgs = parse_args(payload)?;
-            to_json(add_account_from_file(args.path, args.name).await?)
+            to_json(add_account_from_file(args.path, args.name, args.force_replace).await?)
         }
         "add_account_from_auth_json_text" => {
             let args: UploadAuthJsonArgs = parse_args(payload)?;
-            to_json(add_account_from_auth_json_text(args.name, args.contents).await?)
+            to_json(
+                add_account_from_auth_json_text(args.name, args.contents, args.force_replace)
+                    .await?,
+            )
         }
         "get_usage" => {
             let args: AccountIdArgs = parse_args(payload)?;
@@ -172,7 +188,14 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
             let args: LoginArgs = parse_args(payload)?;
             to_json(start_login(args.account_name).await?)
         }
-        "complete_login" => to_json(complete_login().await?),
+        "complete_login" => {
+            let args = if payload.is_null() {
+                CompleteLoginArgs::default()
+            } else {
+                parse_args(payload)?
+            };
+            to_json(complete_login(args.force_replace).await?)
+        }
         "cancel_login" => to_json(cancel_login().await?),
         "export_accounts_slim_text" => to_json(export_accounts_slim_text().await?),
         "import_accounts_slim_text" => {

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -7,16 +7,27 @@ import {
   type FileSource,
 } from "../lib/platform";
 
+const ACCOUNT_REPLACE_CONFIRMATION_PREFIX = "ACCOUNT_REPLACE_CONFIRMATION_REQUIRED:";
+
+function getReplacementAccountName(error: unknown): string | null {
+  const message = error instanceof Error ? error.message : String(error);
+  const index = message.indexOf(ACCOUNT_REPLACE_CONFIRMATION_PREFIX);
+  if (index < 0) return null;
+  const name = message.slice(index + ACCOUNT_REPLACE_CONFIRMATION_PREFIX.length).trim();
+  return name || "this account";
+}
+
 interface AddAccountModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onImportFile: (source: FileSource, name: string) => Promise<void>;
+  onImportFile: (source: FileSource, name: string, forceReplace?: boolean) => Promise<void>;
   onStartOAuth: (name: string) => Promise<{ auth_url: string }>;
-  onCompleteOAuth: () => Promise<unknown>;
+  onCompleteOAuth: (forceReplace?: boolean) => Promise<unknown>;
   onCancelOAuth: () => Promise<void>;
 }
 
 type Tab = "oauth" | "import";
+type ReplacementConfirmation = { mode: Tab; accountName: string };
 
 export function AddAccountModal({
   isOpen,
@@ -34,7 +45,10 @@ export function AddAccountModal({
   const [oauthPending, setOauthPending] = useState(false);
   const [authUrl, setAuthUrl] = useState<string>("");
   const [copied, setCopied] = useState<boolean>(false);
-  const isPrimaryDisabled = loading || (activeTab === "oauth" && oauthPending);
+  const [replaceConfirmation, setReplaceConfirmation] =
+    useState<ReplacementConfirmation | null>(null);
+  const isPrimaryDisabled =
+    loading || (activeTab === "oauth" && oauthPending) || replaceConfirmation !== null;
   const tauriRuntime = isTauriRuntime();
 
   const resetForm = () => {
@@ -44,11 +58,14 @@ export function AddAccountModal({
     setLoading(false);
     setOauthPending(false);
     setAuthUrl("");
+    setReplaceConfirmation(null);
   };
 
   const handleClose = () => {
-    if (oauthPending) {
-      onCancelOAuth();
+    if (oauthPending || replaceConfirmation?.mode === "oauth") {
+      void onCancelOAuth().catch((err) => {
+        console.error("Failed to cancel login:", err);
+      });
     }
     resetForm();
     onClose();
@@ -63,10 +80,21 @@ export function AddAccountModal({
       setOauthPending(true);
       setLoading(false);
 
-      // Wait for completion
-      await onCompleteOAuth();
+      // Wait for completion. Stale OAuth duplicates are replaced by the backend;
+      // healthy duplicates return a confirmation request and keep the fresh
+      // credentials staged so we can retry without another browser login.
+      await onCompleteOAuth(false);
       handleClose();
     } catch (err) {
+      const replacementAccountName = getReplacementAccountName(err);
+      if (replacementAccountName) {
+        setReplaceConfirmation({ mode: "oauth", accountName: replacementAccountName });
+        setError(null);
+        setLoading(false);
+        setOauthPending(false);
+        return;
+      }
+
       setError(err instanceof Error ? err.message : String(err));
       setLoading(false);
       setOauthPending(false);
@@ -91,7 +119,38 @@ export function AddAccountModal({
     try {
       setLoading(true);
       setError(null);
-      await onImportFile(fileSource, name.trim());
+      await onImportFile(fileSource, name.trim(), false);
+      handleClose();
+    } catch (err) {
+      const replacementAccountName = getReplacementAccountName(err);
+      if (replacementAccountName) {
+        setReplaceConfirmation({ mode: "import", accountName: replacementAccountName });
+        setError(null);
+        setLoading(false);
+        return;
+      }
+
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  };
+
+  const handleConfirmReplacement = async () => {
+    if (!replaceConfirmation) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      if (replaceConfirmation.mode === "oauth") {
+        await onCompleteOAuth(true);
+      } else {
+        if (!fileSource) {
+          throw new Error("Please select an auth.json file");
+        }
+        await onImportFile(fileSource, name.trim(), true);
+      }
+
       handleClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -120,6 +179,7 @@ export function AddAccountModal({
           {(["oauth", "import"] as Tab[]).map((tab) => (
             <button
               key={tab}
+              disabled={replaceConfirmation !== null}
               onClick={() => {
                 if (tab === "import" && oauthPending) {
                   void onCancelOAuth().catch((err) => {
@@ -131,7 +191,7 @@ export function AddAccountModal({
                 setActiveTab(tab);
                 setError(null);
               }}
-              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors ${activeTab === tab
+              className={`flex-1 px-4 py-3 text-sm font-medium transition-colors disabled:opacity-50 ${activeTab === tab
                   ? "text-gray-900 dark:text-gray-100 border-b-2 border-gray-900 dark:border-gray-100 -mb-px"
                   : "text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
                 }`}
@@ -241,6 +301,17 @@ export function AddAccountModal({
             </div>
           )}
 
+          {replaceConfirmation && (
+            <div className="p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg text-amber-800 dark:text-amber-200 text-sm">
+              <div className="font-medium mb-1">Replace existing account?</div>
+              <div>
+                <span className="font-medium">{replaceConfirmation.accountName}</span> already
+                exists and its saved session still appears usable. Replace it with the newly
+                authenticated account anyway?
+              </div>
+            </div>
+          )}
+
           {/* Error */}
           {error && (
             <div className="p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-lg text-red-600 dark:text-red-300 text-sm">
@@ -251,23 +322,46 @@ export function AddAccountModal({
 
         {/* Footer */}
         <div className="flex gap-3 p-5 border-t border-gray-100 dark:border-gray-800">
-          <button
-            onClick={handleClose}
-            className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={activeTab === "oauth" ? handleOAuthLogin : handleImportFile}
-            disabled={isPrimaryDisabled}
-            className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 transition-colors disabled:opacity-50"
-          >
-            {loading
-              ? "Adding..."
-              : activeTab === "oauth"
-                ? "Generate Login Link"
-                : "Import"}
-          </button>
+          {replaceConfirmation ? (
+            <>
+              <button
+                onClick={handleClose}
+                disabled={loading}
+                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors disabled:opacity-50"
+              >
+                Keep existing
+              </button>
+              <button
+                onClick={() => {
+                  void handleConfirmReplacement();
+                }}
+                disabled={loading}
+                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-amber-600 hover:bg-amber-700 text-white transition-colors disabled:opacity-50"
+              >
+                {loading ? "Replacing..." : "Replace anyway"}
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                onClick={handleClose}
+                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={activeTab === "oauth" ? handleOAuthLogin : handleImportFile}
+                disabled={isPrimaryDisabled}
+                className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 transition-colors disabled:opacity-50"
+              >
+                {loading
+                  ? "Adding..."
+                  : activeTab === "oauth"
+                    ? "Generate Login Link"
+                    : "Import"}
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -268,15 +268,20 @@ export function useAccounts() {
   );
 
   const importFromFile = useCallback(
-    async (source: FileSource, name: string) => {
+    async (source: FileSource, name: string, forceReplace = false) => {
       try {
         if (typeof source === "string") {
-          await invokeBackend<AccountInfo>("add_account_from_file", { path: source, name });
+          await invokeBackend<AccountInfo>("add_account_from_file", {
+            path: source,
+            name,
+            forceReplace,
+          });
         } else {
           const contents = await source.text();
           await invokeBackend<AccountInfo>("add_account_from_auth_json_text", {
             name,
             contents,
+            forceReplace,
           });
         }
         const accountList = await loadAccounts();
@@ -300,9 +305,9 @@ export function useAccounts() {
     }
   }, []);
 
-  const completeOAuthLogin = useCallback(async () => {
+  const completeOAuthLogin = useCallback(async (forceReplace = false) => {
     try {
-      const account = await invokeBackend<AccountInfo>("complete_login");
+      const account = await invokeBackend<AccountInfo>("complete_login", { forceReplace });
       const accountList = await loadAccounts();
       await refreshUsage(accountList);
       return account;


### PR DESCRIPTION
When re-adding an account with the same name, Codex Switcher currently rejects the duplicate outright. This PR makes duplicate replacement safer and more useful.

Behavior:
- if the existing saved OAuth session is stale, replace it automatically without prompting;
- if the existing session is genuinely still usable, ask for confirmation before overwriting it;
- validate the existing session by performing a one-time refresh-token check, even if its current access token has not expired yet;
- treat terminal refresh failures such as `refresh_token_invalidated`, `refresh_token_reused`, or `Your session has ended` as a stale saved session;
- transient/unknown refresh failures remain conservative and require confirmation;
- if two accounts share a display name but have different known ChatGPT account IDs, never replace silently;
- preserve the existing internal account ID, creation time, and last-used history when credentials are replaced;
- OAuth credentials are staged while the confirmation dialog is shown, so confirming does not require another browser login;
- the same replacement flow works for imported `auth.json` credentials.

Validation:
- frontend production build passes (`tsc && vite build`);
- Rust test suite on the clean upstream branch passes: 46 passed, 0 failed;
- branch is one commit directly on top of current upstream `main` with no version/release changes.