### PR TITLE
fix: stabilize metadata refresh and releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,9 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             note="$INPUT_RELEASE_NOTE"
           else
-            note="$(git tag --list --format='%(contents)' "$RELEASE_TAG")"
+            remote_tag_ref="refs/release-tags/$RELEASE_TAG"
+            git fetch --force --no-tags origin "refs/tags/$RELEASE_TAG:$remote_tag_ref"
+            note="$(git for-each-ref --format='%(contents)' "$remote_tag_ref")"
           fi
           {
             echo 'note<<RELEASE_NOTE_EOF'

--- a/src-tauri/src/api/usage.rs
+++ b/src-tauri/src/api/usage.rs
@@ -66,37 +66,27 @@ struct AccountsCheckEntitlement {
 
 /// Get usage information for an account
 pub async fn get_account_usage(account: &StoredAccount) -> Result<UsageInfo> {
-    println!("[Usage] Fetching usage for account: {}", account.name);
-
     match &account.auth_data {
-        AuthData::ApiKey { .. } => {
-            println!("[Usage] API key accounts don't support usage info");
-            Ok(UsageInfo {
-                account_id: account.id.clone(),
-                plan_type: Some("api_key".to_string()),
-                primary_used_percent: None,
-                primary_window_minutes: None,
-                primary_resets_at: None,
-                secondary_used_percent: None,
-                secondary_window_minutes: None,
-                secondary_resets_at: None,
-                has_credits: None,
-                unlimited_credits: None,
-                credits_balance: None,
-                error: Some("Usage info not available for API key accounts".to_string()),
-            })
-        }
+        AuthData::ApiKey { .. } => Ok(UsageInfo {
+            account_id: account.id.clone(),
+            plan_type: Some("api_key".to_string()),
+            primary_used_percent: None,
+            primary_window_minutes: None,
+            primary_resets_at: None,
+            secondary_used_percent: None,
+            secondary_window_minutes: None,
+            secondary_resets_at: None,
+            has_credits: None,
+            unlimited_credits: None,
+            credits_balance: None,
+            error: Some("Usage info not available for API key accounts".to_string()),
+        }),
         AuthData::ChatGPT { .. } => get_usage_with_chatgpt_auth(account).await,
     }
 }
 
 /// Send a minimal authenticated request to warm up account traffic paths.
 pub async fn warmup_account(account: &StoredAccount) -> Result<()> {
-    println!(
-        "[Warmup] Sending warm-up request for account: {}",
-        account.name
-    );
-
     match &account.auth_data {
         AuthData::ApiKey { key } => warmup_with_api_key(key).await,
         AuthData::ChatGPT { .. } => warmup_with_chatgpt_auth(account).await,
@@ -181,11 +171,8 @@ async fn parse_usage_response(
     response: reqwest::Response,
 ) -> Result<UsageInfo> {
     let status = response.status();
-    println!("[Usage] Response status: {status}");
 
     if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        println!("[Usage] Error response: {body}");
         return Ok(UsageInfo::error(
             account_id.to_string(),
             format!("API error: {status}"),
@@ -196,21 +183,12 @@ async fn parse_usage_response(
         .text()
         .await
         .context("Failed to read response body")?;
-    println!(
-        "[Usage] Response body: {}",
-        &body_text[..body_text.len().min(200)]
-    );
 
     let payload: RateLimitStatusPayload =
         serde_json::from_str(&body_text).context("Failed to parse usage response")?;
 
-    println!("[Usage] Parsed plan_type: {}", payload.plan_type);
-
     let usage = convert_payload_to_usage_info(account_id, payload);
-    println!(
-        "[Usage] {} - primary: {:?}%, plan: {:?}",
-        account_name, usage.primary_used_percent, usage.plan_type
-    );
+    println!("[Usage] Refreshed account: {account_name}");
 
     Ok(usage)
 }
@@ -347,7 +325,6 @@ fn build_chatgpt_headers(
     }
 
     if let Some(acc_id) = chatgpt_account_id {
-        println!("[Usage] Using ChatGPT Account ID: {acc_id}");
         if let Ok(header_name) = HeaderName::from_bytes(b"chatgpt-account-id") {
             if let Ok(header_value) = HeaderValue::from_str(acc_id) {
                 headers.insert(header_name, header_value);
@@ -388,7 +365,6 @@ async fn send_chatgpt_get_request(
 ) -> Result<reqwest::Response> {
     let client = reqwest::Client::new();
     let headers = build_chatgpt_headers(access_token, chatgpt_account_id)?;
-    println!("[Usage] Requesting: {url}");
 
     client
         .get(url)
@@ -563,8 +539,6 @@ fn extract_credits(credits: Option<CreditStatusDetails>) -> Option<CreditStatusD
 
 /// Refresh all account usage
 pub async fn refresh_all_usage(accounts: &[StoredAccount]) -> Vec<UsageInfo> {
-    println!("[Usage] Refreshing usage for {} accounts", accounts.len());
-
     let concurrency = accounts.len().min(10).max(1);
     let results: Vec<UsageInfo> = stream::iter(accounts.iter().cloned())
         .map(|account| async move {
@@ -580,7 +554,6 @@ pub async fn refresh_all_usage(accounts: &[StoredAccount]) -> Vec<UsageInfo> {
         .collect()
         .await;
 
-    println!("[Usage] Refresh complete");
     results
 }
 

--- a/src-tauri/src/auth/storage.rs
+++ b/src-tauri/src/auth/storage.rs
@@ -272,24 +272,41 @@ pub fn update_account_metadata(
         .find(|a| a.id == account_id)
         .context("Account not found")?;
 
+    let mut changed = false;
+
     if let Some(new_name) = name {
-        account.name = new_name;
+        if account.name != new_name {
+            account.name = new_name;
+            changed = true;
+        }
     }
 
-    if email.is_some() {
-        account.email = email;
+    if let Some(new_email) = email {
+        if account.email.as_ref() != Some(&new_email) {
+            account.email = Some(new_email);
+            changed = true;
+        }
     }
 
-    if plan_type.is_some() {
-        account.plan_type = plan_type;
+    if let Some(new_plan_type) = plan_type {
+        if account.plan_type.as_ref() != Some(&new_plan_type) {
+            account.plan_type = Some(new_plan_type);
+            changed = true;
+        }
     }
 
     if let Some(subscription_expires_at) = subscription_expires_at {
-        account.subscription_expires_at = subscription_expires_at;
+        if account.subscription_expires_at != subscription_expires_at {
+            account.subscription_expires_at = subscription_expires_at;
+            changed = true;
+        }
     }
 
     let updated = account.clone();
-    save_accounts(&store)?;
+    if changed {
+        save_accounts(&store)?;
+        println!("[Account] Saved updated metadata for: {}", updated.name);
+    }
     Ok(updated)
 }
 

--- a/src-tauri/src/auth/token_refresh.rs
+++ b/src-tauri/src/auth/token_refresh.rs
@@ -65,10 +65,6 @@ pub(crate) async fn ensure_chatgpt_tokens_fresh_locked(
             ..
         } => {
             if chatgpt_tokens_need_refresh_at(id_token, access_token, Utc::now().timestamp()) {
-                println!(
-                    "[Auth] OAuth token expired/near expiry for account {}, refreshing",
-                    current.name
-                );
                 refresh_chatgpt_tokens_locked(&current).await
             } else {
                 Ok(current)
@@ -91,10 +87,6 @@ async fn refresh_chatgpt_tokens_locked(account: &StoredAccount) -> Result<Stored
     let (current, is_active) = load_account_reconciling_live_auth(&account.id)?;
 
     if is_active && crate::commands::process::ensure_codex_not_running().is_err() {
-        println!(
-            "[Auth] Using the running app's live credentials for active account {}",
-            current.name
-        );
         return Ok(current);
     }
 
@@ -133,6 +125,7 @@ async fn refresh_chatgpt_tokens_locked(account: &StoredAccount) -> Result<Stored
         claims.plan_type,
         claims.subscription_expires_at,
     )?;
+    println!("[Auth] Refreshed OAuth tokens for: {}", updated.name);
 
     // Refresh tokens can be single-use. Persist a rotated replacement before
     // reporting an unusable ID token, so a later retry can still recover.

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -4,7 +4,9 @@ use crate::api::usage::{
     fetch_chatgpt_account_metadata, get_account_usage, refresh_all_usage,
     warmup_account as send_warmup,
 };
-use crate::auth::{get_account, load_accounts, refresh_chatgpt_tokens, update_account_metadata};
+use crate::auth::{
+    ensure_chatgpt_tokens_fresh, get_account, load_accounts, update_account_metadata,
+};
 use crate::types::{AccountInfo, AuthData, UsageInfo, WarmupSummary};
 use futures::{stream, StreamExt};
 
@@ -31,8 +33,8 @@ pub async fn get_usage(app: tauri::AppHandle, account_id: String) -> Result<Usag
     Ok(usage)
 }
 
-/// Force-refresh account metadata for a specific account.
-/// For ChatGPT accounts this refreshes OAuth tokens and pulls live subscription metadata.
+/// Refresh account metadata for a specific account.
+/// For ChatGPT accounts this ensures OAuth tokens are valid and pulls live subscription metadata.
 /// For API key accounts this is a no-op.
 #[tauri::command]
 pub async fn refresh_account_metadata(account_id: String) -> Result<AccountInfo, String> {
@@ -43,7 +45,7 @@ pub async fn refresh_account_metadata(account_id: String) -> Result<AccountInfo,
     let updated = match &account.auth_data {
         AuthData::ApiKey { .. } => account,
         AuthData::ChatGPT { .. } => {
-            let refreshed = refresh_chatgpt_tokens(&account)
+            let refreshed = ensure_chatgpt_tokens_fresh(&account)
                 .await
                 .map_err(|e| e.to_string())?;
             let live_metadata = fetch_chatgpt_account_metadata(&refreshed)

--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -210,7 +210,8 @@ export function AccountCard({
 
   const planKey = account.plan_type?.toLowerCase() || "api_key";
   const planColorClass = planColors[planKey] || planColors.free;
-  const showSubscriptionStatus = account.auth_mode === "chat_g_p_t";
+  const showSubscriptionStatus =
+    account.auth_mode === "chat_g_p_t" && account.plan_type?.toLowerCase() !== "free";
   const subscriptionStatus = getSubscriptionStatus(account.subscription_expires_at);
   const compactResetCredits = !account.is_active;
 

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -8,11 +8,16 @@ import type {
 } from "../types";
 import { invokeBackend, isTauriRuntime, type FileSource } from "../lib/platform";
 
+const METADATA_REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const METADATA_REFRESH_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
 export function useAccounts() {
   const [accounts, setAccounts] = useState<AccountWithUsage[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const accountsRef = useRef<AccountWithUsage[]>([]);
+  const metadataRefreshAtRef = useRef(new Map<string, number>());
+  const metadataRefreshInFlightRef = useRef(new Set<string>());
   const maxConcurrentUsageRequests = 10;
 
   useEffect(() => {
@@ -94,30 +99,76 @@ export function useAccounts() {
     }
   }, []);
 
+  const refreshMetadata = useCallback(
+    async (
+      accountList?: AccountInfo[] | AccountWithUsage[],
+      force = false
+    ) => {
+      const list = accountList ?? accountsRef.current;
+      const now = Date.now();
+      const dueAccounts = list.filter((account) => {
+        const lastRefreshAt = metadataRefreshAtRef.current.get(account.id) ?? 0;
+        return (
+          !metadataRefreshInFlightRef.current.has(account.id) &&
+          (force || now - lastRefreshAt >= METADATA_REFRESH_INTERVAL_MS)
+        );
+      });
+
+      // Mark attempts before starting requests so overlapping refresh cycles
+      // cannot issue duplicate metadata calls for the same account.
+      dueAccounts.forEach((account) => {
+        metadataRefreshAtRef.current.set(account.id, now);
+        metadataRefreshInFlightRef.current.add(account.id);
+      });
+
+      await runWithConcurrency(
+        dueAccounts,
+        async (account) => {
+          try {
+            const metadata = await invokeBackend<AccountInfo>("refresh_account_metadata", {
+              accountId: account.id,
+            });
+            setAccounts((prev) =>
+              prev.map((item) =>
+                item.id === account.id
+                  ? {
+                      ...item,
+                      plan_type: metadata.plan_type,
+                      subscription_expires_at: metadata.subscription_expires_at,
+                    }
+                  : item
+              )
+            );
+          } catch (err) {
+            // Allow the next metadata check to retry a transient failure.
+            metadataRefreshAtRef.current.delete(account.id);
+            console.warn("Failed to refresh account metadata:", err);
+          } finally {
+            metadataRefreshInFlightRef.current.delete(account.id);
+          }
+        },
+        maxConcurrentUsageRequests
+      );
+    },
+    [maxConcurrentUsageRequests, runWithConcurrency]
+  );
+
   const refreshUsage = useCallback(
     async (
       accountList?: AccountInfo[] | AccountWithUsage[],
       options?: { refreshMetadata?: boolean }
     ) => {
       try {
-        let list = accountList ?? accountsRef.current;
+        const list = accountList ?? accountsRef.current;
         if (list.length === 0) {
           return;
         }
 
-        if (options?.refreshMetadata) {
-          await runWithConcurrency(
-            list,
-            async (account) => {
-              await invokeBackend<AccountInfo>("refresh_account_metadata", {
-                accountId: account.id,
-              });
-            },
-            maxConcurrentUsageRequests
-          );
-
-          list = await loadAccounts(true);
-        }
+        // Explicit refreshes include metadata, but run it beside usage so a
+        // slow accounts endpoint never delays healthy rate-limit updates.
+        const metadataPromise = options?.refreshMetadata
+          ? refreshMetadata(list, true)
+          : Promise.resolve();
 
         const accountIds = list.map((account) => account.id);
         const accountIdSet = new Set(accountIds);
@@ -164,12 +215,19 @@ export function useAccounts() {
         );
 
         reportUsageToTray(Array.from(usageResults.values()));
+        await metadataPromise;
       } catch (err) {
         console.error("Failed to refresh usage:", err);
         throw err;
       }
     },
-    [buildUsageError, loadAccounts, maxConcurrentUsageRequests, reportUsageToTray, runWithConcurrency]
+    [
+      buildUsageError,
+      maxConcurrentUsageRequests,
+      refreshMetadata,
+      reportUsageToTray,
+      runWithConcurrency,
+    ]
   );
 
   const refreshSingleUsage = useCallback(async (
@@ -177,10 +235,10 @@ export function useAccounts() {
     options?: { refreshMetadata?: boolean }
   ) => {
     try {
-      if (options?.refreshMetadata) {
-        await invokeBackend<AccountInfo>("refresh_account_metadata", { accountId });
-        await loadAccounts(true);
-      }
+      const account = accountsRef.current.find((item) => item.id === accountId);
+      const metadataPromise = options?.refreshMetadata && account
+        ? refreshMetadata([account], true)
+        : Promise.resolve();
 
       setAccounts((prev) =>
         prev.map((a) =>
@@ -194,6 +252,7 @@ export function useAccounts() {
         )
       );
       reportUsageToTray([usage]);
+      await metadataPromise;
       return usage;
     } catch (err) {
       console.error("Failed to refresh single usage:", err);
@@ -211,7 +270,7 @@ export function useAccounts() {
       );
       throw err;
     }
-  }, [buildUsageError, loadAccounts, reportUsageToTray]);
+  }, [buildUsageError, refreshMetadata, reportUsageToTray]);
 
   const warmupAccount = useCallback(async (accountId: string) => {
     try {
@@ -389,15 +448,27 @@ export function useAccounts() {
   }, []);
 
   useEffect(() => {
-    loadAccounts().then((accountList) => refreshUsage(accountList));
+    loadAccounts().then((accountList) => {
+      void refreshUsage(accountList);
+      void refreshMetadata(accountList);
+    });
     
     // Auto-refresh usage every 60 seconds (same as official Codex CLI)
-    const interval = setInterval(() => {
+    const usageInterval = setInterval(() => {
       refreshUsage().catch(() => {});
     }, 60000);
+
+    // Subscription metadata changes much less often than usage. The cache
+    // prevents this check from producing network traffic more than every 6h.
+    const metadataInterval = setInterval(() => {
+      refreshMetadata().catch(() => {});
+    }, METADATA_REFRESH_CHECK_INTERVAL_MS);
     
-    return () => clearInterval(interval);
-  }, [loadAccounts, refreshUsage]);
+    return () => {
+      clearInterval(usageInterval);
+      clearInterval(metadataInterval);
+    };
+  }, [loadAccounts, refreshMetadata, refreshUsage]);
 
   useEffect(() => {
     let unlisten: (() => void) | undefined;


### PR DESCRIPTION
- throttle subscription metadata independently from usage
- avoid redundant writes and sensitive response logging
- hide subscription expiry for free accounts
- fetch release notes through a dedicated remote tag ref