### PR TITLE
feat: add Cursor account and resizable floating quota support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@
   Easily switch between accounts, monitor usage, schedule warm-ups, and stay in control of your quota
 </p>
 
+## Unofficial Cursor Integration Disclaimer
+
+The Cursor integration in this branch is a community contribution. It is not
+affiliated with, endorsed by, or supported by the original Codex Switcher
+maintainers, OpenAI, or Cursor. Use it only with accounts you own and in
+accordance with each provider's terms. The integration reads Cursor's local
+session database in read-only mode and sends the resulting short-lived session
+only to Cursor-owned endpoints; it does not persist Cursor passwords or access
+tokens.
+
+The upstream repository currently declares no software license. This GitHub
+fork and branch are provided only for upstream review and contribution through
+GitHub's fork and pull-request workflow. They do not claim or grant independent
+permission to redistribute the upstream source or compiled binaries. No public
+binary release is provided from this fork.
+
+## AI-Assisted Development Disclosure
+
+The Cursor integration in this fork was primarily implemented by OpenAI's
+GPT-5.6 SOL. Human maintainers provide the product requirements, scope
+decisions, review, and final acceptance.
+
 ## Features
 
 - **Multi-Account Management** – Add, rename, mask, import, export, and manage multiple Codex accounts in one place
@@ -22,6 +44,8 @@
 - **Rate-Limit Monitoring** – View real-time 5-hour session and weekly usage, reset timing, credits, and subscription expiry
 - **Blocked Switch Recovery** – Detect running Codex sessions and offer a force-close flow before retrying the account switch
 - **Dual Login Mode** – Authenticate with ChatGPT OAuth or import existing `auth.json` files
+- **Cursor Account Integration** – Detect a signed-in Cursor account without storing its password or access token
+- **Resizable Floating Panel** – Pin, drag, resize, and filter the existing tray popup without adding a separate UI surface
 
 ## Installation
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "plist",
  "rand 0.9.2",
  "reqwest 0.12.28",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -1057,6 +1058,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1642,6 +1655,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -2257,6 +2279,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3529,6 +3562,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12", features = ["json"] }
+rusqlite = { version = "0.37", features = ["bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 dirs = "6"

--- a/src-tauri/src/auth/mod.rs
+++ b/src-tauri/src/auth/mod.rs
@@ -6,8 +6,7 @@ pub mod switcher;
 pub mod token_refresh;
 
 // ponytail: refreshes are rare; one global lock keeps auth.json and accounts.json ordered.
-pub(crate) static AUTH_OPERATION_LOCK: tokio::sync::Mutex<()> =
-    tokio::sync::Mutex::const_new(());
+pub(crate) static AUTH_OPERATION_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 pub use oauth_server::*;
 pub use storage::*;

--- a/src-tauri/src/commands/cursor.rs
+++ b/src-tauri/src/commands/cursor.rs
@@ -1,0 +1,379 @@
+//! Read-only integration with the signed-in Cursor desktop app.
+//!
+//! Cursor owns login and credential persistence. We only read its local
+//! session database with a read-only SQLite connection and use the resulting
+//! short-lived session to query Cursor's own usage endpoints.
+
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use base64::Engine;
+use chrono::{DateTime, Utc};
+use reqwest::StatusCode;
+use rusqlite::{OpenFlags, OptionalExtension};
+use serde::Deserialize;
+
+use crate::types::{CursorAccountInfo, UsageInfo};
+
+const CURSOR_ACCOUNT_ID: &str = "cursor:desktop";
+const CURSOR_BASE_URL: &str = "https://cursor.com";
+static CURSOR_LOGIN_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+#[tauri::command]
+pub async fn start_cursor_login() -> Result<(), String> {
+    launch_cursor().map_err(|error| error.to_string())?;
+    CURSOR_LOGIN_GENERATION.fetch_add(1, Ordering::Relaxed);
+    Ok(())
+}
+
+/// Wait for Cursor's official login to produce a usable local session.
+#[tauri::command]
+pub async fn complete_cursor_login() -> Result<CursorAccountInfo, String> {
+    let generation = CURSOR_LOGIN_GENERATION.load(Ordering::Relaxed);
+    if generation == 0 {
+        return Err("No pending Cursor login".into());
+    }
+
+    for _ in 0..120 {
+        if CURSOR_LOGIN_GENERATION.load(Ordering::Relaxed) != generation {
+            return Err("Cursor login was cancelled".into());
+        }
+        if let Ok(account) = fetch_cursor_account().await {
+            return Ok(account);
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+    Err("Cursor login was not detected. Finish signing in from Cursor and try again.".into())
+}
+
+/// Cancel a pending Cursor login without changing Cursor's own session.
+#[tauri::command]
+pub async fn cancel_cursor_login() -> Result<(), String> {
+    CURSOR_LOGIN_GENERATION.fetch_add(1, Ordering::Relaxed);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn cursor_account() -> Result<Option<CursorAccountInfo>, String> {
+    match fetch_cursor_account().await {
+        Ok(account) => Ok(Some(account)),
+        Err(CursorError::NotSignedIn) => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+#[tauri::command]
+pub async fn cursor_usage() -> Result<UsageInfo, String> {
+    fetch_cursor_usage()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[derive(Debug, thiserror::Error)]
+enum CursorError {
+    #[error("Cursor is not signed in")]
+    NotSignedIn,
+    #[error("Cursor session could not be read: {0}")]
+    Session(String),
+    #[error("Cursor usage request failed: {0}")]
+    Request(String),
+}
+
+fn state_db_in(data_dir: PathBuf) -> PathBuf {
+    data_dir
+        .join("User")
+        .join("globalStorage")
+        .join("state.vscdb")
+}
+
+fn cursor_state_db_path() -> Option<PathBuf> {
+    if let Some(data_dir) = std::env::var_os("CODEX_SWITCHER_CURSOR_DATA_DIR") {
+        return Some(state_db_in(data_dir.into()));
+    }
+
+    let standard = state_db_in(dirs::config_dir()?.join("Cursor"));
+    if standard.is_file() {
+        return Some(standard);
+    }
+
+    // Keep redirected Cursor profiles usable without adding another settings
+    // surface. This supports the common `cursor-data/Roaming-Cursor` migration
+    // layout and remains read-only; the standard directory always wins.
+    #[cfg(target_os = "windows")]
+    for letter in b'C'..=b'Z' {
+        let migrated = state_db_in(PathBuf::from(format!(
+            "{}:\\cursor-data\\Roaming-Cursor",
+            letter as char
+        )));
+        if migrated.is_file() {
+            return Some(migrated);
+        }
+    }
+
+    Some(standard)
+}
+
+fn load_cursor_access_token() -> Result<String, CursorError> {
+    let path = cursor_state_db_path().ok_or(CursorError::NotSignedIn)?;
+    if !path.exists() {
+        return Err(CursorError::NotSignedIn);
+    }
+
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+    let connection = rusqlite::Connection::open_with_flags(&path, flags)
+        .map_err(|error| CursorError::Session(error.to_string()))?;
+    connection
+        .busy_timeout(Duration::from_millis(250))
+        .map_err(|error| CursorError::Session(error.to_string()))?;
+    let value: Option<String> = connection
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = ?1 LIMIT 1",
+            ["cursorAuth/accessToken"],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| CursorError::Session(error.to_string()))?;
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or(CursorError::NotSignedIn)
+}
+
+fn cursor_cookie(access_token: &str) -> String {
+    let subject = jwt_subject(access_token).unwrap_or_default();
+    format!(
+        "WorkosCursorSessionToken={subject}%3A%3A{}",
+        access_token.trim()
+    )
+}
+
+fn jwt_subject(token: &str) -> Option<String> {
+    let payload = token.split('.').nth(1)?;
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    json.get("sub")?.as_str().map(str::to_string)
+}
+
+fn cursor_client() -> Result<reqwest::Client, CursorError> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|error| CursorError::Request(error.to_string()))
+}
+
+async fn cursor_get(path: &str) -> Result<reqwest::Response, CursorError> {
+    let cookie = cursor_cookie(&load_cursor_access_token()?);
+    let response = cursor_client()?
+        .get(format!("{CURSOR_BASE_URL}{path}"))
+        .header("Cookie", cookie)
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .map_err(|error| CursorError::Request(error.to_string()))?;
+    if matches!(
+        response.status(),
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN
+    ) {
+        return Err(CursorError::NotSignedIn);
+    }
+    if !response.status().is_success() {
+        return Err(CursorError::Request(format!("HTTP {}", response.status())));
+    }
+    Ok(response)
+}
+
+async fn fetch_cursor_account() -> Result<CursorAccountInfo, CursorError> {
+    let (me, usage) = tokio::try_join!(
+        async {
+            cursor_get("/api/auth/me")
+                .await?
+                .json::<CursorUser>()
+                .await
+                .map_err(|error| CursorError::Request(error.to_string()))
+        },
+        fetch_usage_summary()
+    )?;
+    let plan_type = usage.membership_type.as_deref().map(format_plan);
+    let name = me
+        .email
+        .clone()
+        .or(me.name)
+        .unwrap_or_else(|| "Cursor".into());
+    Ok(CursorAccountInfo {
+        id: CURSOR_ACCOUNT_ID.into(),
+        name,
+        email: me.email,
+        plan_type,
+        is_connected: true,
+    })
+}
+
+async fn fetch_usage_summary() -> Result<CursorUsageSummary, CursorError> {
+    cursor_get("/api/usage-summary")
+        .await?
+        .json::<CursorUsageSummary>()
+        .await
+        .map_err(|error| CursorError::Request(error.to_string()))
+}
+
+async fn fetch_cursor_usage() -> Result<UsageInfo, CursorError> {
+    let summary = fetch_usage_summary().await?;
+    Ok(cursor_usage_info(&summary))
+}
+
+fn cursor_usage_info(summary: &CursorUsageSummary) -> UsageInfo {
+    let reset_at = summary
+        .billing_cycle_end
+        .as_deref()
+        .and_then(parse_timestamp);
+    let plan = summary
+        .individual_usage
+        .as_ref()
+        .and_then(|usage| usage.plan.as_ref());
+    // Cursor exposes two independent model pools. `apiPercentUsed` backs the
+    // dashboard's "Other Models" meter; `totalPercentUsed` is an overall
+    // spend meter and must not be projected as third-party model usage.
+    let primary = plan.and_then(|plan| plan.api_percent_used.map(clamp_percent));
+    let secondary = plan.and_then(|plan| plan.auto_percent_used.map(clamp_percent));
+    UsageInfo {
+        account_id: CURSOR_ACCOUNT_ID.into(),
+        plan_type: summary.membership_type.as_deref().map(format_plan),
+        primary_used_percent: primary,
+        primary_window_minutes: None,
+        primary_resets_at: reset_at,
+        secondary_used_percent: secondary,
+        secondary_window_minutes: None,
+        secondary_resets_at: reset_at,
+        has_credits: None,
+        unlimited_credits: summary.is_unlimited,
+        credits_balance: None,
+        error: None,
+    }
+}
+
+fn clamp_percent(value: f64) -> f64 {
+    if value.is_finite() {
+        value.clamp(0.0, 100.0)
+    } else {
+        0.0
+    }
+}
+
+fn parse_timestamp(value: &str) -> Option<i64> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc).timestamp())
+}
+
+fn format_plan(value: &str) -> String {
+    format!(
+        "Cursor {}",
+        value
+            .chars()
+            .next()
+            .map(char::to_uppercase)
+            .into_iter()
+            .flatten()
+            .chain(value.chars().skip(1))
+            .collect::<String>()
+    )
+}
+
+fn launch_cursor() -> anyhow::Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        let local = std::env::var_os("LOCALAPPDATA")
+            .ok_or_else(|| anyhow::anyhow!("LOCALAPPDATA is unavailable"))?;
+        let executable = PathBuf::from(local)
+            .join("Programs")
+            .join("cursor")
+            .join("Cursor.exe");
+        if !executable.exists() {
+            anyhow::bail!("Cursor is not installed in the current Windows account");
+        }
+        std::process::Command::new(executable).spawn()?;
+        return Ok(());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .args(["-a", "Cursor"])
+            .spawn()?;
+        Ok(())
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::process::Command::new("cursor").spawn()?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorUser {
+    email: Option<String>,
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorUsageSummary {
+    billing_cycle_end: Option<String>,
+    membership_type: Option<String>,
+    is_unlimited: Option<bool>,
+    individual_usage: Option<CursorIndividualUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorIndividualUsage {
+    plan: Option<CursorPlanUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CursorPlanUsage {
+    auto_percent_used: Option<f64>,
+    api_percent_used: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cookie_uses_jwt_subject_without_exposing_other_claims() {
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"sub":"user_123","email":"private@example.com"}"#);
+        let token = format!("header.{payload}.signature");
+        assert_eq!(
+            cursor_cookie(&token),
+            format!("WorkosCursorSessionToken=user_123%3A%3A{token}")
+        );
+    }
+
+    #[test]
+    fn cursor_usage_maps_api_to_third_party_and_auto_to_first_party() {
+        let summary = CursorUsageSummary {
+            billing_cycle_end: Some("2026-09-29T00:00:00Z".into()),
+            membership_type: Some("pro".into()),
+            is_unlimited: Some(false),
+            individual_usage: Some(CursorIndividualUsage {
+                plan: Some(CursorPlanUsage {
+                    auto_percent_used: Some(13.0),
+                    api_percent_used: Some(81.0),
+                }),
+            }),
+        };
+
+        let usage = cursor_usage_info(&summary);
+
+        assert_eq!(usage.primary_used_percent, Some(81.0));
+        assert_eq!(usage.secondary_used_percent, Some(13.0));
+        assert_eq!(usage.primary_resets_at, usage.secondary_resets_at);
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod account;
 pub mod account_stats;
+pub mod cursor;
 pub mod oauth;
 pub mod process;
 pub mod usage;
@@ -9,6 +10,7 @@ pub mod window;
 
 pub use account::*;
 pub use account_stats::*;
+pub use cursor::*;
 pub use oauth::*;
 pub use process::*;
 pub use usage::*;

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -9,7 +9,7 @@ use tauri::{AppHandle, Manager, Runtime};
 
 use crate::{
     auth::{load_app_settings, save_app_settings},
-    types::{DockDisplayMode, UsageInfo},
+    types::{AppSettings, DockDisplayMode, UsageInfo},
 };
 
 /// Label of the borderless tray popup window.
@@ -33,6 +33,34 @@ pub fn report_usage(app: AppHandle, usages: Vec<UsageInfo>) {
     crate::tray::ingest_usage(&app, usages);
     #[cfg(not(desktop))]
     let _ = (app, usages);
+}
+
+#[tauri::command]
+pub fn get_app_settings() -> Result<AppSettings, String> {
+    load_app_settings().map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub fn set_floating_panel_settings(
+    app: AppHandle,
+    enabled: bool,
+    account_ids: Vec<String>,
+    show_reset_times: bool,
+) -> Result<AppSettings, String> {
+    let mut settings = load_app_settings().map_err(|error| error.to_string())?;
+    settings.floating_panel_enabled = enabled;
+    settings.floating_account_ids = account_ids;
+    settings.floating_show_reset_times = show_reset_times;
+    save_app_settings(&settings).map_err(|error| error.to_string())?;
+
+    if let Some(window) = app.get_webview_window(TRAY_WINDOW) {
+        let _ = window.set_always_on_top(true);
+        if enabled {
+            let _ = window.show();
+        }
+    }
+    let _ = tauri::Emitter::emit_to(&app, TRAY_WINDOW, "tray-refresh", ());
+    Ok(settings)
 }
 
 /// Hide the tray popup window (called by the tray UI after an action).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,14 +11,16 @@ pub mod types;
 pub mod web;
 
 use commands::{
-    ack_close_behavior_prompt, add_account_from_file, cancel_login, check_codex_processes,
-    complete_close_behavior, complete_login, delete_account, export_accounts_full_encrypted_file,
-    export_accounts_slim_text, get_account_usage_stats, get_active_account_info,
+    ack_close_behavior_prompt, add_account_from_file, cancel_cursor_login, cancel_login,
+    check_codex_processes, complete_close_behavior, complete_cursor_login, complete_login,
+    cursor_account, cursor_usage, delete_account, export_accounts_full_encrypted_file,
+    export_accounts_slim_text, get_account_usage_stats, get_active_account_info, get_app_settings,
     get_dock_display_mode, get_masked_account_ids, get_usage, hide_tray_window,
     import_accounts_full_encrypted_file, import_accounts_slim_text, kill_codex_processes,
     list_accounts, open_main_window, quit_app, refresh_account_metadata,
     refresh_all_accounts_usage, rename_account, report_usage, set_dock_display_mode,
-    set_masked_account_ids, start_login, switch_account, warmup_account, warmup_all_accounts,
+    set_floating_panel_settings, set_masked_account_ids, start_cursor_login, start_login,
+    switch_account, warmup_account, warmup_all_accounts,
 };
 use tauri::Emitter;
 
@@ -79,6 +81,11 @@ pub fn run() {
             start_login,
             complete_login,
             cancel_login,
+            start_cursor_login,
+            complete_cursor_login,
+            cancel_cursor_login,
+            cursor_account,
+            cursor_usage,
             // Usage
             get_usage,
             get_account_usage_stats,
@@ -94,6 +101,8 @@ pub fn run() {
             open_main_window,
             quit_app,
             report_usage,
+            get_app_settings,
+            set_floating_panel_settings,
             get_dock_display_mode,
             set_dock_display_mode,
             complete_close_behavior,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -37,6 +37,8 @@ const OPEN_ITEM_ID: &str = "open";
 const QUIT_ITEM_ID: &str = "quit";
 const TRAY_WIDTH: f64 = 300.0;
 const TRAY_HEIGHT: f64 = 420.0;
+const TRAY_MIN_WIDTH: f64 = 280.0;
+const TRAY_MIN_HEIGHT: f64 = 300.0;
 
 #[derive(Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -109,7 +111,8 @@ fn create_tray_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     let window = WebviewWindowBuilder::new(app, TRAY_WINDOW, WebviewUrl::App("tray.html".into()))
         .title("Codex Switcher")
         .inner_size(TRAY_WIDTH, TRAY_HEIGHT)
-        .resizable(false)
+        .min_inner_size(TRAY_MIN_WIDTH, TRAY_MIN_HEIGHT)
+        .resizable(true)
         .decorations(false)
         .transparent(true)
         .always_on_top(true)
@@ -117,12 +120,18 @@ fn create_tray_window<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .visible(false)
         .build()?;
 
-    // Hide the popup as soon as it loses focus so it behaves like a native menu.
+    // In normal mode this behaves like a native popup. Floating mode deliberately
+    // keeps this same panel visible; it does not create a second UI surface.
     let app_handle = app.clone();
     window.on_window_event(move |event| {
         if let WindowEvent::Focused(false) = event {
-            if let Some(window) = app_handle.get_webview_window(TRAY_WINDOW) {
-                let _ = window.hide();
+            let pinned = crate::auth::load_app_settings()
+                .map(|settings| settings.floating_panel_enabled)
+                .unwrap_or(false);
+            if !pinned {
+                if let Some(window) = app_handle.get_webview_window(TRAY_WINDOW) {
+                    let _ = window.hide();
+                }
             }
         }
     });
@@ -149,12 +158,17 @@ fn toggle_tray_window<R: Runtime>(app: &AppHandle<R>, cursor: PhysicalPosition<f
         return;
     };
 
-    if window.is_visible().unwrap_or(false) {
+    let pinned = crate::auth::load_app_settings()
+        .map(|settings| settings.floating_panel_enabled)
+        .unwrap_or(false);
+    if window.is_visible().unwrap_or(false) && !pinned {
         let _ = window.hide();
         return;
     }
 
-    position_near_cursor(&window, cursor);
+    if !pinned {
+        position_near_cursor(&window, cursor);
+    }
     let _ = window.show();
     let _ = window.set_focus();
     let _ = app.emit_to(TRAY_WINDOW, TRAY_REFRESH_EVENT, ());
@@ -405,14 +419,12 @@ fn active_usage_title(active_account_id: Option<&str>) -> String {
         .and_then(|cache| cache.get(active_account_id).cloned());
 
     match usage {
-        Some(usage) if usage.error.is_none() => {
-            usage_title(
-                usage.primary_used_percent,
-                usage.primary_window_minutes,
-                usage.secondary_used_percent,
-                usage.secondary_window_minutes,
-            )
-        }
+        Some(usage) if usage.error.is_none() => usage_title(
+            usage.primary_used_percent,
+            usage.primary_window_minutes,
+            usage.secondary_used_percent,
+            usage.secondary_window_minutes,
+        ),
         _ => "H:-- W:--".to_string(),
     }
 }
@@ -425,13 +437,13 @@ fn usage_title(
 ) -> String {
     let mut parts = Vec::new();
     if let Some(remaining) = remaining_percent_label(primary_used_percent) {
-        let label = window_duration_label(primary_window_minutes)
-            .unwrap_or_else(|| "H".to_string());
+        let label =
+            window_duration_label(primary_window_minutes).unwrap_or_else(|| "H".to_string());
         parts.push(format!("{label}:{remaining}"));
     }
     if let Some(remaining) = remaining_percent_label(secondary_used_percent) {
-        let label = window_duration_label(secondary_window_minutes)
-            .unwrap_or_else(|| "W".to_string());
+        let label =
+            window_duration_label(secondary_window_minutes).unwrap_or_else(|| "W".to_string());
         parts.push(format!("{label}:{remaining}"));
     }
 
@@ -485,8 +497,8 @@ fn usage_suffix(account_id: &str) -> String {
 
     let mut parts = Vec::new();
     if let Some(remaining) = session_remaining_title(usage.primary_used_percent, false) {
-        let label = window_duration_label(usage.primary_window_minutes)
-            .unwrap_or_else(|| "S".to_string());
+        let label =
+            window_duration_label(usage.primary_window_minutes).unwrap_or_else(|| "S".to_string());
         parts.push(format!("{label}:{remaining}"));
     }
     if let Some(used) = usage.secondary_used_percent {
@@ -644,17 +656,17 @@ mod tests {
             usage_title(None, None, Some(35.0), Some(7 * 24 * 60)),
             "7d:65%"
         );
-        assert_eq!(
-            usage_title(Some(27.0), Some(5 * 60), None, None),
-            "5h:73%"
-        );
+        assert_eq!(usage_title(Some(27.0), Some(5 * 60), None, None), "5h:73%");
         assert_eq!(usage_title(None, None, None, None), "H:-- W:--");
     }
 
     #[test]
     fn window_duration_labels_round_to_hours_and_days() {
         assert_eq!(window_duration_label(Some(5 * 60)), Some("5h".to_string()));
-        assert_eq!(window_duration_label(Some(12 * 60)), Some("12h".to_string()));
+        assert_eq!(
+            window_duration_label(Some(12 * 60)),
+            Some("12h".to_string())
+        );
         assert_eq!(
             window_duration_label(Some(7 * 24 * 60)),
             Some("7d".to_string())

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -47,6 +47,12 @@ pub struct AppSettings {
     pub dock_display_mode: DockDisplayMode,
     #[serde(default = "default_close_behavior_prompt_enabled")]
     pub close_behavior_prompt_enabled: bool,
+    /// Keep the existing tray panel visible when it loses focus.
+    pub floating_panel_enabled: bool,
+    /// Account ids included in the tray/floating panel. Empty means all.
+    pub floating_account_ids: Vec<String>,
+    /// Show reset countdowns beside rate windows.
+    pub floating_show_reset_times: bool,
 }
 
 impl Default for AppSettings {
@@ -55,6 +61,9 @@ impl Default for AppSettings {
             tray_display_mode: TrayDisplayMode::default(),
             dock_display_mode: DockDisplayMode::default(),
             close_behavior_prompt_enabled: true,
+            floating_panel_enabled: false,
+            floating_account_ids: Vec::new(),
+            floating_show_reset_times: true,
         }
     }
 }
@@ -411,6 +420,17 @@ pub struct UsageInfo {
     pub credits_balance: Option<String>,
     /// Error message if usage fetch failed
     pub error: Option<String>,
+}
+
+/// Read-only Cursor account metadata. Cursor remains the credential owner;
+/// Codex Switcher never persists the desktop app's access token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CursorAccountInfo {
+    pub id: String,
+    pub name: String,
+    pub email: Option<String>,
+    pub plan_type: Option<String>,
+    pub is_connected: bool,
 }
 
 impl UsageInfo {

--- a/src-tauri/src/web.rs
+++ b/src-tauri/src/web.rs
@@ -9,13 +9,15 @@ use serde_json::{json, Value};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 use tokio::runtime::Runtime;
 
+use crate::auth::load_app_settings;
 use crate::commands::{
-    add_account_from_auth_json_text, add_account_from_file, cancel_login, check_codex_processes,
-    complete_login, delete_account, export_accounts_full_encrypted_bytes,
-    export_accounts_slim_text, fetch_usage, get_account_usage_stats, get_active_account_info,
-    get_masked_account_ids, import_accounts_full_encrypted_bytes, import_accounts_slim_text,
-    kill_codex_processes, list_accounts, refresh_account_metadata, refresh_all_accounts_usage,
-    rename_account, set_masked_account_ids, start_login, switch_account, warmup_account,
+    add_account_from_auth_json_text, add_account_from_file, cancel_cursor_login, cancel_login,
+    check_codex_processes, complete_cursor_login, complete_login, cursor_account, cursor_usage,
+    delete_account, export_accounts_full_encrypted_bytes, export_accounts_slim_text, fetch_usage,
+    get_account_usage_stats, get_active_account_info, get_masked_account_ids,
+    import_accounts_full_encrypted_bytes, import_accounts_slim_text, kill_codex_processes,
+    list_accounts, refresh_account_metadata, refresh_all_accounts_usage, rename_account,
+    set_masked_account_ids, start_cursor_login, start_login, switch_account, warmup_account,
     warmup_all_accounts,
 };
 
@@ -174,6 +176,12 @@ async fn invoke_web_command(command: &str, payload: Value) -> Result<Value, Stri
         }
         "complete_login" => to_json(complete_login().await?),
         "cancel_login" => to_json(cancel_login().await?),
+        "start_cursor_login" => to_json(start_cursor_login().await?),
+        "complete_cursor_login" => to_json(complete_cursor_login().await?),
+        "cancel_cursor_login" => to_json(cancel_cursor_login().await?),
+        "cursor_account" => to_json(cursor_account().await?),
+        "cursor_usage" => to_json(cursor_usage().await?),
+        "get_app_settings" => to_json(load_app_settings().map_err(|error| error.to_string())?),
         "export_accounts_slim_text" => to_json(export_accounts_slim_text().await?),
         "import_accounts_slim_text" => {
             let args: ImportSlimArgs = parse_args(payload)?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,14 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAccounts } from "./hooks/useAccounts";
 import { useForceCloseCodexProcesses } from "./hooks/useForceCloseCodexProcesses";
 import { AccountCard, AddAccountModal, UpdateChecker } from "./components";
-import type { AccountWithUsage, CodexProcessInfo, DockDisplayMode, UsageInfo } from "./types";
+import type {
+  AccountWithUsage,
+  AppSettings,
+  CodexProcessInfo,
+  CursorAccountInfo,
+  DockDisplayMode,
+  UsageInfo,
+} from "./types";
 import {
   exportFullBackupFile,
   importFullBackupFile,
@@ -226,6 +233,9 @@ function App() {
     readTimedWarmupTimes()
   );
   const [isTimedWarmupOpen, setIsTimedWarmupOpen] = useState(false);
+  const [isFloatingSettingsOpen, setIsFloatingSettingsOpen] = useState(false);
+  const [cursorAccount, setCursorAccount] = useState<CursorAccountInfo | null>(null);
+  const [floatingSettings, setFloatingSettings] = useState<AppSettings | null>(null);
   const [timedWarmupRunning, setTimedWarmupRunning] = useState(false);
   const [timedWarmupDraft, setTimedWarmupDraft] = useState("");
   const [maskedAccounts, setMaskedAccounts] = useState<Set<string>>(new Set());
@@ -262,6 +272,63 @@ function App() {
   useEffect(() => {
     accountsRef.current = accounts;
   }, [accounts]);
+
+  const loadProviderSettings = useCallback(async () => {
+    const [settings, cursor] = await Promise.all([
+      invokeBackend<AppSettings>("get_app_settings"),
+      invokeBackend<CursorAccountInfo | null>("cursor_account").catch(() => null),
+    ]);
+    setFloatingSettings(settings);
+    setCursorAccount(cursor);
+  }, []);
+
+  useEffect(() => {
+    void loadProviderSettings();
+  }, [loadProviderSettings]);
+
+  const saveFloatingSettings = useCallback(
+    async (next: Pick<AppSettings, "floating_panel_enabled" | "floating_account_ids" | "floating_show_reset_times">) => {
+      const settings = await invokeBackend<AppSettings>("set_floating_panel_settings", {
+        enabled: next.floating_panel_enabled,
+        accountIds: next.floating_account_ids,
+        showResetTimes: next.floating_show_reset_times,
+      });
+      setFloatingSettings(settings);
+    },
+    []
+  );
+
+  const toggleFloatingAccount = useCallback(
+    (accountId: string) => {
+      if (!floatingSettings) return;
+      const allIds = [...accounts.map((account) => account.id), ...(cursorAccount ? [cursorAccount.id] : [])];
+      const selected = floatingSettings.floating_account_ids.length === 0
+        ? new Set(allIds)
+        : new Set(floatingSettings.floating_account_ids);
+      if (selected.has(accountId)) selected.delete(accountId);
+      else selected.add(accountId);
+      void saveFloatingSettings({
+        ...floatingSettings,
+        floating_account_ids: Array.from(selected),
+      });
+    },
+    [accounts, cursorAccount, floatingSettings, saveFloatingSettings]
+  );
+
+  const startCursorLogin = useCallback(async () => {
+    await invokeBackend("start_cursor_login");
+  }, []);
+
+  const completeCursorLogin = useCallback(async () => {
+    const account = await invokeBackend<CursorAccountInfo>("complete_cursor_login");
+    setCursorAccount(account);
+    window.dispatchEvent(new CustomEvent("accounts-changed"));
+    return account;
+  }, []);
+
+  const cancelCursorLogin = useCallback(async () => {
+    await invokeBackend("cancel_cursor_login");
+  }, []);
 
   useEffect(() => {
     if (!isAccountSearchEnabled && accountSearchQuery) {
@@ -1449,6 +1516,7 @@ function App() {
                 <button
                   onClick={() => {
                     setIsTimedWarmupOpen(false);
+                    setIsFloatingSettingsOpen(false);
                     setIsNavMenuOpen((prev) => !prev);
                   }}
                   className={`flex h-10 w-10 items-center justify-center rounded-lg transition-colors shrink-0 ${
@@ -1515,6 +1583,23 @@ function App() {
                         {themeMode === "dark" ? "☾ Dark" : "☀ Light"}
                       </span>
                     </button>
+                    <button
+                      onClick={() => {
+                        setIsNavMenuOpen(false);
+                        setIsTimedWarmupOpen(false);
+                        setIsFloatingSettingsOpen((prev) => !prev);
+                      }}
+                      className="flex w-full items-center justify-between gap-2 rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-gray-100 dark:text-white dark:hover:bg-neutral-900"
+                    >
+                      <span>Floating Panel</span>
+                      <span className={`rounded-md px-1.5 py-0.5 text-[11px] font-medium ${
+                        floatingSettings?.floating_panel_enabled
+                          ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+                          : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                      }`}>
+                        {floatingSettings?.floating_panel_enabled ? "On" : "Off"}
+                      </span>
+                    </button>
                   </div>
                 )}
                 {isTimedWarmupOpen && (
@@ -1571,6 +1656,43 @@ function App() {
                       >
                         Add
                       </button>
+                    </div>
+                  </div>
+                )}
+                {isFloatingSettingsOpen && floatingSettings && (
+                  <div className="absolute right-0 z-20 mt-2 w-64 rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-900">
+                    <label className="flex items-center justify-between text-sm font-medium text-gray-800 dark:text-gray-100">
+                      <span>Floating panel</span>
+                      <input
+                        type="checkbox"
+                        checked={floatingSettings.floating_panel_enabled}
+                        onChange={(event) => void saveFloatingSettings({ ...floatingSettings, floating_panel_enabled: event.target.checked })}
+                        className="h-4 w-4 accent-emerald-600"
+                      />
+                    </label>
+                    <label className="mt-3 flex items-center justify-between text-sm text-gray-700 dark:text-gray-200">
+                      <span>Show reset time</span>
+                      <input
+                        type="checkbox"
+                        checked={floatingSettings.floating_show_reset_times}
+                        onChange={(event) => void saveFloatingSettings({ ...floatingSettings, floating_show_reset_times: event.target.checked })}
+                        className="h-4 w-4 accent-emerald-600"
+                      />
+                    </label>
+                    <div className="mt-3 border-t border-gray-100 pt-2 dark:border-gray-800">
+                      <p className="mb-1 text-[11px] font-medium text-gray-500 dark:text-gray-400">Accounts</p>
+                      {[
+                        ...accounts.map((account) => ({ account, provider: "Codex" })),
+                        ...(cursorAccount ? [{ account: cursorAccount, provider: "Cursor" }] : []),
+                      ].map(({ account, provider }) => {
+                        const selected = floatingSettings.floating_account_ids.length === 0 || floatingSettings.floating_account_ids.includes(account.id);
+                        return (
+                          <label key={account.id} className="flex items-center gap-2 rounded-md px-1 py-1 text-sm text-gray-700 dark:text-gray-200">
+                            <input type="checkbox" checked={selected} onChange={() => toggleFloatingAccount(account.id)} className="h-4 w-4 accent-emerald-600" />
+                            <span className="min-w-0 flex-1 truncate">{account.name} · {provider}</span>
+                          </label>
+                        );
+                      })}
                     </div>
                   </div>
                 )}
@@ -2013,6 +2135,9 @@ function App() {
         onStartOAuth={startOAuthLogin}
         onCompleteOAuth={completeOAuthLogin}
         onCancelOAuth={cancelOAuthLogin}
+        onStartCursorLogin={startCursorLogin}
+        onCompleteCursorLogin={completeCursorLogin}
+        onCancelCursorLogin={cancelCursorLogin}
       />
 
       {/* Import/Export Config Modal */}

--- a/src/TrayMenu.tsx
+++ b/src/TrayMenu.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useEffect, useState } from "react";
-import type { AccountInfo, AccountUsageStats, DockDisplayMode, UsageInfo } from "./types";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type {
+  AccountInfo,
+  AccountUsageStats,
+  AppSettings,
+  CursorAccountInfo,
+  DockDisplayMode,
+  UsageInfo,
+} from "./types";
 import { invokeBackend, isTauriRuntime } from "./lib/platform";
 import {
   applyTheme,
@@ -16,6 +24,7 @@ import {
 const TRAY_REFRESH_EVENT = "tray-refresh";
 const ACCOUNTS_CHANGED_EVENT = "accounts-changed";
 const SWITCH_ACCOUNT_BLOCKED_EVENT = "switch-account-blocked";
+const trayWindow = getCurrentWindow();
 // Mirrors the backend guard message in process.rs (ensure_codex_not_running).
 const CODEX_RUNNING_PREFIX = "Cannot switch accounts while";
 
@@ -93,6 +102,21 @@ function sumDailyTokens(stats: AccountUsageStats, days: number): number {
   return stats.daily.reduce((total, day) => (keys.has(day.date) ? total + day.tokens : total), 0);
 }
 
+type TrayAccount = AccountInfo & { provider: "codex" | "cursor" };
+
+function rateWindowLabel(
+  provider: TrayAccount["provider"],
+  slot: "primary" | "secondary",
+  minutes: number | null
+): string {
+  if (minutes === 5 * 60) return "5h";
+  if (minutes === 7 * 24 * 60) return "7d";
+  if (provider === "cursor") {
+    return slot === "primary" ? "Third-party models" : "First-party models";
+  }
+  return slot === "primary" ? "Session" : "Weekly";
+}
+
 function retainUsageForAccounts(
   usageById: Record<string, UsageInfo>,
   accounts: AccountInfo[]
@@ -114,6 +138,15 @@ function TrayMenu() {
   const [refreshing, setRefreshing] = useState(false);
   const [autoWarmupAllEnabled, setAutoWarmupAllEnabled] = useState(readAutoWarmupAllEnabled);
   const [dockDisplayMode, setDockDisplayMode] = useState<DockDisplayMode | null>(null);
+  const [cursorAccount, setCursorAccount] = useState<CursorAccountInfo | null>(null);
+  const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
+
+  const handleTitlebarDrag = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (!isTauriRuntime() || event.button !== 0) return;
+    if ((event.target as HTMLElement).closest("button")) return;
+    event.preventDefault();
+    void trayWindow.startDragging();
+  }, []);
 
   // Fetch each account's rate-limit usage in parallel; rows fill in as they land.
   const loadUsage = useCallback(async (list: AccountInfo[]) => {
@@ -201,11 +234,38 @@ function TrayMenu() {
   const load = useCallback(async () => {
     try {
       void loadDockDisplayMode();
-      const list = await invokeBackend<AccountInfo[]>("list_accounts");
+      const [list, cursor, settings] = await Promise.all([
+        invokeBackend<AccountInfo[]>("list_accounts"),
+        invokeBackend<CursorAccountInfo | null>("cursor_account").catch(() => null),
+        invokeBackend<AppSettings>("get_app_settings"),
+      ]);
       setAccounts(list);
+      setCursorAccount(cursor);
+      setAppSettings(settings);
       setUsageById((prev) => retainUsageForAccounts(prev, list));
       setError(null);
       void loadUsage(list); // Don't block the list render on the usage calls.
+      if (cursor) {
+        void invokeBackend<UsageInfo>("cursor_usage")
+          .then((usage) => setUsageById((prev) => ({ ...prev, [cursor.id]: usage })))
+          .catch((err) => setUsageById((prev) => ({
+            ...prev,
+            [cursor.id]: {
+              account_id: cursor.id,
+              plan_type: cursor.plan_type,
+              primary_used_percent: null,
+              primary_window_minutes: null,
+              primary_resets_at: null,
+              secondary_used_percent: null,
+              secondary_window_minutes: null,
+              secondary_resets_at: null,
+              has_credits: null,
+              unlimited_credits: null,
+              credits_balance: null,
+              error: formatError(err),
+            },
+          })));
+      }
       void loadActiveStats(list);
     } catch (err) {
       setError(formatError(err));
@@ -218,11 +278,25 @@ function TrayMenu() {
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      const list = await invokeBackend<AccountInfo[]>("list_accounts");
+      const [list, cursor, settings] = await Promise.all([
+        invokeBackend<AccountInfo[]>("list_accounts"),
+        invokeBackend<CursorAccountInfo | null>("cursor_account").catch(() => null),
+        invokeBackend<AppSettings>("get_app_settings"),
+      ]);
       setAccounts(list);
+      setCursorAccount(cursor);
+      setAppSettings(settings);
       setUsageById((prev) => retainUsageForAccounts(prev, list));
       setError(null);
-      await Promise.all([loadUsage(list), loadActiveStats(list)]);
+      await Promise.all([
+        loadUsage(list),
+        loadActiveStats(list),
+        cursor
+          ? invokeBackend<UsageInfo>("cursor_usage").then((usage) =>
+              setUsageById((prev) => ({ ...prev, [cursor.id]: usage }))
+            )
+          : Promise.resolve(),
+      ]);
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -301,7 +375,8 @@ function TrayMenu() {
     };
   }, [load]);
 
-  const handleSwitch = useCallback(async (account: AccountInfo) => {
+  const handleSwitch = useCallback(async (account: TrayAccount) => {
+    if (account.provider === "cursor") return;
     if (account.is_active) {
       void invokeBackend("hide_tray_window");
       return;
@@ -333,9 +408,35 @@ function TrayMenu() {
     }
   }, []);
 
+  const displayAccounts: TrayAccount[] = [
+    ...accounts.map((account) => ({ ...account, provider: "codex" as const })),
+    ...(cursorAccount
+      ? [{
+          id: cursorAccount.id,
+          name: cursorAccount.name,
+          email: cursorAccount.email,
+          plan_type: cursorAccount.plan_type,
+          subscription_expires_at: null,
+          auth_mode: "chat_g_p_t" as const,
+          is_active: false,
+          created_at: "",
+          last_used_at: null,
+          provider: "cursor" as const,
+        }]
+      : []),
+  ].filter((account) =>
+    !appSettings ||
+    appSettings.floating_account_ids.length === 0 ||
+    appSettings.floating_account_ids.includes(account.id)
+  );
+
   return (
     <div className="flex h-screen w-screen flex-col overflow-hidden rounded-xl border border-gray-200 bg-white text-gray-900 shadow-2xl dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100">
-      <div className="flex items-center gap-2 border-b border-gray-100 px-3 py-2 dark:border-gray-800">
+      <div
+        data-tauri-drag-region
+        onMouseDown={handleTitlebarDrag}
+        className="flex cursor-move select-none items-center gap-2 border-b border-gray-100 px-3 py-2 dark:border-gray-800"
+      >
         <div className="flex h-6 w-6 items-center justify-center rounded-md bg-black text-xs font-bold text-white">
           C
         </div>
@@ -373,12 +474,12 @@ function TrayMenu() {
           <div className="px-2 py-6 text-center text-xs text-gray-500 dark:text-gray-400">
             Loading...
           </div>
-        ) : accounts.length === 0 ? (
+        ) : displayAccounts.length === 0 ? (
           <div className="px-2 py-6 text-center text-xs text-gray-500 dark:text-gray-400">
             No accounts configured
           </div>
         ) : (
-          accounts.map((account) => {
+          displayAccounts.map((account) => {
             const plan = formatPlan(account.plan_type);
             const usage = usageById[account.id];
             const stats = statsById[account.id];
@@ -386,12 +487,12 @@ function TrayMenu() {
               usage && !usage.error
                 ? ([
                     {
-                      label: "Session",
+                      label: rateWindowLabel(account.provider, "primary", usage.primary_window_minutes),
                       used: usage.primary_used_percent,
                       resetAt: usage.primary_resets_at,
                     },
                     {
-                      label: "Weekly",
+                      label: rateWindowLabel(account.provider, "secondary", usage.secondary_window_minutes),
                       used: usage.secondary_used_percent,
                       resetAt: usage.secondary_resets_at,
                     },
@@ -465,7 +566,7 @@ function TrayMenu() {
                               <span className={tone.text}>
                                 {remaining.toFixed(0)}% left
                               </span>
-                              {reset && (
+                              {appSettings?.floating_show_reset_times !== false && reset && (
                                 <span>
                                   {reset === "now" ? "Resets now" : `Resets in ${reset}`}
                                 </span>
@@ -484,7 +585,7 @@ function TrayMenu() {
                       {account.email}
                     </span>
                   ) : null}
-                  {account.is_active && stats?.available && (
+                  {account.provider === "codex" && account.is_active && stats?.available && (
                     <span className="mt-2 grid grid-cols-2 gap-1.5">
                       <span className="rounded-md bg-white px-2 py-1 text-[11px] text-gray-600 shadow-sm dark:bg-gray-950 dark:text-gray-300">
                         <span className="block font-medium text-gray-900 dark:text-gray-100">

--- a/src/components/AddAccountModal.tsx
+++ b/src/components/AddAccountModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   describeFileSource,
   isTauriRuntime,
@@ -14,9 +14,12 @@ interface AddAccountModalProps {
   onStartOAuth: (name: string) => Promise<{ auth_url: string }>;
   onCompleteOAuth: () => Promise<unknown>;
   onCancelOAuth: () => Promise<void>;
+  onStartCursorLogin: () => Promise<void>;
+  onCompleteCursorLogin: () => Promise<unknown>;
+  onCancelCursorLogin: () => Promise<void>;
 }
 
-type Tab = "oauth" | "import";
+type Tab = "oauth" | "cursor" | "import";
 
 export function AddAccountModal({
   isOpen,
@@ -25,16 +28,20 @@ export function AddAccountModal({
   onStartOAuth,
   onCompleteOAuth,
   onCancelOAuth,
+  onStartCursorLogin,
+  onCompleteCursorLogin,
+  onCancelCursorLogin,
 }: AddAccountModalProps) {
   const [activeTab, setActiveTab] = useState<Tab>("oauth");
   const [name, setName] = useState("");
   const [fileSource, setFileSource] = useState<FileSource | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [oauthPending, setOauthPending] = useState(false);
+  const [pendingProvider, setPendingProvider] = useState<"oauth" | "cursor" | null>(null);
   const [authUrl, setAuthUrl] = useState<string>("");
   const [copied, setCopied] = useState<boolean>(false);
-  const isPrimaryDisabled = loading || (activeTab === "oauth" && oauthPending);
+  const loginAttemptRef = useRef(0);
+  const isPrimaryDisabled = loading || pendingProvider !== null;
   const tauriRuntime = isTauriRuntime();
 
   const resetForm = () => {
@@ -42,34 +49,74 @@ export function AddAccountModal({
     setFileSource(null);
     setError(null);
     setLoading(false);
-    setOauthPending(false);
+    setPendingProvider(null);
     setAuthUrl("");
   };
 
-  const handleClose = () => {
-    if (oauthPending) {
-      onCancelOAuth();
+  const cancelPendingLogin = () => {
+    const provider = pendingProvider;
+    loginAttemptRef.current += 1;
+    setPendingProvider(null);
+    setLoading(false);
+    if (provider === "oauth") {
+      void onCancelOAuth().catch((err) => console.error("Failed to cancel ChatGPT login:", err));
+    } else if (provider === "cursor") {
+      void onCancelCursorLogin().catch((err) => console.error("Failed to cancel Cursor login:", err));
     }
+  };
+
+  const handleClose = () => {
+    cancelPendingLogin();
+    resetForm();
+    onClose();
+  };
+
+  const finishAndClose = () => {
+    loginAttemptRef.current += 1;
     resetForm();
     onClose();
   };
 
   const handleOAuthLogin = async () => {
+    const attempt = loginAttemptRef.current + 1;
+    loginAttemptRef.current = attempt;
     try {
       setLoading(true);
       setError(null);
       const info = await onStartOAuth(name.trim());
+      if (loginAttemptRef.current !== attempt) return;
       setAuthUrl(info.auth_url);
-      setOauthPending(true);
+      setPendingProvider("oauth");
       setLoading(false);
 
       // Wait for completion
       await onCompleteOAuth();
-      handleClose();
+      if (loginAttemptRef.current === attempt) finishAndClose();
     } catch (err) {
+      if (loginAttemptRef.current !== attempt) return;
       setError(err instanceof Error ? err.message : String(err));
       setLoading(false);
-      setOauthPending(false);
+      setPendingProvider(null);
+    }
+  };
+
+  const handleCursorLogin = async () => {
+    const attempt = loginAttemptRef.current + 1;
+    loginAttemptRef.current = attempt;
+    try {
+      setLoading(true);
+      setError(null);
+      await onStartCursorLogin();
+      if (loginAttemptRef.current !== attempt) return;
+      setPendingProvider("cursor");
+      setLoading(false);
+      await onCompleteCursorLogin();
+      if (loginAttemptRef.current === attempt) finishAndClose();
+    } catch (err) {
+      if (loginAttemptRef.current !== attempt) return;
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+      setPendingProvider(null);
     }
   };
 
@@ -117,17 +164,11 @@ export function AddAccountModal({
 
         {/* Tabs */}
         <div className="flex border-b border-gray-100 dark:border-gray-800">
-          {(["oauth", "import"] as Tab[]).map((tab) => (
+          {(["oauth", "cursor", "import"] as Tab[]).map((tab) => (
             <button
               key={tab}
               onClick={() => {
-                if (tab === "import" && oauthPending) {
-                  void onCancelOAuth().catch((err) => {
-                    console.error("Failed to cancel login:", err);
-                  });
-                  setOauthPending(false);
-                  setLoading(false);
-                }
+                if (tab !== activeTab && pendingProvider) cancelPendingLogin();
                 setActiveTab(tab);
                 setError(null);
               }}
@@ -136,7 +177,7 @@ export function AddAccountModal({
                   : "text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
                 }`}
             >
-              {tab === "oauth" ? "ChatGPT Login" : "Import File"}
+              {tab === "oauth" ? "ChatGPT Login" : tab === "cursor" ? "Cursor Login" : "Import File"}
             </button>
           ))}
         </div>
@@ -144,7 +185,7 @@ export function AddAccountModal({
         {/* Content */}
         <div className="p-5 space-y-4">
           {/* Account name is optional; the backend derives one when blank. */}
-          <div>
+          {activeTab !== "cursor" && <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Account Name (optional)
             </label>
@@ -155,12 +196,12 @@ export function AddAccountModal({
               placeholder="Leave blank to use email"
               className="w-full px-4 py-2.5 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:border-gray-400 dark:focus:border-gray-500 focus:ring-1 focus:ring-gray-400 dark:focus:ring-gray-500 transition-colors"
             />
-          </div>
+          </div>}
 
           {/* Tab-specific content */}
           {activeTab === "oauth" && (
             <div className="text-sm text-gray-500 dark:text-gray-400">
-              {oauthPending ? (
+              {pendingProvider === "oauth" ? (
                 <div className="text-center py-4">
                   <div className="animate-spin h-8 w-8 border-2 border-gray-900 dark:border-gray-100 border-t-transparent rounded-full mx-auto mb-3"></div>
                   <p className="text-gray-700 dark:text-gray-300 font-medium mb-2">Waiting for browser login...</p>
@@ -219,6 +260,26 @@ export function AddAccountModal({
             </div>
           )}
 
+          {activeTab === "cursor" && (
+            <div className="text-sm text-gray-500 dark:text-gray-400">
+              {pendingProvider === "cursor" ? (
+                <div className="py-4 text-center">
+                  <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-2 border-gray-900 border-t-transparent dark:border-gray-100 dark:border-t-transparent" />
+                  <p className="mb-2 font-medium text-gray-700 dark:text-gray-300">
+                    Waiting for Cursor login...
+                  </p>
+                  <p className="text-xs">
+                    Sign in from the official Cursor window. Codex Switcher will detect the session automatically.
+                  </p>
+                </div>
+              ) : (
+                <p>
+                  Open Cursor and sign in there. Codex Switcher only reads the resulting local session and never stores your Cursor password.
+                </p>
+              )}
+            </div>
+          )}
+
           {activeTab === "import" && (
             <div>
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
@@ -258,7 +319,7 @@ export function AddAccountModal({
             Cancel
           </button>
           <button
-            onClick={activeTab === "oauth" ? handleOAuthLogin : handleImportFile}
+            onClick={activeTab === "oauth" ? handleOAuthLogin : activeTab === "cursor" ? handleCursorLogin : handleImportFile}
             disabled={isPrimaryDisabled}
             className="flex-1 px-4 py-2.5 text-sm font-medium rounded-lg bg-gray-900 hover:bg-gray-800 dark:bg-gray-100 dark:hover:bg-gray-200 text-white dark:text-gray-900 transition-colors disabled:opacity-50"
           >
@@ -266,6 +327,8 @@ export function AddAccountModal({
               ? "Adding..."
               : activeTab === "oauth"
                 ? "Generate Login Link"
+                : activeTab === "cursor"
+                  ? "Open Cursor"
                 : "Import"}
           </button>
         </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,23 @@ export interface UsageInfo {
   error: string | null;
 }
 
+export interface CursorAccountInfo {
+  id: string;
+  name: string;
+  email: string | null;
+  plan_type: string | null;
+  is_connected: boolean;
+}
+
+export interface AppSettings {
+  tray_display_mode: "icon_and_session" | "active_usage_text" | "hidden";
+  dock_display_mode: DockDisplayMode;
+  close_behavior_prompt_enabled: boolean;
+  floating_panel_enabled: boolean;
+  floating_account_ids: string[];
+  floating_show_reset_times: boolean;
+}
+
 export interface AccountUsageSummary {
   lifetime_tokens: number | null;
   peak_daily_tokens: number | null;


### PR DESCRIPTION
## Disclaimer

This is an unofficial community contribution. It is not affiliated with, endorsed by, or supported by the original Codex Switcher maintainers, OpenAI, or Cursor. The Cursor integration is intended only for accounts owned by the user and must be used in accordance with each provider's terms. It opens the official Cursor application for sign-in, reads Cursor's local session database in read-only mode, sends the short-lived session only to Cursor-owned endpoints, and does not persist Cursor passwords or access tokens.

The upstream repository currently declares no software license. This fork and pull request are provided only for upstream review through GitHub's fork and pull-request workflow. They do not claim or grant independent permission to redistribute the upstream source or compiled binaries. No binary release has been published from this fork.

## AI-Assisted Development Disclosure

The Cursor integration in this fork was primarily implemented by OpenAI's GPT-5.6 SOL. Human maintainers provide the product requirements, scope decisions, review, and final acceptance.

## Summary

- add a Cursor Login tab to the existing Add Account modal while preserving the native interaction and styling
- detect the signed-in Cursor desktop account without storing Cursor credentials
- read Cursor quota data from Cursor-owned endpoints
- map `apiPercentUsed` to Third-party models and `autoPercentUsed` to First-party models
- reuse the existing tray popup as an always-on-top, draggable, natively resizable floating panel
- allow users to select visible Codex/Cursor accounts and optionally show reset times
- keep Codex 5h/7d labels separate from Cursor billing-cycle quotas
- add Windows support for redirected Cursor profile data while preferring the standard path

## Privacy Review

- no local account email addresses were found in the source or diff
- no user-specific absolute paths were found
- no GitHub tokens, OpenAI keys, or JWT-like secrets were found
- the commit uses a GitHub noreply author address

## Verification

- Rust: 45 passed, 0 failed
- Frontend tests: 3 passed, 0 failed
- TypeScript and Vite production build: passed
- `cargo fmt --check`: passed
- `git diff --check`: passed
- unsigned Tauri production build: passed
- Windows UI: Cursor account detection and both quota labels verified against the Cursor usage page
- Windows UI: Third-party models correctly showed remaining quota derived from Cursor's Other Models used percentage
- Windows UI: the floating panel remained draggable and accepted native edge resizing while preserving the existing layout

The local Windows installers are unsigned and were used only for verification; they have not been attached to this PR or published as a release.