### PR TITLE
fix: preserve cached usage when deleting accounts

### DIFF
--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -246,8 +246,19 @@ export function useAccounts() {
   const deleteAccount = useCallback(
     async (accountId: string) => {
       try {
+        const deletedAccount = accountsRef.current.find((account) => account.id === accountId);
         await invokeBackend("delete_account", { accountId });
-        await loadAccounts();
+
+        if (deletedAccount && !deletedAccount.is_active) {
+          // Deleting an inactive account does not change any other account. Keep
+          // their already-fetched usage in place instead of rebuilding the list.
+          setAccounts((prev) => prev.filter((account) => account.id !== accountId));
+          return;
+        }
+
+        // Removing the active account can make another account active on the
+        // backend. Re-read account metadata, but never discard cached usage.
+        await loadAccounts(true);
       } catch (err) {
         throw err;
       }


### PR DESCRIPTION
Deleting an account currently calls `loadAccounts()` without preserving usage, which clears cached usage for every remaining account and makes all cards temporarily fall back to `Fetching usage...`.\n\nThis changes the delete flow so that:\n- deleting an inactive account removes only that account from local state and leaves every other account's cached usage untouched;\n- deleting the active account still reloads account metadata because the backend may promote another account to active, but does so with `preserveUsage=true`;\n- no global usage refetch is triggered by account deletion.\n\nValidation:\n- frontend production build passes (`tsc && vite build`).\n- branch is one commit directly on top of current upstream `main`; only `src/hooks/useAccounts.ts` is changed.